### PR TITLE
Query comments

### DIFF
--- a/docs/api/MongoDB/Query/Query.php
+++ b/docs/api/MongoDB/Query/Query.php
@@ -28,20 +28,66 @@ final class Query
     private $limit;
 
     /**
-     * Constructs a new Query
+     * Sets the query criteria
      *
-     * @param array|object $query    Query document
-     * @param array|object $selector Selector document
-     * @param integer      $flags    Query flags
-     * @param integer      $skip     Skip
-     * @param integer      $limit    Limit
+     * @param array $query Query document
      */
-    public function __construct($query, $selector, $flags, $skip, $limit)
+    public function setQuery(array $query)
     {
         $this->query = $query;
+    }
+
+    /**
+     * Merges a query with the current one.
+     *
+     * @param array $criteria The query.
+     */
+    public function mergeQuery(array $query)
+    {
+        if (!$this->query) {
+            $this->query = $query;
+        } else {
+            $this->criteria = array_merge($this->query, $query);
+        }
+    }
+
+    /**
+     * Sets the query projection
+     *
+     * @param array $selector Selector document
+     */
+    public function setSelector(array $selector)
+    {
         $this->selector = $selector;
-        $this->flags = (integer) $flags;
-        $this->skip = (integer) $skip;
-        $this->limit = (integer) $limit;
+    }
+
+    /**
+     * Sets the query flags
+     *
+     * @param integer $flags Query flags
+     */
+    public function setFlags($flags)
+    {
+        $this->flags = (int) $flags;
+    }
+
+    /**
+     * Sets the skip param
+     *
+     * @param integer $skip Skip
+     */
+    public function setSkip($skip)
+    {
+        $this->skip = (int) $skip;
+    }
+
+    /**
+     * Sets the limit param
+     *
+     * @param integer $limit Limit
+     */
+    public function setLimit($limit)
+    {
+        $this->limit = (int) $limit;
     }
 }


### PR DESCRIPTION
Hi there,

As @jmikola suggests me, this is are my comments/thoughts about this new library

In a query all the params are optional, why make all the params mandatory? How access to the stored values?

This is my version of the Query object as a pure value object, with setters/getter and extra helper function called `merge Query` useful to delay the query declaration.

``` php
$query = new Query();
$query->setQuery(['age' => ['$gt' => 5]]);
$query->mergeCriteria(['gendre' => 'male']);
```

I have some extra question/suggestions:
- Maybe fluent?

``` php
$query = new Query();
$query->setQuery(['foo' => 'bar'])->setLimit(5)->setSkip(10);
```
- Maybe defensive programming on setters? I know not is a good practice but  helps to avoid bug when passing unexpected values.

The cli have the same behaviour and is a bit annoying if you dont remember the correct definition and you call `db.foo.remove({}, {multiple:true})`
- Missing sort and hint params. Why?
- Why final classes? Maybe someone needs extend it. (global)
- Why accept arrays or object? (global)

Best regards
