### PR TITLE
PHP-1068: Test that CommandResult is iterable

### DIFF
--- a/tests/standalone/manager-executeCommand-001.phpt
+++ b/tests/standalone/manager-executeCommand-001.phpt
@@ -8,14 +8,16 @@ require_once "tests/utils/basic.inc";
 
 $manager = new MongoDB\Manager(MONGODB_URI);
 
-$command = new MongoDB\Command(array('isMaster' => 1));
+$command = new MongoDB\Command(array('ping' => 1));
 $result = $manager->executeCommand(DATABASE_NAME, $command);
 
 var_dump($result instanceof MongoDB\CommandResult);
 
-$responseDocument = $result->getResponseDocument();
+echo "Dumping response document:\n";
+var_dump($result->getResponseDocument());
 
-var_dump( ! empty($responseDocument['ok']));
+echo "Dumping iterated result:\n";
+var_dump(iterator_to_array($result));
 
 $server = $result->getServer();
 
@@ -28,7 +30,19 @@ var_dump($server->getPort());
 <?php exit(0); ?>
 --EXPECT--
 bool(true)
-bool(true)
+Dumping response document:
+array(1) {
+  ["ok"]=>
+  float(1)
+}
+Dumping iterated result:
+array(1) {
+  [0]=>
+  array(1) {
+    ["ok"]=>
+    float(1)
+  }
+}
 bool(true)
 string(9) "localhost"
 int(27017)


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1068

Use ping instead of isMaster since the result document is more predictable.
