### PR TITLE
PHP-1171: Implement WriteConcernError class

### DIFF
--- a/php_phongo_classes.h
+++ b/php_phongo_classes.h
@@ -93,6 +93,9 @@ typedef struct {
 
 typedef struct {
 	zend_object              std;
+	int                      code;
+	char                    *message;
+	zval                    *info;
 } php_phongo_writeconcernerror_t;
 
 typedef struct {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1171

Removed constructor and implemented populate method, which should operate on BSON documents within WriteResult's writeConcernError(s) field.
