### PR TITLE
PHPC-203: Result::toArray() should proxy iterator_to_array($this)

### DIFF
--- a/tests/standalone/manager-executeCommand-001.phpt
+++ b/tests/standalone/manager-executeCommand-001.phpt
@@ -15,11 +15,8 @@ var_dump($command);
 var_dump($result instanceof MongoDB\Driver\Result);
 var_dump($result);
 
-echo "Dumping response document:\n";
-var_dump($result->toArray());
-
-echo "Dumping iterated result:\n";
-var_dump(iterator_to_array($result));
+echo "\nDumping response document:\n";
+var_dump(current($result->toArray()));
 
 $server = $result->getServer();
 
@@ -104,18 +101,11 @@ object(MongoDB\Driver\Result)#%d (%d) {
   ["is_command_cursor"]=>
   bool(false)
 }
+
 Dumping response document:
 array(1) {
   ["ok"]=>
   float(1)
-}
-Dumping iterated result:
-array(1) {
-  [0]=>
-  array(1) {
-    ["ok"]=>
-    float(1)
-  }
 }
 bool(true)
 string(%d) "%s"

--- a/tests/standalone/result-toArray-001.phpt
+++ b/tests/standalone/result-toArray-001.phpt
@@ -1,0 +1,64 @@
+--TEST--
+MongoDB\Driver\Result::toArray()
+--SKIPIF--
+<?php require "tests/utils/basic-skipif.inc"; CLEANUP(STANDALONE) ?>
+--FILE--
+<?php
+require_once "tests/utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$manager->executeInsert(NS, array('_id' => 1, 'x' => 1));
+$manager->executeInsert(NS, array('_id' => 2, 'x' => 1));
+
+$result = $manager->executeQuery(NS, new MongoDB\Driver\Query(array("x" => 1)));
+
+echo "Dumping Result::toArray():\n";
+var_dump($result->toArray());
+
+// Execute the query a second time, since we cannot iterate twice
+$result = $manager->executeQuery(NS, new MongoDB\Driver\Query(array("x" => 1)));
+
+echo "\nDumping iterated Result:\n";
+var_dump(iterator_to_array($result));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Dumping Result::toArray():
+array(2) {
+  [0]=>
+  array(2) {
+    ["_id"]=>
+    int(1)
+    ["x"]=>
+    int(1)
+  }
+  [1]=>
+  array(2) {
+    ["_id"]=>
+    int(2)
+    ["x"]=>
+    int(1)
+  }
+}
+
+Dumping iterated Result:
+array(2) {
+  [0]=>
+  array(2) {
+    ["_id"]=>
+    int(1)
+    ["x"]=>
+    int(1)
+  }
+  [1]=>
+  array(2) {
+    ["_id"]=>
+    int(2)
+    ["x"]=>
+    int(1)
+  }
+}
+===DONE===

--- a/tests/standalone/result-toArray-002.phpt
+++ b/tests/standalone/result-toArray-002.phpt
@@ -1,0 +1,34 @@
+--TEST--
+MongoDB\Driver\Result::toArray() respects type map
+--SKIPIF--
+<?php require "tests/utils/basic-skipif.inc"; CLEANUP(STANDALONE) ?>
+--FILE--
+<?php
+require_once "tests/utils/basic.inc";
+
+class MyArrayObject extends ArrayObject implements BSON\Unserializable
+{
+    function bsonUnserialize(array $data)
+    {
+        parent::__construct($data);
+    }
+}
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$manager->executeInsert(NS, array('_id' => 1, 'x' => array(1, 2, 3)));
+$manager->executeInsert(NS, array('_id' => 2, 'x' => array(4, 5, 6)));
+
+$result = $manager->executeQuery(NS, new MongoDB\Driver\Query(array('x' => 1)));
+$result->setTypeMap(array("array" => "MyArrayObject"));
+
+$documents = $result->toArray();
+
+var_dump($documents[0]['x'] instanceof MyArrayObject);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(true)
+===DONE===

--- a/tests/standalone/server-executeCommand-001.phpt
+++ b/tests/standalone/server-executeCommand-001.phpt
@@ -9,21 +9,92 @@ require_once __DIR__ . "/../utils/basic.inc";
 $manager = new MongoDB\Driver\Manager(STANDALONE);
 $server = $manager->executeQuery(NS, new MongoDB\Driver\Query(array()))->getServer();
 
-$command = new MongoDB\Driver\Command(array('isMaster' => 1));
+$command = new MongoDB\Driver\Command(array('ping' => 1));
 $result = $server->executeCommand(DATABASE_NAME, $command);
 
 var_dump($result instanceof MongoDB\Driver\Result);
+var_dump($result);
 
-$responseDocument = $result->toArray();
+echo "\nDumping response document:\n";
+var_dump(current($result->toArray()));
 
-var_dump( ! empty($responseDocument['ok']));
 var_dump($server == $result->getServer());
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(true)
-bool(true)
+object(MongoDB\Driver\Result)#%d (%d) {
+  ["cursor"]=>
+  array(19) {
+    ["stamp"]=>
+    int(0)
+    ["is_command"]=>
+    bool(true)
+    ["sent"]=>
+    bool(true)
+    ["done"]=>
+    bool(false)
+    ["failed"]=>
+    bool(false)
+    ["end_of_event"]=>
+    bool(false)
+    ["in_exhaust"]=>
+    bool(false)
+    ["redir_primary"]=>
+    bool(false)
+    ["has_fields"]=>
+    bool(false)
+    ["query"]=>
+    array(1) {
+      ["ping"]=>
+      int(1)
+    }
+    ["fields"]=>
+    array(0) {
+    }
+    ["read_preference"]=>
+    array(2) {
+      ["mode"]=>
+      int(1)
+      ["tags"]=>
+      array(0) {
+      }
+    }
+    ["flags"]=>
+    int(0)
+    ["skip"]=>
+    int(0)
+    ["limit"]=>
+    int(1)
+    ["count"]=>
+    int(1)
+    ["batch_size"]=>
+    int(0)
+    ["ns"]=>
+    string(11) "phongo.$cmd"
+    ["current_doc"]=>
+    array(1) {
+      ["ok"]=>
+      float(1)
+    }
+  }
+  ["firstBatch"]=>
+  array(1) {
+    ["ok"]=>
+    float(1)
+  }
+  ["server_id"]=>
+  int(1)
+  ["is_command_cursor"]=>
+  bool(false)
+}
+
+Dumping response document:
+array(1) {
+  ["ok"]=>
+  float(1)
+}
 bool(true)
 ===DONE===

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -230,7 +230,7 @@ function configureFailPoint(MongoDB\Driver\Manager $manager, $failPoint, $mode, 
 
     $cmd = new MongoDB\Driver\Command($doc);
     $result = $manager->executeCommand("admin", $cmd);
-    $arr = $result->toArray();
+    $arr = current($result->toArray());
     if (empty($arr["ok"])) {
         var_dump($result);
         throw new RuntimeException("Failpoint failed");


### PR DESCRIPTION
 * https://jira.mongodb.org/browse/PHPC-203
 * https://jira.mongodb.org/browse/PHPC-204

----

This introduces a BC break in that toArray() no longer returns the first result document. It must now be manually unwrapped from the return value.