### PR TITLE
LDAP VM does not require python-pip (or epel)

### DIFF
--- a/scripts/centos/ldap/install.sh
+++ b/scripts/centos/ldap/install.sh
@@ -1,7 +1,5 @@
 yum -y update
-# python-pip is in epel..
-yum -y install epel-release
-yum -y install openldap-servers openldap-clients openldap-devel python-devel gcc cyrus-sasl-plain xfsprogs net-snmp ps-misc wget python-pip python-ldap
+yum -y install openldap-servers openldap-clients openldap-devel python-devel gcc cyrus-sasl-plain xfsprogs net-snmp ps-misc wget python-ldap
 
 service slapd stop
 service slapd start


### PR DESCRIPTION
When building the VMs on Friday, I encountered some errors with selecting a mirror for the epel repository. Ultimately, I noticed that the LDAP VM doesn't actually depend on `python-pip`, which was the only reason we were installing epel. This removes them both.