### PR TITLE
->[to|from]Array() -> [to|from]PHP(). "root" typemapping. Default "root" to stdclass, not array

### DIFF
--- a/php_bson.h
+++ b/php_bson.h
@@ -72,8 +72,8 @@ PHONGO_API void zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *
 PHONGO_API int bson_to_zval(const unsigned char *data, int data_len, php_phongo_bson_state *state);
 PHONGO_API void php_phongo_bson_typemap_to_state(zval *typemap, php_phongo_bson_typemap *map TSRMLS_DC);
 
-PHP_FUNCTION(toArray);
-PHP_FUNCTION(fromArray);
+PHP_FUNCTION(toPHP);
+PHP_FUNCTION(fromPHP);
 PHP_FUNCTION(toJSON);
 PHP_FUNCTION(fromJSON);
 

--- a/php_bson.h
+++ b/php_bson.h
@@ -56,6 +56,8 @@ typedef struct {
 	zend_class_entry              *document;
 	php_phongo_bson_typemap_types  array_type;
 	zend_class_entry              *array;
+	php_phongo_bson_typemap_types  root_type;
+	zend_class_entry              *root;
 } php_phongo_bson_typemap;
 
 typedef struct {
@@ -64,7 +66,7 @@ typedef struct {
 	zend_class_entry        *odm;
 } php_phongo_bson_state;
 
-#define PHONGO_BSON_STATE_INITIALIZER  {NULL, { PHONGO_TYPEMAP_NONE, NULL, PHONGO_TYPEMAP_NONE, NULL}, NULL}
+#define PHONGO_BSON_STATE_INITIALIZER  {NULL, { PHONGO_TYPEMAP_NONE, NULL, PHONGO_TYPEMAP_NONE, NULL, PHONGO_TYPEMAP_NONE, NULL}, NULL}
 
 PHONGO_API void zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *bson, bson_t **bson_out TSRMLS_DC);
 PHONGO_API int bson_to_zval(const unsigned char *data, int data_len, php_phongo_bson_state *state);

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2075,11 +2075,11 @@ PHP_MINFO_FUNCTION(mongodb)
 
 /* {{{ mongodb_functions[]
 */
-ZEND_BEGIN_ARG_INFO_EX(ai_bson_fromArray, 0, 0, 1)
-	ZEND_ARG_INFO(0, array)
+ZEND_BEGIN_ARG_INFO_EX(ai_bson_fromPHP, 0, 0, 1)
+	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO();
 
-ZEND_BEGIN_ARG_INFO_EX(ai_bson_toArray, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(ai_bson_toPHP, 0, 0, 1)
 	ZEND_ARG_INFO(0, bson)
 ZEND_END_ARG_INFO();
 
@@ -2092,8 +2092,8 @@ ZEND_BEGIN_ARG_INFO_EX(ai_bson_fromJSON, 0, 0, 1)
 ZEND_END_ARG_INFO();
 
 const zend_function_entry mongodb_functions[] = {
-	ZEND_NS_FE(BSON_NAMESPACE, fromArray, ai_bson_fromArray)
-	ZEND_NS_FE(BSON_NAMESPACE, toArray,   ai_bson_toArray)
+	ZEND_NS_FE(BSON_NAMESPACE, fromPHP, ai_bson_fromPHP)
+	ZEND_NS_FE(BSON_NAMESPACE, toPHP,   ai_bson_toPHP)
 	ZEND_NS_FE(BSON_NAMESPACE, toJSON,    ai_bson_toJSON)
 	ZEND_NS_FE(BSON_NAMESPACE, fromJSON,  ai_bson_fromJSON)
 	PHP_FE_END

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1347,6 +1347,7 @@ void php_phongo_server_to_zval(zval *retval, const mongoc_server_description_t *
 	if (sd->tags.len) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
 		/* Use native arrays for debugging output */
+		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		MAKE_STD_ZVAL(state.zchild);
@@ -1356,6 +1357,7 @@ void php_phongo_server_to_zval(zval *retval, const mongoc_server_description_t *
 	{
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
 		/* Use native arrays for debugging output */
+		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		MAKE_STD_ZVAL(state.zchild);
@@ -1375,6 +1377,7 @@ void php_phongo_read_preference_to_zval(zval *retval, const mongoc_read_prefs_t 
 	if (read_prefs->tags.len) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
 		/* Use native arrays for debugging output */
+		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		MAKE_STD_ZVAL(state.zchild);

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1346,6 +1346,8 @@ void php_phongo_server_to_zval(zval *retval, const mongoc_server_description_t *
 	}
 	if (sd->tags.len) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
+		/* Use native arrays for debugging output */
+		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		MAKE_STD_ZVAL(state.zchild);
 		bson_to_zval(bson_get_data(&sd->tags), sd->tags.len, &state);
@@ -1353,6 +1355,8 @@ void php_phongo_server_to_zval(zval *retval, const mongoc_server_description_t *
 	}
 	{
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
+		/* Use native arrays for debugging output */
+		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		MAKE_STD_ZVAL(state.zchild);
 		bson_to_zval(bson_get_data(&sd->last_is_master), sd->last_is_master.len, &state);
@@ -1370,6 +1374,8 @@ void php_phongo_read_preference_to_zval(zval *retval, const mongoc_read_prefs_t 
 	add_assoc_long_ex(retval, ZEND_STRS("mode"), read_prefs->mode);
 	if (read_prefs->tags.len) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
+		/* Use native arrays for debugging output */
+		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		MAKE_STD_ZVAL(state.zchild);
 		bson_to_zval(bson_get_data(&read_prefs->tags), read_prefs->tags.len, &state);
@@ -1432,6 +1438,9 @@ void php_phongo_cursor_to_zval(zval *retval, php_phongo_cursor_t *cursor) /* {{{
 		_ADD_BOOL(zcursor, has_fields);
 #undef _ADD_BOOL
 
+		/* Avoid using PHONGO_TYPEMAP_NATIVE_ARRAY for decoding query, selector,
+		 * and current documents so that users can differentiate BSON arrays
+		 * and documents. */
 		{
 			php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
 

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -133,6 +133,8 @@ HashTable *php_phongo_query_get_debug_info(zval *object, int *is_temp TSRMLS_DC)
 
 	array_init_size(&retval, 6);
 
+	/* Avoid using PHONGO_TYPEMAP_NATIVE_ARRAY for decoding query and selector
+	 * documents so that users can differentiate BSON arrays and documents. */
 	if (intern->query) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
 

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -164,6 +164,7 @@ PHP_METHOD(Server, getTags)
 
 	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id))) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
+		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		MAKE_STD_ZVAL(state.zchild);
 		bson_to_zval(bson_get_data(&sd->tags), sd->tags.len, &state);
@@ -191,6 +192,7 @@ PHP_METHOD(Server, getInfo)
 
 	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id))) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
+		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		MAKE_STD_ZVAL(state.zchild);
 		bson_to_zval(bson_get_data(&sd->last_is_master), sd->last_is_master.len, &state);

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -164,6 +164,7 @@ PHP_METHOD(Server, getTags)
 
 	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id))) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
+		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		MAKE_STD_ZVAL(state.zchild);
@@ -192,6 +193,7 @@ PHP_METHOD(Server, getInfo)
 
 	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id))) {
 		php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
+		state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 		state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 		MAKE_STD_ZVAL(state.zchild);

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -235,7 +235,7 @@ PHP_METHOD(WriteResult, getUpsertedIds)
 	}
 }
 /* }}} */
-/* {{{ proto WriteConcernError[] WriteResult::getWriteConcernError()
+/* {{{ proto WriteConcernError WriteResult::getWriteConcernError()
    Return any write concern error that occurred */
 PHP_METHOD(WriteResult, getWriteConcernError)
 {

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -445,6 +445,7 @@ HashTable *php_phongo_writeresult_get_debug_info(zval *object, int *is_temp TSRM
 	add_assoc_long_ex(&retval, ZEND_STRS("nUpserted"), intern->write_result.nUpserted);
 
 	/* Use native arrays for debugging output */
+	state.map.root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 	state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
 	MAKE_STD_ZVAL(state.zchild);

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -444,6 +444,9 @@ HashTable *php_phongo_writeresult_get_debug_info(zval *object, int *is_temp TSRM
 	add_assoc_long_ex(&retval, ZEND_STRS("nRemoved"), intern->write_result.nRemoved);
 	add_assoc_long_ex(&retval, ZEND_STRS("nUpserted"), intern->write_result.nUpserted);
 
+	/* Use native arrays for debugging output */
+	state.map.document_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+
 	MAKE_STD_ZVAL(state.zchild);
 	bson_to_zval(bson_get_data(&intern->write_result.upserted), intern->write_result.upserted.len, &state);
 	add_assoc_zval_ex(&retval, ZEND_STRS("upsertedIds"), state.zchild);

--- a/src/bson.c
+++ b/src/bson.c
@@ -905,10 +905,10 @@ int bson_to_zval(const unsigned char *data, int data_len, php_phongo_bson_state 
 	/* If php_phongo_bson_visit_binary() finds an ODM class, it supersedes our
 	 * document type. */
 	if (state->odm) {
-		state->map.document_type = PHONGO_TYPEMAP_CLASS;
+		state->map.root_type = PHONGO_TYPEMAP_CLASS;
 	}
 
-	switch (state->map.document_type) {
+	switch (state->map.root_type) {
 		case PHONGO_TYPEMAP_NATIVE_ARRAY:
 			/* Nothing to do here */
 			break;
@@ -916,11 +916,11 @@ int bson_to_zval(const unsigned char *data, int data_len, php_phongo_bson_state 
 		case PHONGO_TYPEMAP_CLASS:
 			/* If the class implements Unserializable, initialize the object
 			 * from our array data; otherwise, fall through to native object. */
-			if (instanceof_function(state->odm ? state->odm : state->map.document, php_phongo_unserializable_ce TSRMLS_CC)) {
+			if (instanceof_function(state->odm ? state->odm : state->map.root, php_phongo_unserializable_ce TSRMLS_CC)) {
 				zval *obj = NULL;
 
 				MAKE_STD_ZVAL(obj);
-				object_init_ex(obj, state->odm ? state->odm : state->map.document);
+				object_init_ex(obj, state->odm ? state->odm : state->map.root);
 				zend_call_method_with_1_params(&obj, NULL, NULL, BSON_UNSERIALIZE_FUNC_NAME, NULL, state->zchild);
 				zval_ptr_dtor(&state->zchild);
 				state->zchild = obj;
@@ -970,7 +970,6 @@ void php_phongo_bson_typemap_to_state(zval *typemap, php_phongo_bson_typemap *ma
 		char                  *classname;
 		int                    classname_len;
 		zend_bool              classname_free = 0;
-		zend_class_entry      *array_ce = NULL, *document_ce = NULL;
 
 		classname = php_array_fetchl_string(typemap, "array", sizeof("array")-1, &classname_len, &classname_free);
 		if (classname_len) {
@@ -979,8 +978,8 @@ void php_phongo_bson_typemap_to_state(zval *typemap, php_phongo_bson_typemap *ma
 			} else if (!strcasecmp(classname, "stdclass") || !strcasecmp(classname, "object")) {
 				map->array_type = PHONGO_TYPEMAP_NATIVE_OBJECT;
 			} else {
+				zend_class_entry *array_ce = zend_fetch_class(classname, classname_len, ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 				map->array_type = PHONGO_TYPEMAP_CLASS;
-				array_ce = zend_fetch_class(classname, classname_len, ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 
 				if (instanceof_function(array_ce, php_phongo_unserializable_ce TSRMLS_CC)) {
 					map->array = array_ce;
@@ -998,11 +997,30 @@ void php_phongo_bson_typemap_to_state(zval *typemap, php_phongo_bson_typemap *ma
 			} else if (!strcasecmp(classname, "stdclass") || !strcasecmp(classname, "object")) {
 				map->document_type = PHONGO_TYPEMAP_NATIVE_OBJECT;
 			} else {
+				zend_class_entry *document_ce = zend_fetch_class(classname, classname_len, ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 				map->document_type = PHONGO_TYPEMAP_CLASS;
-				document_ce = zend_fetch_class(classname, classname_len, ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 
 				if (instanceof_function(document_ce, php_phongo_unserializable_ce TSRMLS_CC)) {
 					map->document = document_ce;
+				}
+			}
+			if (classname_free) {
+				efree(classname);
+			}
+		}
+
+		classname = php_array_fetchl_string(typemap, "root", sizeof("root")-1, &classname_len, &classname_free);
+		if (classname_len) {
+			if (!strcasecmp(classname, "array")) {
+				map->root_type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+			} else if (!strcasecmp(classname, "stdclass") || !strcasecmp(classname, "object")) {
+				map->root_type = PHONGO_TYPEMAP_NATIVE_OBJECT;
+			} else {
+				zend_class_entry *root_ce = zend_fetch_class(classname, classname_len, ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
+				map->root_type = PHONGO_TYPEMAP_CLASS;
+
+				if (instanceof_function(root_ce, php_phongo_unserializable_ce TSRMLS_CC)) {
+					map->root = root_ce;
 				}
 			}
 			if (classname_free) {

--- a/src/bson.c
+++ b/src/bson.c
@@ -943,9 +943,9 @@ int bson_to_zval(const unsigned char *data, int data_len, php_phongo_bson_state 
 	return 1;
 }
 
-/* {{{ proto string BSON\fromArray(array|object data)
-   Returns the BSON representation of a value */
-PHP_FUNCTION(fromArray)
+/* {{{ proto string BSON\fromPHP(array|object $value)
+   Returns the BSON representation of a PHP value */
+PHP_FUNCTION(fromPHP)
 {
 	zval   *data;
 	bson_t *bson;
@@ -1029,9 +1029,9 @@ void php_phongo_bson_typemap_to_state(zval *typemap, php_phongo_bson_typemap *ma
 		}
 	}
 }
-/* {{{ proto string BSON\toArray(string data [, array $typemap = array()])
-   Returns the PHP representation of a BSON value, optionally converting them into custom types/classes */
-PHP_FUNCTION(toArray)
+/* {{{ proto array|object BSON\toPHP(string $bson [, array $typemap = array()])
+   Returns the PHP representation of a BSON value, optionally converting it into a custom class */
+PHP_FUNCTION(toPHP)
 {
 	char                  *data;
 	int                    data_len;

--- a/src/bson.c
+++ b/src/bson.c
@@ -1055,7 +1055,7 @@ PHP_FUNCTION(toPHP)
 }
 /* }}} */
 
-/* {{{ proto BSON\toJSON BSON\toJSON(string data)
+/* {{{ proto string BSON\toJSON(string $bson)
    Returns the JSON representation of a BSON value */
 PHP_FUNCTION(toJSON)
 {
@@ -1086,7 +1086,7 @@ PHP_FUNCTION(toJSON)
 }
 /* }}} */
 
-/* {{{ proto string BSON\fromJSON(string data)
+/* {{{ proto string BSON\fromJSON(string $json)
    Returns the BSON representation of a JSON value */
 PHP_FUNCTION(fromJSON)
 {

--- a/tests/bson/bson-binary-001.phpt
+++ b/tests/bson/bson-binary-001.phpt
@@ -33,11 +33,11 @@ throws(function() use($classname) {
 
 
 foreach($tests as $n => $test) {
-    $s = fromArray($test);
+    $s = fromPHP($test);
     echo "Test#{$n} ", $json = toJSON($s), "\n";
     $bson = fromJSON($json);
-    $testagain = toArray($bson);
-    var_dump(toJSON(fromArray($test)), toJSON(fromArray($testagain)));
+    $testagain = toPHP($bson);
+    var_dump(toJSON(fromPHP($test)), toJSON(fromPHP($testagain)));
     var_dump((object)$test == (object)$testagain);
 }
 

--- a/tests/bson/bson-decode-001.phpt
+++ b/tests/bson/bson-decode-001.phpt
@@ -44,7 +44,7 @@ foreach($tests as $n => $test) {
     $s = fromArray($test);
     echo "Test#{$n} ", toJSON($s), "\n";
     $val = toArray($s);
-    if ($val == $test) {
+    if ($val == (object) $test) {
         echo "OK\n";
     } else {
         var_dump($val, $test);

--- a/tests/bson/bson-decode-001.phpt
+++ b/tests/bson/bson-decode-001.phpt
@@ -41,9 +41,9 @@ $tests = array(
 );
 
 foreach($tests as $n => $test) {
-    $s = fromArray($test);
+    $s = fromPHP($test);
     echo "Test#{$n} ", toJSON($s), "\n";
-    $val = toArray($s);
+    $val = toPHP($s);
     if ($val == (object) $test) {
         echo "OK\n";
     } else {

--- a/tests/bson/bson-decode-002.phpt
+++ b/tests/bson/bson-decode-002.phpt
@@ -25,7 +25,7 @@ $tests = array(
 foreach($tests as $n => $test) {
     $s = BSON\fromArray($test);
     echo "Test#{$n} ", BSON\toJSON($s), "\n";
-    $val = BSON\toArray($s, array("document"=> "MyArrayObject", "array" => "MyArrayObject"));
+    $val = BSON\toArray($s, array("root"=> "MyArrayObject", "document"=> "MyArrayObject", "array" => "MyArrayObject"));
     var_dump($val);
 }
 ?>

--- a/tests/bson/bson-decode-002.phpt
+++ b/tests/bson/bson-decode-002.phpt
@@ -23,9 +23,9 @@ $tests = array(
 );
 
 foreach($tests as $n => $test) {
-    $s = BSON\fromPHP($test);
-    echo "Test#{$n} ", BSON\toJSON($s), "\n";
-    $val = BSON\toPHP($s, array("root"=> "MyArrayObject", "document"=> "MyArrayObject", "array" => "MyArrayObject"));
+    $s = fromPHP($test);
+    echo "Test#{$n} ", toJSON($s), "\n";
+    $val = toPHP($s, array("root"=> "MyArrayObject", "document"=> "MyArrayObject", "array" => "MyArrayObject"));
     var_dump($val);
 }
 ?>

--- a/tests/bson/bson-decode-002.phpt
+++ b/tests/bson/bson-decode-002.phpt
@@ -23,9 +23,9 @@ $tests = array(
 );
 
 foreach($tests as $n => $test) {
-    $s = BSON\fromArray($test);
+    $s = BSON\fromPHP($test);
     echo "Test#{$n} ", BSON\toJSON($s), "\n";
-    $val = BSON\toArray($s, array("root"=> "MyArrayObject", "document"=> "MyArrayObject", "array" => "MyArrayObject"));
+    $val = BSON\toPHP($s, array("root"=> "MyArrayObject", "document"=> "MyArrayObject", "array" => "MyArrayObject"));
     var_dump($val);
 }
 ?>

--- a/tests/bson/bson-encode-001.phpt
+++ b/tests/bson/bson-encode-001.phpt
@@ -35,7 +35,7 @@ $tests = array(
 );
 
 foreach($tests as $n => $test) {
-    $s = fromArray($test);
+    $s = fromPHP($test);
     echo "Test#{$n} ", toJSON($s), "\n";
     hex_dump($s);
 }

--- a/tests/bson/bson-encode-002.phpt
+++ b/tests/bson/bson-encode-002.phpt
@@ -81,12 +81,15 @@ Encoded BSON:
      0 : 23 00 00 00 02 72 61 6e 64 6f 6d 00 06 00 00 00  [#....random.....]
     10 : 63 6c 61 73 73 00 02 30 00 05 00 00 00 64 61 74  [class..0.....dat]
     20 : 61 00 00                                         [a..]
-Decoded BSON:
+AssociativeArray::bsonUnserialize() was called with data:
 array(2) {
   ["random"]=>
   string(5) "class"
   [0]=>
   string(4) "data"
+}
+Decoded BSON:
+object(AssociativeArray)#%d (0) {
 }
 
 Testing embedded AssociativeArray:
@@ -102,11 +105,14 @@ array(2) {
   [0]=>
   string(4) "data"
 }
-Decoded BSON:
+AssociativeArray::bsonUnserialize() was called with data:
 array(1) {
   ["embed"]=>
   object(AssociativeArray)#%d (0) {
   }
+}
+Decoded BSON:
+object(AssociativeArray)#%d (0) {
 }
 
 Testing top-level NumericArray:
@@ -114,7 +120,7 @@ Testing top-level NumericArray:
 Encoded BSON:
      0 : 1a 00 00 00 10 30 00 01 00 00 00 10 31 00 02 00  [.....0......1...]
     10 : 00 00 10 32 00 03 00 00 00 00                    [...2......]
-Decoded BSON:
+NumericArray::bsonUnserialize() was called with data:
 array(3) {
   [0]=>
   int(1)
@@ -122,6 +128,9 @@ array(3) {
   int(2)
   [2]=>
   int(3)
+}
+Decoded BSON:
+object(NumericArray)#%d (0) {
 }
 
 Testing embedded NumericArray:
@@ -139,10 +148,13 @@ array(3) {
   [2]=>
   int(3)
 }
-Decoded BSON:
+NumericArray::bsonUnserialize() was called with data:
 array(1) {
   ["embed"]=>
   object(NumericArray)#%d (0) {
   }
+}
+Decoded BSON:
+object(NumericArray)#%d (0) {
 }
 ===DONE===

--- a/tests/bson/bson-encode-002.phpt
+++ b/tests/bson/bson-encode-002.phpt
@@ -36,38 +36,38 @@ class NumericArray implements BSON\Serializable, BSON\Unserializable
 }
 
 echo "Testing top-level AssociativeArray:\n";
-$bson = BSON\fromPHP(new AssociativeArray);
-echo BSON\toJSON($bson), "\n";
+$bson = fromPHP(new AssociativeArray);
+echo toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
-$value = BSON\toPHP($bson, array("root" => 'AssociativeArray'));
+$value = toPHP($bson, array("root" => 'AssociativeArray'));
 echo "Decoded BSON:\n";
 var_dump($value);
 
 echo "\nTesting embedded AssociativeArray:\n";
-$bson = BSON\fromPHP(array('embed' => new AssociativeArray));
-echo BSON\toJSON($bson), "\n";
+$bson = fromPHP(array('embed' => new AssociativeArray));
+echo toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
-$value = BSON\toPHP($bson, array("document" => 'AssociativeArray'));
+$value = toPHP($bson, array("document" => 'AssociativeArray'));
 echo "Decoded BSON:\n";
 var_dump($value);
 
 echo "\nTesting top-level NumericArray:\n";
-$bson = BSON\fromPHP(new NumericArray);
-echo BSON\toJSON($bson), "\n";
+$bson = fromPHP(new NumericArray);
+echo toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
-$value = BSON\toPHP($bson, array("root" => 'NumericArray'));
+$value = toPHP($bson, array("root" => 'NumericArray'));
 echo "Decoded BSON:\n";
 var_dump($value);
 
 echo "\nTesting embedded NumericArray:\n";
-$bson = BSON\fromPHP(array('embed' => new NumericArray));
-echo BSON\toJSON($bson), "\n";
+$bson = fromPHP(array('embed' => new NumericArray));
+echo toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
-$value = BSON\toPHP($bson, array("document" => 'NumericArray'));
+$value = toPHP($bson, array("document" => 'NumericArray'));
 echo "Decoded BSON:\n";
 var_dump($value);
 

--- a/tests/bson/bson-encode-002.phpt
+++ b/tests/bson/bson-encode-002.phpt
@@ -36,38 +36,38 @@ class NumericArray implements BSON\Serializable, BSON\Unserializable
 }
 
 echo "Testing top-level AssociativeArray:\n";
-$bson = BSON\fromArray(new AssociativeArray);
+$bson = BSON\fromPHP(new AssociativeArray);
 echo BSON\toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
-$value = BSON\toArray($bson, array("root" => 'AssociativeArray'));
+$value = BSON\toPHP($bson, array("root" => 'AssociativeArray'));
 echo "Decoded BSON:\n";
 var_dump($value);
 
 echo "\nTesting embedded AssociativeArray:\n";
-$bson = BSON\fromArray(array('embed' => new AssociativeArray));
+$bson = BSON\fromPHP(array('embed' => new AssociativeArray));
 echo BSON\toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
-$value = BSON\toArray($bson, array("document" => 'AssociativeArray'));
+$value = BSON\toPHP($bson, array("document" => 'AssociativeArray'));
 echo "Decoded BSON:\n";
 var_dump($value);
 
 echo "\nTesting top-level NumericArray:\n";
-$bson = BSON\fromArray(new NumericArray);
+$bson = BSON\fromPHP(new NumericArray);
 echo BSON\toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
-$value = BSON\toArray($bson, array("root" => 'NumericArray'));
+$value = BSON\toPHP($bson, array("root" => 'NumericArray'));
 echo "Decoded BSON:\n";
 var_dump($value);
 
 echo "\nTesting embedded NumericArray:\n";
-$bson = BSON\fromArray(array('embed' => new NumericArray));
+$bson = BSON\fromPHP(array('embed' => new NumericArray));
 echo BSON\toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
-$value = BSON\toArray($bson, array("document" => 'NumericArray'));
+$value = BSON\toPHP($bson, array("document" => 'NumericArray'));
 echo "Decoded BSON:\n";
 var_dump($value);
 

--- a/tests/bson/bson-encode-002.phpt
+++ b/tests/bson/bson-encode-002.phpt
@@ -40,7 +40,7 @@ $bson = BSON\fromArray(new AssociativeArray);
 echo BSON\toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
-$value = BSON\toArray($bson, array("document" => 'AssociativeArray'));
+$value = BSON\toArray($bson, array("root" => 'AssociativeArray'));
 echo "Decoded BSON:\n";
 var_dump($value);
 
@@ -58,7 +58,7 @@ $bson = BSON\fromArray(new NumericArray);
 echo BSON\toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
-$value = BSON\toArray($bson, array("document" => 'NumericArray'));
+$value = BSON\toArray($bson, array("root" => 'NumericArray'));
 echo "Decoded BSON:\n";
 var_dump($value);
 
@@ -105,14 +105,11 @@ array(2) {
   [0]=>
   string(4) "data"
 }
-AssociativeArray::bsonUnserialize() was called with data:
-array(1) {
+Decoded BSON:
+object(stdClass)#%d (1) {
   ["embed"]=>
   object(AssociativeArray)#%d (0) {
   }
-}
-Decoded BSON:
-object(AssociativeArray)#%d (0) {
 }
 
 Testing top-level NumericArray:
@@ -148,13 +145,10 @@ array(3) {
   [2]=>
   int(3)
 }
-NumericArray::bsonUnserialize() was called with data:
-array(1) {
+Decoded BSON:
+object(stdClass)#%d (1) {
   ["embed"]=>
   object(NumericArray)#%d (0) {
   }
-}
-Decoded BSON:
-object(NumericArray)#%d (0) {
 }
 ===DONE===

--- a/tests/bson/bson-encode-003.phpt
+++ b/tests/bson/bson-encode-003.phpt
@@ -53,7 +53,7 @@ Test#0 { "stuff" : { "__pclass" : { "$type" : "80", "$binary" : "TXlDbGFzcw==" }
     20 : 43 6c 61 73 73 02 72 61 6e 64 6f 6d 00 06 00 00  [Class.random....]
     30 : 00 63 6c 61 73 73 00 02 30 00 05 00 00 00 64 61  [.class..0.....da]
     40 : 74 61 00 00 00                                   [ta...]
-array(1) {
+object(stdClass)#%d (1) {
   ["stuff"]=>
   object(MyClass)#%d (1) {
     ["props"]=>
@@ -70,7 +70,7 @@ Test#1 { "stuff" : { "__pclass" : { "$type" : "80", "$binary" : "TXlDbGFzczI=" }
     10 : 5f 5f 70 63 6c 61 73 73 00 08 00 00 00 80 4d 79  [__pclass......My]
     20 : 43 6c 61 73 73 32 10 30 00 01 00 00 00 10 31 00  [Class2.0......1.]
     30 : 02 00 00 00 10 32 00 03 00 00 00 00 00           [.....2.......]
-array(1) {
+object(stdClass)#%d (1) {
   ["stuff"]=>
   object(MyClass2)#%d (1) {
     ["props"]=>
@@ -94,7 +94,7 @@ Test#2 { "stuff" : [ { "__pclass" : { "$type" : "80", "$binary" : "TXlDbGFzcw=="
     60 : 80 4d 79 43 6c 61 73 73 32 10 30 00 01 00 00 00  [.MyClass2.0.....]
     70 : 10 31 00 02 00 00 00 10 32 00 03 00 00 00 00 00  [.1......2.......]
     80 : 00                                               [.]
-array(1) {
+object(stdClass)#%d (1) {
   ["stuff"]=>
   array(2) {
     [0]=>

--- a/tests/bson/bson-encode-003.phpt
+++ b/tests/bson/bson-encode-003.phpt
@@ -37,10 +37,10 @@ $tests = array(
 );
 
 foreach($tests as $n => $test) {
-    $s = fromArray($test);
+    $s = fromPHP($test);
     echo "Test#{$n} ", toJSON($s), "\n";
     hex_dump($s);
-    $ret = toArray($s);
+    $ret = toPHP($s);
     var_dump($ret);
 }
 ?>

--- a/tests/bson/bson-encode-004.phpt
+++ b/tests/bson/bson-encode-004.phpt
@@ -22,10 +22,10 @@ $hannes->addFriend($mikola);
 
 var_dump($hannes);
 
-$s = fromArray(array($hannes));
+$s = fromPHP(array($hannes));
 echo "Test ", toJSON($s), "\n";
 hex_dump($s);
-$ret = toArray($s);
+$ret = toPHP($s);
 var_dump($ret);
 ?>
 ===DONE===

--- a/tests/bson/bson-encode-004.phpt
+++ b/tests/bson/bson-encode-004.phpt
@@ -94,7 +94,7 @@ Test { "0" : { "__pclass" : { "$type" : "80", "$binary" : "UGVyc29u" }, "name" :
    100 : 00 04 61 64 64 72 65 73 73 65 73 00 05 00 00 00  [..addresses.....]
    110 : 00 04 66 72 69 65 6e 64 73 00 05 00 00 00 00 00  [..friends.......]
    120 : 00 00 00                                         [...]
-array(1) {
+object(stdClass)#%d (1) {
   [0]=>
   object(Person)#%d (5) {
     ["name":protected]=>

--- a/tests/bson/bson-encode-004.phpt
+++ b/tests/bson/bson-encode-004.phpt
@@ -36,7 +36,7 @@ object(Person)#%d (5) {
   string(6) "Hannes"
   ["age":protected]=>
   int(42)
-  ["address":protected]=>
+  ["addresses":protected]=>
   array(2) {
     [0]=>
     object(Address)#%d (2) {
@@ -61,7 +61,7 @@ object(Person)#%d (5) {
       string(6) "Jeremy"
       ["age":protected]=>
       int(21)
-      ["address":protected]=>
+      ["addresses":protected]=>
       array(0) {
       }
       ["friends":protected]=>
@@ -74,25 +74,26 @@ object(Person)#%d (5) {
   ["secret":protected]=>
   string(24) "Hannes confidential info"
 }
-Test { "0" : { "__pclass" : { "$type" : "80", "$binary" : "UGVyc29u" }, "name" : "Hannes", "age" : 42, "address" : [ { "__pclass" : { "$type" : "80", "$binary" : "QWRkcmVzcw==" }, "zip" : 94086, "country" : "USA" }, { "__pclass" : { "$type" : "80", "$binary" : "QWRkcmVzcw==" }, "zip" : 200, "country" : "Iceland" } ], "friends" : [ { "__pclass" : { "$type" : "80", "$binary" : "UGVyc29u" }, "name" : "Jeremy", "age" : 21, "address" : [  ], "friends" : [  ] } ] } }
-     0 : 1f 01 00 00 03 30 00 17 01 00 00 05 5f 5f 70 63  [.....0......__pc]
+Test { "0" : { "__pclass" : { "$type" : "80", "$binary" : "UGVyc29u" }, "name" : "Hannes", "age" : 42, "addresses" : [ { "__pclass" : { "$type" : "80", "$binary" : "QWRkcmVzcw==" }, "zip" : 94086, "country" : "USA" }, { "__pclass" : { "$type" : "80", "$binary" : "QWRkcmVzcw==" }, "zip" : 200, "country" : "Iceland" } ], "friends" : [ { "__pclass" : { "$type" : "80", "$binary" : "UGVyc29u" }, "name" : "Jeremy", "age" : 21, "addresses" : [  ], "friends" : [  ] } ] } }
+     0 : 23 01 00 00 03 30 00 1b 01 00 00 05 5f 5f 70 63  [#....0......__pc]
     10 : 6c 61 73 73 00 06 00 00 00 80 50 65 72 73 6f 6e  [lass......Person]
     20 : 02 6e 61 6d 65 00 07 00 00 00 48 61 6e 6e 65 73  [.name.....Hannes]
     30 : 00 10 61 67 65 00 2a 00 00 00 04 61 64 64 72 65  [..age.*....addre]
-    40 : 73 73 00 79 00 00 00 03 30 00 35 00 00 00 05 5f  [ss.y....0.5...._]
-    50 : 5f 70 63 6c 61 73 73 00 07 00 00 00 80 41 64 64  [_pclass......Add]
-    60 : 72 65 73 73 10 7a 69 70 00 86 6f 01 00 02 63 6f  [ress.zip..o...co]
-    70 : 75 6e 74 72 79 00 04 00 00 00 55 53 41 00 00 03  [untry.....USA...]
-    80 : 31 00 39 00 00 00 05 5f 5f 70 63 6c 61 73 73 00  [1.9....__pclass.]
-    90 : 07 00 00 00 80 41 64 64 72 65 73 73 10 7a 69 70  [.....Address.zip]
-    A0 : 00 c8 00 00 00 02 63 6f 75 6e 74 72 79 00 08 00  [......country...]
-    B0 : 00 00 49 63 65 6c 61 6e 64 00 00 00 04 66 72 69  [..Iceland....fri]
-    C0 : 65 6e 64 73 00 58 00 00 00 03 30 00 50 00 00 00  [ends.X....0.P...]
-    D0 : 05 5f 5f 70 63 6c 61 73 73 00 06 00 00 00 80 50  [.__pclass......P]
-    E0 : 65 72 73 6f 6e 02 6e 61 6d 65 00 07 00 00 00 4a  [erson.name.....J]
-    F0 : 65 72 65 6d 79 00 10 61 67 65 00 15 00 00 00 04  [eremy..age......]
-   100 : 61 64 64 72 65 73 73 00 05 00 00 00 00 04 66 72  [address.......fr]
-   110 : 69 65 6e 64 73 00 05 00 00 00 00 00 00 00 00     [iends..........]
+    40 : 73 73 65 73 00 79 00 00 00 03 30 00 35 00 00 00  [sses.y....0.5...]
+    50 : 05 5f 5f 70 63 6c 61 73 73 00 07 00 00 00 80 41  [.__pclass......A]
+    60 : 64 64 72 65 73 73 10 7a 69 70 00 86 6f 01 00 02  [ddress.zip..o...]
+    70 : 63 6f 75 6e 74 72 79 00 04 00 00 00 55 53 41 00  [country.....USA.]
+    80 : 00 03 31 00 39 00 00 00 05 5f 5f 70 63 6c 61 73  [..1.9....__pclas]
+    90 : 73 00 07 00 00 00 80 41 64 64 72 65 73 73 10 7a  [s......Address.z]
+    A0 : 69 70 00 c8 00 00 00 02 63 6f 75 6e 74 72 79 00  [ip......country.]
+    B0 : 08 00 00 00 49 63 65 6c 61 6e 64 00 00 00 04 66  [....Iceland....f]
+    C0 : 72 69 65 6e 64 73 00 5a 00 00 00 03 30 00 52 00  [riends.Z....0.R.]
+    D0 : 00 00 05 5f 5f 70 63 6c 61 73 73 00 06 00 00 00  [...__pclass.....]
+    E0 : 80 50 65 72 73 6f 6e 02 6e 61 6d 65 00 07 00 00  [.Person.name....]
+    F0 : 00 4a 65 72 65 6d 79 00 10 61 67 65 00 15 00 00  [.Jeremy..age....]
+   100 : 00 04 61 64 64 72 65 73 73 65 73 00 05 00 00 00  [..addresses.....]
+   110 : 00 04 66 72 69 65 6e 64 73 00 05 00 00 00 00 00  [..friends.......]
+   120 : 00 00 00                                         [...]
 array(1) {
   [0]=>
   object(Person)#%d (5) {
@@ -100,7 +101,7 @@ array(1) {
     string(6) "Hannes"
     ["age":protected]=>
     int(42)
-    ["address":protected]=>
+    ["addresses":protected]=>
     array(2) {
       [0]=>
       object(Address)#%d (2) {
@@ -125,7 +126,7 @@ array(1) {
         string(6) "Jeremy"
         ["age":protected]=>
         int(21)
-        ["address":protected]=>
+        ["addresses":protected]=>
         array(0) {
         }
         ["friends":protected]=>

--- a/tests/bson/bson-encode-005.phpt
+++ b/tests/bson/bson-encode-005.phpt
@@ -13,10 +13,10 @@ $data = array(
     "emptyclass" => new stdclass,
 );
 
-$s = fromArray($data);
+$s = fromPHP($data);
 echo "Test ", toJSON($s), "\n";
 hex_dump($s);
-$ret = toArray($s);
+$ret = toPHP($s);
 var_dump($ret);
 ?>
 ===DONE===

--- a/tests/bson/bson-encode-005.phpt
+++ b/tests/bson/bson-encode-005.phpt
@@ -26,7 +26,7 @@ Test { "emptyarray" : [  ], "emptyclass" : {  } }
      0 : 27 00 00 00 04 65 6d 70 74 79 61 72 72 61 79 00  ['....emptyarray.]
     10 : 05 00 00 00 00 03 65 6d 70 74 79 63 6c 61 73 73  [......emptyclass]
     20 : 00 05 00 00 00 00 00                             [.......]
-array(2) {
+object(stdClass)#%d (2) {
   ["emptyarray"]=>
   array(0) {
   }

--- a/tests/bson/bson-encode_error-001.phpt
+++ b/tests/bson/bson-encode_error-001.phpt
@@ -27,7 +27,7 @@ $invalidValues = array(new stdClass, 'foo', 1, true);
 
 foreach ($invalidValues as $invalidValue) {
     try {
-        fromArray(new MyClass($invalidValue));
+        fromPHP(new MyClass($invalidValue));
     } catch (MongoDB\Driver\Exception\UnexpectedValueException $e) {
         echo $e->getMessage(), "\n";
     }

--- a/tests/bson/bson-encode_error-002.phpt
+++ b/tests/bson/bson-encode_error-002.phpt
@@ -27,7 +27,7 @@ $invalidValues = array(new stdClass, 'foo', 1, true);
 
 foreach ($invalidValues as $invalidValue) {
     try {
-        $bson = fromArray(array('embed' => new MyClass($invalidValue)));
+        $bson = fromPHP(array('embed' => new MyClass($invalidValue)));
     } catch (MongoDB\Driver\Exception\UnexpectedValueException $e) {
         echo $e->getMessage(), "\n";
     }

--- a/tests/bson/bson-generate-document-id.phpt
+++ b/tests/bson/bson-generate-document-id.phpt
@@ -55,7 +55,7 @@ array(3) {
 }
 
 Dumping fetched user document:
-array(3) {
+object(stdClass)#%d (3) {
   ["_id"]=>
   object(%s\ObjectID)#%d (%d) {
     ["oid"]=>

--- a/tests/bson/bson-javascript-001.phpt
+++ b/tests/bson/bson-javascript-001.phpt
@@ -21,8 +21,8 @@ throws(function() use($classname) {
 
 foreach($tests as $n => $test) {
     echo "Test#{$n}", "\n";
-    $s = fromArray($test);
-    $testagain = toArray($s);
+    $s = fromPHP($test);
+    $testagain = toPHP($s);
     var_dump(current($test) instanceof $classname);
     var_dump(current($testagain) instanceof $classname);
 }

--- a/tests/bson/bson-maxkey-001.phpt
+++ b/tests/bson/bson-maxkey-001.phpt
@@ -13,11 +13,11 @@ $tests = array(
 );
 
 foreach($tests as $n => $test) {
-    $s = fromArray($test);
+    $s = fromPHP($test);
     echo "Test#{$n} ", $json = toJSON($s), "\n";
     $bson = fromJSON($json);
-    $testagain = toArray($bson);
-    var_dump(toJSON(fromArray($test)), toJSON(fromArray($testagain)));
+    $testagain = toPHP($bson);
+    var_dump(toJSON(fromPHP($test)), toJSON(fromPHP($testagain)));
     var_dump((object)$test == (object)$testagain);
 }
 ?>

--- a/tests/bson/bson-minkey-001.phpt
+++ b/tests/bson/bson-minkey-001.phpt
@@ -13,11 +13,11 @@ $tests = array(
 );
 
 foreach($tests as $n => $test) {
-    $s = fromArray($test);
+    $s = fromPHP($test);
     echo "Test#{$n} ", $json = toJSON($s), "\n";
     $bson = fromJSON($json);
-    $testagain = toArray($bson);
-    var_dump(toJSON(fromArray($test)), toJSON(fromArray($testagain)));
+    $testagain = toPHP($bson);
+    var_dump(toJSON(fromPHP($test)), toJSON(fromPHP($testagain)));
     var_dump((object)$test == (object)$testagain);
 }
 ?>

--- a/tests/bson/bson-objectid-001.phpt
+++ b/tests/bson/bson-objectid-001.phpt
@@ -33,11 +33,11 @@ $tests = array(
 );
 
 foreach($tests as $n => $test) {
-    $s = fromArray($test);
+    $s = fromPHP($test);
     echo "Test#{$n} ", $json = toJSON($s), "\n";
     $bson = fromJSON($json);
-    $testagain = toArray($bson);
-    var_dump(toJSON(fromArray($test)), toJSON(fromArray($testagain)));
+    $testagain = toPHP($bson);
+    var_dump(toJSON(fromPHP($test)), toJSON(fromPHP($testagain)));
     var_dump((object)$test == (object)$testagain);
 }
 

--- a/tests/bson/bson-regex-001.phpt
+++ b/tests/bson/bson-regex-001.phpt
@@ -23,11 +23,11 @@ throws(function() use($classname) {
 
 
 foreach($tests as $n => $test) {
-    $s = fromArray($test);
+    $s = fromPHP($test);
     echo "Test#{$n} ", $json = toJSON($s), "\n";
     $bson = fromJSON($json);
-    $testagain = toArray($bson);
-    var_dump(toJSON(fromArray($test)), toJSON(fromArray($testagain)));
+    $testagain = toPHP($bson);
+    var_dump(toJSON(fromPHP($test)), toJSON(fromPHP($testagain)));
     var_dump((object)$test == (object)$testagain);
 }
 

--- a/tests/bson/bson-timestamp-001.phpt
+++ b/tests/bson/bson-timestamp-001.phpt
@@ -20,11 +20,11 @@ $s = new $classname(1234, 5678);
 echo $s, "\n";
 
 foreach($tests as $n => $test) {
-    $s = fromArray($test);
+    $s = fromPHP($test);
     echo "Test#{$n} ", $json = toJSON($s), "\n";
     $bson = fromJSON($json);
-    $testagain = toArray($bson);
-    var_dump(toJSON(fromArray($test)), toJSON(fromArray($testagain)));
+    $testagain = toPHP($bson);
+    var_dump(toJSON(fromPHP($test)), toJSON(fromPHP($testagain)));
     var_dump((object)$test == (object)$testagain);
 }
 ?>

--- a/tests/bson/bson-unknown-001.phpt
+++ b/tests/bson/bson-unknown-001.phpt
@@ -11,13 +11,13 @@ require_once __DIR__ . "/../utils/basic.inc";
 throws(function() {
     $a = array("stderr" => STDERR);
 
-    $b = fromArray($a);
+    $b = fromPHP($a);
 }, "MongoDB\Driver\Exception\UnexpectedValueException");
 
 throws(function() {
     $a = array("stderr" => STDERR, "stdout" => STDOUT);
 
-    $b = fromArray($a);
+    $b = fromPHP($a);
 }, "MongoDB\Driver\Exception\UnexpectedValueException");
 
 

--- a/tests/bson/bson-utcdatetime-001.phpt
+++ b/tests/bson/bson-utcdatetime-001.phpt
@@ -34,11 +34,11 @@ $tests = array(
 );
 
 foreach($tests as $n => $test) {
-    $s = fromArray($test);
+    $s = fromPHP($test);
     echo "Test#{$n} ", $json = toJSON($s), "\n";
     $bson = fromJSON($json);
-    $testagain = toArray($bson);
-    var_dump(toJSON(fromArray($test)), toJSON(fromArray($testagain)));
+    $testagain = toPHP($bson);
+    var_dump(toJSON(fromPHP($test)), toJSON(fromPHP($testagain)));
     var_dump((object)$test == (object)$testagain);
 }
 ?>

--- a/tests/bson/bson-utcdatetime-001.phpt
+++ b/tests/bson/bson-utcdatetime-001.phpt
@@ -29,7 +29,7 @@ throws(function() use($classname) {
 
 $tests = array(
     array($utcdatetime),
-    array($array[0]["x"]),
+    array($array[0]->x),
     array($date),
 );
 

--- a/tests/bson/bug0274.phpt
+++ b/tests/bson/bug0274.phpt
@@ -25,13 +25,13 @@ class NumericArray implements BSON\Serializable
 }
 
 echo "Testing top-level AssociativeArray:\n";
-$bson = fromArray(new AssociativeArray);
+$bson = fromPHP(new AssociativeArray);
 echo toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);
 
 echo "\nTesting top-level NumericArray:\n";
-$bson = fromArray(new NumericArray);
+$bson = fromPHP(new NumericArray);
 echo toJSON($bson), "\n";
 echo "Encoded BSON:\n";
 hex_dump($bson);

--- a/tests/bson/bug0325.phpt
+++ b/tests/bson/bug0325.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 $bson1 = fromJSON('{"x": "y"}');
 $bson2 = fromJSON('{"a": "b"}');
-$value = toArray($bson1 . $bson2);
+$value = toPHP($bson1 . $bson2);
 
 var_dump($value);
 
@@ -16,6 +16,6 @@ var_dump($value);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-Warning: %s\toArray(): Reading document did not exhaust input buffer in %s on line %d
+Warning: %s\toPHP(): Reading document did not exhaust input buffer in %s on line %d
 NULL
 ===DONE===

--- a/tests/bson/typemap-001.phpt
+++ b/tests/bson/typemap-001.phpt
@@ -32,60 +32,87 @@ function fetch($manager, $typemap = array()) {
 }
 
 
-/* Default */
+echo "Default\n";
 $documents = fetch($manager);
+var_dump($documents[0] instanceof stdClass);
 var_dump(is_array($documents[0]->bson_array));
-var_dump(is_object($documents[0]->bson_object));
+var_dump($documents[0]->bson_object instanceof stdClass);
 
 
-/* Setting to MyArrayObject */
+echo "\nSetting to 'MyArrayObject' for arrays\n";
 $documents = fetch($manager, array("array" => "MyArrayObject"));
+var_dump($documents[0] instanceof stdClass);
 var_dump($documents[0]->bson_array instanceof MyArrayObject);
-var_dump(is_object($documents[0]->bson_object));
+var_dump($documents[0]->bson_object instanceof stdClass);
 
-/* Setting to MyArrayObject & MyArrayObject */
-$documents = fetch($manager, array("array" => "MyArrayObject", "document" => "MyArrayObject"));
+echo "\nSetting to 'MyArrayObject' for arrays, embedded, and root documents\n";
+$documents = fetch($manager, array("array" => "MyArrayObject", "document" => "MyArrayObject", "root" => "MyArrayObject"));
+var_dump($documents[0] instanceof MyArrayObject);
 var_dump($documents[0]['bson_array'] instanceof MyArrayObject);
 var_dump($documents[0]['bson_object'] instanceof MyArrayObject);
 
 
-/* Setting to array */
-$documents = fetch($manager, array("array" => "array", "document" => "array"));
+echo "\nSetting to 'array' for arrays, embedded, and root documents\n";
+$documents = fetch($manager, array("array" => "array", "document" => "array", "root" => "array"));
+var_dump(is_array($documents[0]));
 var_dump(is_array($documents[0]['bson_array']));
 var_dump(is_array($documents[0]['bson_object']));
 
 
-/* Setting to stdclass & array */
-$documents = fetch($manager, array("array" => "stdclass", "document" => "array"));
-var_dump(is_object($documents[0]['bson_array']));
+echo "\nSetting to 'stdclass' for arrays and 'array' for embedded and root documents\n";
+$documents = fetch($manager, array("array" => "stdclass", "document" => "array", "root" => "array"));
+var_dump(is_array($documents[0]));
+var_dump($documents[0]['bson_array'] instanceof stdClass);
 var_dump(is_array($documents[0]['bson_object']));
 
 
-/* Setting to array & stdclass */
-$documents = fetch($manager, array("array" => "array", "document" => "stdclass"));
-var_dump(is_array($documents[0]->bson_array));
-var_dump(is_object($documents[0]->bson_object));
+echo "\nSetting to 'array' for arrays, 'stdclass' for embedded document, and 'MyArrayObject' for root document\n";
+$documents = fetch($manager, array("array" => "array", "document" => "stdclass", "root" => "MyArrayObject"));
+var_dump($documents[0] instanceof MyArrayObject);
+var_dump(is_array($documents[0]['bson_array']));
+var_dump($documents[0]['bson_object'] instanceof stdClass);
 
 
-/* Setting to stdclass */
-$documents = fetch($manager, array("array" => "stdclass", "document" => "stdclass"));
-var_dump(is_object($documents[0]->bson_array));
-var_dump(is_object($documents[0]->bson_object));
+echo "\nSetting to 'stdclass' for arrays, embedded, and root documents\n";
+$documents = fetch($manager, array("array" => "stdclass", "document" => "stdclass", "root" => "stdclass"));
+var_dump($documents[0] instanceof stdClass);
+var_dump($documents[0]->bson_array instanceof stdClass);
+var_dump($documents[0]->bson_object instanceof stdClass);
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
+Default
 bool(true)
 bool(true)
 bool(true)
+
+Setting to 'MyArrayObject' for arrays
 bool(true)
 bool(true)
 bool(true)
+
+Setting to 'MyArrayObject' for arrays, embedded, and root documents
 bool(true)
 bool(true)
 bool(true)
+
+Setting to 'array' for arrays, embedded, and root documents
 bool(true)
 bool(true)
+bool(true)
+
+Setting to 'stdclass' for arrays and 'array' for embedded and root documents
+bool(true)
+bool(true)
+bool(true)
+
+Setting to 'array' for arrays, 'stdclass' for embedded document, and 'MyArrayObject' for root document
+bool(true)
+bool(true)
+bool(true)
+
+Setting to 'stdclass' for arrays, embedded, and root documents
 bool(true)
 bool(true)
 bool(true)

--- a/tests/bson/typemap-001.phpt
+++ b/tests/bson/typemap-001.phpt
@@ -34,14 +34,14 @@ function fetch($manager, $typemap = array()) {
 
 /* Default */
 $documents = fetch($manager);
-var_dump(is_array($documents[0]['bson_array']));
-var_dump(is_object($documents[0]['bson_object']));
+var_dump(is_array($documents[0]->bson_array));
+var_dump(is_object($documents[0]->bson_object));
 
 
 /* Setting to MyArrayObject */
 $documents = fetch($manager, array("array" => "MyArrayObject"));
-var_dump($documents[0]['bson_array'] instanceof MyArrayObject);
-var_dump(is_object($documents[0]['bson_object']));
+var_dump($documents[0]->bson_array instanceof MyArrayObject);
+var_dump(is_object($documents[0]->bson_object));
 
 /* Setting to MyArrayObject & MyArrayObject */
 $documents = fetch($manager, array("array" => "MyArrayObject", "document" => "MyArrayObject"));
@@ -55,7 +55,7 @@ var_dump(is_array($documents[0]['bson_array']));
 var_dump(is_array($documents[0]['bson_object']));
 
 
-/* Setting to stdlcass & array */
+/* Setting to stdclass & array */
 $documents = fetch($manager, array("array" => "stdclass", "document" => "array"));
 var_dump(is_object($documents[0]['bson_array']));
 var_dump(is_array($documents[0]['bson_object']));
@@ -63,14 +63,14 @@ var_dump(is_array($documents[0]['bson_object']));
 
 /* Setting to array & stdclass */
 $documents = fetch($manager, array("array" => "array", "document" => "stdclass"));
-var_dump(is_array($documents[0]['bson_array']));
-var_dump(is_object($documents[0]['bson_object']));
+var_dump(is_array($documents[0]->bson_array));
+var_dump(is_object($documents[0]->bson_object));
 
 
 /* Setting to stdclass */
 $documents = fetch($manager, array("array" => "stdclass", "document" => "stdclass"));
-var_dump(is_object($documents[0]['bson_array']));
-var_dump(is_object($documents[0]['bson_object']));
+var_dump(is_object($documents[0]->bson_array));
+var_dump(is_object($documents[0]->bson_object));
 ?>
 ===DONE===
 <?php exit(0); ?>

--- a/tests/bson/typemap-002.phpt
+++ b/tests/bson/typemap-002.phpt
@@ -41,14 +41,14 @@ var_dump(is_array($documents[0]['bson_object']));
 
 /* Setting to array & object */
 $documents = fetch($manager, array("array" => "array", "document" => "object"));
-var_dump(is_array($documents[0]['bson_array']));
-var_dump(is_object($documents[0]['bson_object']));
+var_dump(is_array($documents[0]->bson_array));
+var_dump(is_object($documents[0]->bson_object));
 
 
 /* Setting to object */
 $documents = fetch($manager, array("array" => "object", "document" => "object"));
-var_dump(is_object($documents[0]['bson_array']));
-var_dump(is_object($documents[0]['bson_object']));
+var_dump(is_object($documents[0]->bson_array));
+var_dump(is_object($documents[0]->bson_object));
 ?>
 ===DONE===
 <?php exit(0); ?>

--- a/tests/bson/typemap-002.phpt
+++ b/tests/bson/typemap-002.phpt
@@ -32,30 +32,40 @@ function fetch($manager, $typemap = array()) {
 }
 
 
-
-/* Setting to stdlcass & array */
-$documents = fetch($manager, array("array" => "object", "document" => "array"));
-var_dump(is_object($documents[0]['bson_array']));
+echo "Setting to 'object' for arrays and 'array' for embedded and root documents\n";
+$documents = fetch($manager, array("array" => "object", "document" => "array", "root" => "array"));
+var_dump(is_array($documents[0]));
+var_dump($documents[0]['bson_array'] instanceof stdClass);
 var_dump(is_array($documents[0]['bson_object']));
 
 
-/* Setting to array & object */
-$documents = fetch($manager, array("array" => "array", "document" => "object"));
+echo "\nSetting to 'array' for arrays and 'object' for embedded and root documents\n";
+$documents = fetch($manager, array("array" => "array", "document" => "object", "root" => "object"));
+var_dump($documents[0] instanceof stdClass);
 var_dump(is_array($documents[0]->bson_array));
-var_dump(is_object($documents[0]->bson_object));
+var_dump($documents[0]->bson_object instanceof stdClass);
 
 
-/* Setting to object */
-$documents = fetch($manager, array("array" => "object", "document" => "object"));
-var_dump(is_object($documents[0]->bson_array));
-var_dump(is_object($documents[0]->bson_object));
+echo "\nSetting to 'object' for arrays, embedded, and root documents\n";
+$documents = fetch($manager, array("array" => "object", "document" => "object", "root" => "object"));
+var_dump($documents[0] instanceof stdClass);
+var_dump($documents[0]->bson_array instanceof stdClass);
+var_dump($documents[0]->bson_object instanceof stdClass);
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
+Setting to 'object' for arrays and 'array' for embedded and root documents
 bool(true)
 bool(true)
 bool(true)
+
+Setting to 'array' for arrays and 'object' for embedded and root documents
+bool(true)
+bool(true)
+bool(true)
+
+Setting to 'object' for arrays, embedded, and root documents
 bool(true)
 bool(true)
 bool(true)

--- a/tests/connect/standalone-plain-0001.phpt
+++ b/tests/connect/standalone-plain-0001.phpt
@@ -43,7 +43,7 @@ try {
     $query = new MongoDB\Driver\Query(array("very" => "important"));
     $cursor = $manager->executeQuery(NS, $query);
     foreach($cursor as $document) {
-        var_dump($document["very"]);
+        var_dump($document->very);
     }
     $cmd = new MongoDB\Driver\Command(array("drop" => COLLECTION_NAME));
     $result = $manager->executeCommand(DATABASE_NAME, $cmd);

--- a/tests/connect/standalone-x509-0001.phpt
+++ b/tests/connect/standalone-x509-0001.phpt
@@ -40,7 +40,7 @@ try {
     $query = new MongoDB\Driver\Query(array("very" => "important"));
     $cursor = $manager->executeQuery(NS, $query);
     foreach($cursor as $document) {
-        var_dump($document["very"]);
+        var_dump($document->very);
     }
     $command = new MongoDB\Driver\Command(array("drop" => COLLECTION_NAME));
     $result = $manager->executeCommand(DATABASE_NAME, $command);

--- a/tests/connect/standalone-x509-0002.phpt
+++ b/tests/connect/standalone-x509-0002.phpt
@@ -42,7 +42,7 @@ try {
     $query = new MongoDB\Driver\Query(array("very" => "important"));
     $cursor = $manager->executeQuery(NS, $query);
     foreach($cursor as $document) {
-        var_dump($document["very"]);
+        var_dump($document->very);
     }
     $command = new MongoDB\Driver\Command(array("drop" => COLLECTION_NAME));
     $result = $manager->executeCommand(DATABASE_NAME, $command);

--- a/tests/connect/standalone-x509-0003.phpt
+++ b/tests/connect/standalone-x509-0003.phpt
@@ -28,7 +28,7 @@ try {
     $query = new MongoDB\Driver\Query(array("very" => "important"));
     $cursor = $manager->executeQuery(NS, $query);
     foreach($cursor as $document) {
-        var_dump($document["very"]);
+        var_dump($document->very);
     }
     $command = new MongoDB\Driver\Command(array("drop" => COLLECTION_NAME));
     $result = $manager->executeCommand(DATABASE_NAME, $command);

--- a/tests/connect/standalone-x509-0004.phpt
+++ b/tests/connect/standalone-x509-0004.phpt
@@ -31,7 +31,7 @@ try {
     $query = new MongoDB\Driver\Query(array("very" => "important"));
     $cursor = $manager->executeQuery(NS, $query);
     foreach($cursor as $document) {
-        var_dump($document["very"]);
+        var_dump($document->very);
     }
     $command = new MongoDB\Driver\Command(array("drop" => COLLECTION_NAME));
     $result = $manager->executeCommand(DATABASE_NAME, $command);

--- a/tests/cursor/cursor-IteratorIterator-001.phpt
+++ b/tests/cursor/cursor-IteratorIterator-001.phpt
@@ -20,14 +20,14 @@ foreach (new IteratorIterator($cursor) as $document) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
-array(2) {
+--EXPECTF--
+object(stdClass)#%d (2) {
   ["_id"]=>
   int(1)
   ["x"]=>
   int(1)
 }
-array(2) {
+object(stdClass)#%d (2) {
   ["_id"]=>
   int(2)
   ["x"]=>

--- a/tests/cursor/cursor-IteratorIterator-002.phpt
+++ b/tests/cursor/cursor-IteratorIterator-002.phpt
@@ -28,14 +28,14 @@ foreach (new IteratorIterator($cursor) as $document) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
-array(2) {
+--EXPECTF--
+object(stdClass)#%d (2) {
   ["_id"]=>
   int(1)
   ["x"]=>
   int(1)
 }
-array(2) {
+object(stdClass)#%d (2) {
   ["_id"]=>
   int(2)
   ["x"]=>

--- a/tests/cursor/cursor-destruct-001.phpt
+++ b/tests/cursor/cursor-destruct-001.phpt
@@ -10,7 +10,7 @@ function getNumOpenCursors(MongoDB\Driver\Manager $manager)
 {
     $cursor = $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(array('serverStatus' => 1)));
     $result = current($cursor->toArray());
-    return $result['cursors']->totalOpen;
+    return $result->cursors->totalOpen;
 }
 
 $manager = new MongoDB\Driver\Manager(STANDALONE);

--- a/tests/cursor/cursor-get_iterator-001.phpt
+++ b/tests/cursor/cursor-get_iterator-001.phpt
@@ -38,19 +38,19 @@ try {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 Inserted: 3
 
 First foreach statement:
-array(1) {
+object(stdClass)#%d (1) {
   ["_id"]=>
   int(0)
 }
-array(1) {
+object(stdClass)#%d (1) {
   ["_id"]=>
   int(1)
 }
-array(1) {
+object(stdClass)#%d (1) {
   ["_id"]=>
   int(2)
 }

--- a/tests/cursor/cursor-get_iterator-003.phpt
+++ b/tests/cursor/cursor-get_iterator-003.phpt
@@ -40,17 +40,17 @@ Inserted: 3
 First Cursor::toArray():
 array(3) {
   [0]=>
-  array(1) {
+  object(stdClass)#%d (1) {
     ["_id"]=>
     int(0)
   }
   [1]=>
-  array(1) {
+  object(stdClass)#%d (1) {
     ["_id"]=>
     int(1)
   }
   [2]=>
-  array(1) {
+  object(stdClass)#%d (1) {
     ["_id"]=>
     int(2)
   }

--- a/tests/cursor/cursor-getmore-001.phpt
+++ b/tests/cursor/cursor-getmore-001.phpt
@@ -20,7 +20,7 @@ printf("Inserted: %d\n", $writeResult->getInsertedCount());
 $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query(array(), array('batchSize' => 2)));
 
 foreach ($cursor as $i => $document) {
-    printf("%d => {_id: %d}\n", $i, $document['_id']);
+    printf("%d => {_id: %d}\n", $i, $document->_id);
 }
 
 ?>

--- a/tests/cursor/cursor-getmore-002.phpt
+++ b/tests/cursor/cursor-getmore-002.phpt
@@ -20,7 +20,7 @@ printf("Inserted: %d\n", $writeResult->getInsertedCount());
 $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query(array(), array('batchSize' => 2)));
 
 foreach ($cursor as $i => $document) {
-    printf("%d => {_id: %d}\n", $i, $document['_id']);
+    printf("%d => {_id: %d}\n", $i, $document->_id);
 }
 
 ?>

--- a/tests/cursor/cursor-getmore-003.phpt
+++ b/tests/cursor/cursor-getmore-003.phpt
@@ -28,7 +28,7 @@ $command = new MongoDB\Driver\Command(array(
 $cursor = $manager->executeCommand(DATABASE_NAME, $command);
 
 foreach ($cursor as $i => $document) {
-    printf("%d => {_id: %d}\n", $i, $document['_id']);
+    printf("%d => {_id: %d}\n", $i, $document->_id);
 }
 
 ?>

--- a/tests/cursor/cursor-getmore-004.phpt
+++ b/tests/cursor/cursor-getmore-004.phpt
@@ -28,7 +28,7 @@ $command = new MongoDB\Driver\Command(array(
 $cursor = $manager->executeCommand(DATABASE_NAME, $command);
 
 foreach ($cursor as $i => $document) {
-    printf("%d => {_id: %d}\n", $i, $document['_id']);
+    printf("%d => {_id: %d}\n", $i, $document->_id);
 }
 
 ?>

--- a/tests/cursor/cursor-getmore-005.phpt
+++ b/tests/cursor/cursor-getmore-005.phpt
@@ -19,7 +19,7 @@ $cursor = $manager->executeQuery(NS, $query);
 failGetMore($manager);
 throws(function() use ($cursor) {
     foreach ($cursor as $document) {
-        echo $document['username'] . "\n";
+        echo $document->username . "\n";
     }
 }, "MongoDB\Driver\Exception\ConnectionException");
 

--- a/tests/cursor/cursor-iterator_handlers-001.phpt
+++ b/tests/cursor/cursor-iterator_handlers-001.phpt
@@ -21,7 +21,7 @@ class MyIteratorIterator extends IteratorIterator
         $key = parent::key();
         $current = parent::current();
         $position = is_int($key) ? (string) $key : 'null';
-        $document = is_array($current) ? sprintf("{_id: %d}", $current['_id']) : 'null';
+        $document = is_object($current) ? sprintf("{_id: %d}", $current->_id) : 'null';
         printf("%s: %s => %s\n", $this->name, $position, $document);
     }
 }

--- a/tests/cursor/cursor-rewind-001.phpt
+++ b/tests/cursor/cursor-rewind-001.phpt
@@ -21,7 +21,7 @@ class MyIteratorIterator extends IteratorIterator
         $key = parent::key();
         $current = parent::current();
         $position = is_int($key) ? (string) $key : 'null';
-        $document = is_array($current) ? sprintf("{_id: %d}", $current['_id']) : 'null';
+        $document = is_object($current) ? sprintf("{_id: %d}", $current->_id) : 'null';
         printf("%s: %s => %s\n", $this->name, $position, $document);
     }
 }

--- a/tests/cursor/cursor-toArray-001.phpt
+++ b/tests/cursor/cursor-toArray-001.phpt
@@ -25,18 +25,18 @@ var_dump(iterator_to_array($cursor));
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 Dumping Cursor::toArray():
 array(2) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>
     int(1)
   }
   [1]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["x"]=>
@@ -47,14 +47,14 @@ array(2) {
 Dumping iterated Cursor:
 array(2) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>
     int(1)
   }
   [1]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["x"]=>

--- a/tests/cursor/cursor-toArray-002.phpt
+++ b/tests/cursor/cursor-toArray-002.phpt
@@ -26,7 +26,7 @@ $cursor->setTypeMap(array("array" => "MyArrayObject"));
 
 $documents = $cursor->toArray();
 
-var_dump($documents[0]['x'] instanceof MyArrayObject);
+var_dump($documents[0]->x instanceof MyArrayObject);
 
 ?>
 ===DONE===

--- a/tests/functional/cursor-001.phpt
+++ b/tests/functional/cursor-001.phpt
@@ -18,7 +18,7 @@ $query = new MongoDB\Driver\Query(array(), array(
 $cursor = $manager->executeQuery(NS, $query);
 
 foreach ($cursor as $document) {
-    echo $document['username'] . "\n";
+    echo $document->username . "\n";
 }
 
 ?>

--- a/tests/functional/query-sort-001.phpt
+++ b/tests/functional/query-sort-001.phpt
@@ -18,7 +18,7 @@ $query = new MongoDB\Driver\Query(array(), array(
 $cursor = $manager->executeQuery(NS, $query);
 
 foreach ($cursor as $document) {
-    echo $document['username'] . "\n";
+    echo $document->username . "\n";
 }
 
 ?>

--- a/tests/functional/query-sort-002.phpt
+++ b/tests/functional/query-sort-002.phpt
@@ -18,7 +18,7 @@ $query = new MongoDB\Driver\Query(array(), array(
 $cursor = $manager->executeQuery(NS, $query);
 
 foreach ($cursor as $document) {
-    echo $document['username'] . "\n";
+    echo $document->username . "\n";
 }
 
 ?>

--- a/tests/functional/query-sort-003.phpt
+++ b/tests/functional/query-sort-003.phpt
@@ -21,7 +21,7 @@ $cursor = $manager->executeQuery(NS, $query);
 var_dump(get_class($cursor));
 
 foreach ($cursor as $document) {
-    echo $document['username'] . "\n";
+    echo $document->username . "\n";
 }
 
 ?>
@@ -30,7 +30,7 @@ foreach ($cursor as $document) {
 --EXPECTF--
 object(MongoDB\Driver\Query)#%d (%d) {
   ["query"]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["$orderby"]=>
     object(stdClass)#%d (1) {
       ["username"]=>
@@ -41,7 +41,7 @@ object(MongoDB\Driver\Query)#%d (%d) {
     }
   }
   ["selector"]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(0)
     ["username"]=>

--- a/tests/functional/query-sort-004.phpt
+++ b/tests/functional/query-sort-004.phpt
@@ -26,6 +26,11 @@ var_dump($query);
 
 $cursor = $manager->executeQuery(NS, $query);
 
+/* Numeric keys of stdClass instances cannot be directly accessed, so ensure the
+ * document is decoded as a PHP array.
+ */
+$cursor->setTypeMap(array('document' => 'array'));
+
 foreach ($cursor as $document) {
     echo $document['0'] . "\n";
 }
@@ -37,7 +42,7 @@ foreach ($cursor as $document) {
 Inserted: 5
 object(MongoDB\Driver\Query)#%d (6) {
   ["query"]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["$orderby"]=>
     object(stdClass)#%d (1) {
       [0]=>

--- a/tests/functional/query-sort-004.phpt
+++ b/tests/functional/query-sort-004.phpt
@@ -29,7 +29,7 @@ $cursor = $manager->executeQuery(NS, $query);
 /* Numeric keys of stdClass instances cannot be directly accessed, so ensure the
  * document is decoded as a PHP array.
  */
-$cursor->setTypeMap(array('document' => 'array'));
+$cursor->setTypeMap(array('root' => 'array'));
 
 foreach ($cursor as $document) {
     echo $document['0'] . "\n";

--- a/tests/manager/manager-executeBulkWrite-001.phpt
+++ b/tests/manager/manager-executeBulkWrite-001.phpt
@@ -40,14 +40,14 @@ upsertedId[3]: int(3)
 ===> Collection
 array(2) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["x"]=>
     int(1)
   }
   [1]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(3)
     ["x"]=>

--- a/tests/manager/manager-executeBulkWrite-002.phpt
+++ b/tests/manager/manager-executeBulkWrite-002.phpt
@@ -59,7 +59,7 @@ writeError[1].code: 11000
 ===> Collection
 array(1) {
   [0]=>
-  array(1) {
+  object(stdClass)#%d (1) {
     ["_id"]=>
     int(1)
   }

--- a/tests/manager/manager-executeBulkWrite-003.phpt
+++ b/tests/manager/manager-executeBulkWrite-003.phpt
@@ -71,12 +71,12 @@ writeError[3].code: 11000
 ===> Collection
 array(2) {
   [0]=>
-  array(1) {
+  object(stdClass)#%d (1) {
     ["_id"]=>
     int(1)
   }
   [1]=>
-  array(1) {
+  object(stdClass)#%d (1) {
     ["_id"]=>
     int(2)
   }

--- a/tests/manager/manager-executeBulkWrite-004.phpt
+++ b/tests/manager/manager-executeBulkWrite-004.phpt
@@ -45,7 +45,7 @@ upsertedId[1]: object(%s\ObjectID)#%d (%d) {
 ===> Collection
 array(2) {
   [0]=>
-  array(3) {
+  object(stdClass)#%d (3) {
     ["_id"]=>
     object(%s\ObjectID)#%d (%d) {
       ["oid"]=>
@@ -57,7 +57,7 @@ array(2) {
     string(3) "bar"
   }
   [1]=>
-  array(3) {
+  object(stdClass)#%d (3) {
     ["_id"]=>
     object(%s\ObjectID)#%d (%d) {
       ["oid"]=>

--- a/tests/manager/manager-executeCommand-001.phpt
+++ b/tests/manager/manager-executeCommand-001.phpt
@@ -30,7 +30,7 @@ var_dump($server->getPort());
 --EXPECTF--
 object(MongoDB\Driver\Command)#%d (1) {
   ["command"]=>
-  array(1) {
+  object(stdClass)#%d (1) {
     ["ping"]=>
     int(1)
   }
@@ -58,12 +58,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["has_fields"]=>
     bool(false)
     ["query"]=>
-    array(1) {
+    object(stdClass)#%d (1) {
       ["ping"]=>
       int(1)
     }
     ["fields"]=>
-    array(0) {
+    object(stdClass)#%d (0) {
     }
     ["read_preference"]=>
     array(2) {
@@ -86,7 +86,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["ns"]=>
     string(11) "phongo.$cmd"
     ["current_doc"]=>
-    array(1) {
+    object(stdClass)#%d (1) {
       ["ok"]=>
       float(1)
     }
@@ -96,7 +96,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
 }
 
 Dumping response document:
-array(1) {
+object(stdClass)#%d (1) {
   ["ok"]=>
   float(1)
 }

--- a/tests/manager/manager-executeDelete-001.phpt
+++ b/tests/manager/manager-executeDelete-001.phpt
@@ -36,7 +36,7 @@ deletedCount: 1
 ===> Collection
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["x"]=>

--- a/tests/manager/manager-executeInsert-001.phpt
+++ b/tests/manager/manager-executeInsert-001.phpt
@@ -32,7 +32,7 @@ deletedCount: 0
 ===> Collection
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>

--- a/tests/manager/manager-executeInsert-002.phpt
+++ b/tests/manager/manager-executeInsert-002.phpt
@@ -49,7 +49,7 @@ object(Person)#%d (5) {
   string(6) "Hannes"
   ["age":protected]=>
   int(42)
-  ["address":protected]=>
+  ["addresses":protected]=>
   array(2) {
     [0]=>
     object(Address)#%d (2) {
@@ -74,7 +74,7 @@ object(Person)#%d (5) {
       string(6) "Jeremy"
       ["age":protected]=>
       int(21)
-      ["address":protected]=>
+      ["addresses":protected]=>
       array(0) {
       }
       ["friends":protected]=>

--- a/tests/manager/manager-executeQuery-001.phpt
+++ b/tests/manager/manager-executeQuery-001.phpt
@@ -56,7 +56,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["has_fields"]=>
     bool(true)
     ["query"]=>
-    array(1) {
+    object(stdClass)#%d (1) {
       ["$query"]=>
       object(stdClass)#%d (%d) {
         ["x"]=>
@@ -64,7 +64,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
       }
     }
     ["fields"]=>
-    array(1) {
+    object(stdClass)#%d (1) {
       ["y"]=>
       int(1)
     }
@@ -89,7 +89,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["ns"]=>
     string(39) "phongo.manager_manager_executeQuery_001"
     ["current_doc"]=>
-    array(2) {
+    object(stdClass)#%d (2) {
       ["_id"]=>
       int(2)
       ["y"]=>
@@ -104,7 +104,7 @@ string(%d) "%s"
 int(%d)
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["y"]=>

--- a/tests/manager/manager-executeQuery-005.phpt
+++ b/tests/manager/manager-executeQuery-005.phpt
@@ -23,7 +23,7 @@ $manager->executeBulkWrite(NS, $bulk);
 
 $query = new MongoDB\Driver\Query(array());
 $qr = $manager->executeQuery(NS, $query);
-$qr->setTypeMap(array("document"=> "MyArrayObject", "array" => "MyArrayObject"));
+$qr->setTypeMap(array("root"=> "MyArrayObject", "document"=> "MyArrayObject", "array" => "MyArrayObject"));
 
 foreach($qr as $obj) {
     var_dump($obj);

--- a/tests/manager/manager-executeUpdate-001.phpt
+++ b/tests/manager/manager-executeUpdate-001.phpt
@@ -40,7 +40,7 @@ deletedCount: 0
 ===> Collection
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>

--- a/tests/manager/manager-executeUpdate-002.phpt
+++ b/tests/manager/manager-executeUpdate-002.phpt
@@ -43,21 +43,21 @@ deletedCount: 0
 ===> Collection
 array(3) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>
     int(2)
   }
   [1]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["x"]=>
     int(2)
   }
   [2]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(3)
     ["x"]=>

--- a/tests/manager/manager-executeUpdate-003.phpt
+++ b/tests/manager/manager-executeUpdate-003.phpt
@@ -38,7 +38,7 @@ upsertedId[0]: int(1)
 ===> Collection
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>

--- a/tests/manager/manager-executeUpdate-004.phpt
+++ b/tests/manager/manager-executeUpdate-004.phpt
@@ -38,7 +38,7 @@ upsertedId[0]: int(1)
 ===> Collection
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>

--- a/tests/manager/manager-selectserver-001.phpt
+++ b/tests/manager/manager-selectserver-001.phpt
@@ -43,12 +43,12 @@ throws(function() use($server2, $bulk) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 bool(true)
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["y"]=>
@@ -59,7 +59,7 @@ bool(true)
 bool(true)
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["y"]=>

--- a/tests/readPreference/002.phpt
+++ b/tests/readPreference/002.phpt
@@ -47,7 +47,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["has_fields"]=>
     bool(false)
     ["query"]=>
-    array(1) {
+    object(stdClass)#%d (1) {
       ["$query"]=>
       object(stdClass)#%d (%d) {
         ["my"]=>
@@ -55,7 +55,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
       }
     }
     ["fields"]=>
-    array(0) {
+    object(stdClass)#%d (0) {
     }
     ["read_preference"]=>
     array(2) {
@@ -103,7 +103,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["has_fields"]=>
     bool(false)
     ["query"]=>
-    array(2) {
+    object(stdClass)#%d (2) {
       ["$query"]=>
       object(stdClass)#%d (%d) {
         ["my"]=>
@@ -119,7 +119,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
       }
     }
     ["fields"]=>
-    array(0) {
+    object(stdClass)#%d (0) {
     }
     ["read_preference"]=>
     array(2) {
@@ -167,7 +167,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["has_fields"]=>
     bool(false)
     ["query"]=>
-    array(2) {
+    object(stdClass)#%d (2) {
       ["$query"]=>
       object(stdClass)#%d (%d) {
         ["my"]=>
@@ -183,7 +183,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
       }
     }
     ["fields"]=>
-    array(0) {
+    object(stdClass)#%d (0) {
     }
     ["read_preference"]=>
     array(2) {
@@ -231,7 +231,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["has_fields"]=>
     bool(false)
     ["query"]=>
-    array(2) {
+    object(stdClass)#%d (2) {
       ["$query"]=>
       object(stdClass)#%d (%d) {
         ["my"]=>
@@ -247,7 +247,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
       }
     }
     ["fields"]=>
-    array(0) {
+    object(stdClass)#%d (0) {
     }
     ["read_preference"]=>
     array(2) {
@@ -295,7 +295,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["has_fields"]=>
     bool(false)
     ["query"]=>
-    array(2) {
+    object(stdClass)#%d (2) {
       ["$query"]=>
       object(stdClass)#%d (%d) {
         ["my"]=>
@@ -311,7 +311,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
       }
     }
     ["fields"]=>
-    array(0) {
+    object(stdClass)#%d (0) {
     }
     ["read_preference"]=>
     array(2) {

--- a/tests/replicaset/manager-getservers-001.phpt
+++ b/tests/replicaset/manager-getservers-001.phpt
@@ -85,7 +85,7 @@ array(3) {
       ["me"]=>
       string(19) "192.168.112.10:3000"
       ["electionId"]=>
-      object(%s\ObjectID)#8 (1) {
+      object(%s\ObjectID)#%d (1) {
         ["oid"]=>
         string(24) "%s"
       }

--- a/tests/replicaset/manager-getservers-001.phpt
+++ b/tests/replicaset/manager-getservers-001.phpt
@@ -45,7 +45,7 @@ array(3) {
     ["is_passive"]=>
     bool(false)
     ["tags"]=>
-    array(2) {
+    array(%d) {
       ["dc"]=>
       string(2) "pa"
       ["ordinal"]=>
@@ -76,7 +76,7 @@ array(3) {
       ["primary"]=>
       string(19) "192.168.112.10:3000"
       ["tags"]=>
-      object(stdClass)#%d (%d) {
+      array(%d) {
         ["dc"]=>
         string(2) "pa"
         ["ordinal"]=>
@@ -127,7 +127,7 @@ array(3) {
     ["is_passive"]=>
     bool(false)
     ["tags"]=>
-    array(2) {
+    array(%d) {
       ["dc"]=>
       string(3) "nyc"
       ["ordinal"]=>
@@ -158,7 +158,7 @@ array(3) {
       ["primary"]=>
       string(19) "192.168.112.10:3000"
       ["tags"]=>
-      object(stdClass)#%d (%d) {
+      array(%d) {
         ["dc"]=>
         string(3) "nyc"
         ["ordinal"]=>

--- a/tests/replicaset/manager-selectserver-001.phpt
+++ b/tests/replicaset/manager-selectserver-001.phpt
@@ -46,12 +46,12 @@ var_dump($result->getInsertedCount());
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 bool(true)
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["y"]=>
@@ -62,7 +62,7 @@ bool(true)
 bool(true)
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["y"]=>

--- a/tests/replicaset/writeresult-getserver-002.phpt
+++ b/tests/replicaset/writeresult-getserver-002.phpt
@@ -93,7 +93,7 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
 }
 string(14) "192.168.112.10"
 int(3001)
-array(2) {
+object(stdClass)#%d (2) {
   ["_id"]=>
   object(%s\ObjectID)#%d (1) {
     ["oid"]=>

--- a/tests/server/server-executeBulkWrite-001.phpt
+++ b/tests/server/server-executeBulkWrite-001.phpt
@@ -56,7 +56,7 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["upsertedIds"]=>
   array(1) {
     [0]=>
-    object(stdClass)#%d (%d) {
+    array(%d) {
       ["index"]=>
       int(3)
       ["_id"]=>
@@ -85,14 +85,14 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
 ===> Collection
 array(2) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (%d) {
     ["_id"]=>
     int(2)
     ["x"]=>
     int(1)
   }
   [1]=>
-  array(2) {
+  object(stdClass)#%d (%d) {
     ["_id"]=>
     int(3)
     ["x"]=>

--- a/tests/server/server-executeCommand-001.phpt
+++ b/tests/server/server-executeCommand-001.phpt
@@ -47,12 +47,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["has_fields"]=>
     bool(false)
     ["query"]=>
-    array(1) {
+    object(stdClass)#%d (1) {
       ["ping"]=>
       int(1)
     }
     ["fields"]=>
-    array(0) {
+    object(stdClass)#%d (0) {
     }
     ["read_preference"]=>
     array(2) {
@@ -75,7 +75,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
     ["ns"]=>
     string(11) "phongo.$cmd"
     ["current_doc"]=>
-    array(1) {
+    object(stdClass)#%d (1) {
       ["ok"]=>
       float(1)
     }
@@ -85,7 +85,7 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
 }
 
 Dumping response document:
-array(1) {
+object(stdClass)#%d (1) {
   ["ok"]=>
   float(1)
 }

--- a/tests/server/server-executeQuery-001.phpt
+++ b/tests/server/server-executeQuery-001.phpt
@@ -26,12 +26,12 @@ var_dump(iterator_to_array($cursor));
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 bool(true)
 array(1) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["y"]=>

--- a/tests/server/server-executeQuery-002.phpt
+++ b/tests/server/server-executeQuery-002.phpt
@@ -26,12 +26,12 @@ var_dump(iterator_to_array($cursor));
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 bool(true)
 array(3) {
   [0]=>
-  array(3) {
+  object(stdClass)#%d (3) {
     ["_id"]=>
     int(3)
     ["x"]=>
@@ -40,7 +40,7 @@ array(3) {
     int(5)
   }
   [1]=>
-  array(3) {
+  object(stdClass)#%d (3) {
     ["_id"]=>
     int(2)
     ["x"]=>
@@ -49,7 +49,7 @@ array(3) {
     int(4)
   }
   [2]=>
-  array(3) {
+  object(stdClass)#%d (3) {
     ["_id"]=>
     int(1)
     ["x"]=>

--- a/tests/server/server-executeQuery-003.phpt
+++ b/tests/server/server-executeQuery-003.phpt
@@ -26,12 +26,12 @@ var_dump(iterator_to_array($cursor));
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 bool(true)
 array(3) {
   [0]=>
-  array(3) {
+  object(stdClass)#%d (3) {
     ["_id"]=>
     int(1)
     ["x"]=>
@@ -40,7 +40,7 @@ array(3) {
     int(3)
   }
   [1]=>
-  array(3) {
+  object(stdClass)#%d (3) {
     ["_id"]=>
     int(2)
     ["x"]=>
@@ -49,7 +49,7 @@ array(3) {
     int(4)
   }
   [2]=>
-  array(3) {
+  object(stdClass)#%d (3) {
     ["_id"]=>
     int(3)
     ["x"]=>

--- a/tests/standalone/update-multi-001.phpt
+++ b/tests/standalone/update-multi-001.phpt
@@ -79,46 +79,46 @@ printf("Changed %d out of expected 3 (_id=4, _id=5, _id=6)\n", $result->getModif
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 Changed 1 out of expected 1 (_id=1)
 array(6) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>
     int(3)
   }
   [1]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["x"]=>
     int(2)
   }
   [2]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(3)
     ["x"]=>
     int(2)
   }
   [3]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(4)
     ["x"]=>
     int(2)
   }
   [4]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(5)
     ["x"]=>
     int(2)
   }
   [5]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(6)
     ["x"]=>
@@ -128,42 +128,42 @@ array(6) {
 Changed 2 out of expected 2, (_id=5, _id=6)
 array(6) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>
     int(3)
   }
   [1]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["x"]=>
     int(4)
   }
   [2]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(3)
     ["x"]=>
     int(2)
   }
   [3]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(4)
     ["x"]=>
     int(2)
   }
   [4]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(5)
     ["x"]=>
     int(2)
   }
   [5]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(6)
     ["x"]=>
@@ -173,42 +173,42 @@ array(6) {
 Changed 1 out of expected 1, (_id=2)
 array(6) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>
     int(3)
   }
   [1]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["x"]=>
     int(4)
   }
   [2]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(3)
     ["x"]=>
     int(41)
   }
   [3]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(4)
     ["x"]=>
     int(2)
   }
   [4]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(5)
     ["x"]=>
     int(2)
   }
   [5]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(6)
     ["x"]=>
@@ -218,42 +218,42 @@ array(6) {
 Changed 1 out of expected 1 (id_=3)
 array(6) {
   [0]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(1)
     ["x"]=>
     int(3)
   }
   [1]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(2)
     ["x"]=>
     int(4)
   }
   [2]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(3)
     ["x"]=>
     int(41)
   }
   [3]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(4)
     ["x"]=>
     int(42)
   }
   [4]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(5)
     ["x"]=>
     int(42)
   }
   [5]=>
-  array(2) {
+  object(stdClass)#%d (2) {
     ["_id"]=>
     int(6)
     ["x"]=>

--- a/tests/utils/classes.inc
+++ b/tests/utils/classes.inc
@@ -4,18 +4,18 @@ use MongoDB\BSON as BSON;
 class Person implements BSON\Persistable {
     protected $name;
     protected $age;
-    protected $address = array();
+    protected $addresses = array();
     protected $friends = array();
     protected $secret = "none";
 
     function __construct($name, $age) {
         $this->name = $name;
         $this->age  = $age;
-        $this->address = array();
+        $this->addresses = array();
         $this->secret = "$name confidential info";
     }
     function addAddress(Address $address) {
-        $this->address[] = $address;
+        $this->addresses[] = $address;
     }
     function addFriend(Person $friend) {
         $this->friends[] = $friend;
@@ -24,14 +24,14 @@ class Person implements BSON\Persistable {
         return array(
             "name"    => $this->name,
             "age"     => $this->age,
-            "address" => $this->address,
+            "addresses" => $this->addresses,
             "friends" => $this->friends,
         );
     }
     function bsonUnserialize(array $data) {
         $this->name    = $data["name"];
         $this->age     = $data["age"];
-        $this->address = $data["address"];
+        $this->addresses = $data["addresses"];
         $this->friends = $data["friends"];
     }
 }

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -374,11 +374,11 @@ function getMOPresetBase() {
     return $BASE;
 }
 
-function toArray($var, $typemap = array()) {
+function toPHP($var, $typemap = array()) {
     $func = BSON_NAMESPACE . "\\" . __FUNCTION__;
     return $func($var, $typemap);
 }
-function fromArray($var) {
+function fromPHP($var) {
     $func = BSON_NAMESPACE . "\\" . __FUNCTION__;
     return $func($var);
 }

--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -342,7 +342,7 @@ function configureFailPoint(MongoDB\Driver\Manager $manager, $failPoint, $mode, 
     $cmd = new MongoDB\Driver\Command($doc);
     $result = $manager->executeCommand("admin", $cmd);
     $arr = current($result->toArray());
-    if (empty($arr["ok"])) {
+    if (empty($arr->ok)) {
         var_dump($result);
         throw new RuntimeException("Failpoint failed");
     }


### PR DESCRIPTION
 * https://jira.mongodb.org/browse/PHPC-311

Rename BSON\to|from]Array() to BSON\[to|from]PHP()

 * https://jira.mongodb.org/browse/PHPC-315

Support setting the "root" (container) value to explicit type.
->setTypemap(["root" => "array"]);

 * https://jira.mongodb.org/browse/PHPC-319

Use stdClass, not array, for top-level containers by default