### PR TITLE
PHPC-334: Split hex_dump() test case

### DIFF
--- a/tests/bson/bug0334-001.phpt
+++ b/tests/bson/bug0334-001.phpt
@@ -11,8 +11,8 @@ require_once __DIR__ . "/../utils/basic.inc";
 class MyClass implements BSON\Persistable {
     function bsonSerialize() {
         return array(
-            "foo" => "bar",
             "__pclass" => "baz",
+            "foo" => "bar",
         );
     }
     function bsonUnserialize(array $data) {
@@ -25,5 +25,8 @@ $php = toPHP($bson, array('root' => 'array'));
 var_dump($php['__pclass']->getData());
 
 ?>
+===DONE===
+<?php exit(0); ?>
 --EXPECT--
 string(7) "MyClass"
+===DONE===

--- a/tests/bson/bug0334-002.phpt
+++ b/tests/bson/bug0334-002.phpt
@@ -1,0 +1,31 @@
+--TEST--
+PHPC-334: Encoded BSON should never have multiple __pclass keys
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+use MongoDB\BSON as BSON;
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+class MyClass implements BSON\Persistable {
+    function bsonSerialize() {
+        return array(
+            "__pclass" => "baz",
+            "foo" => "bar",
+        );
+    }
+    function bsonUnserialize(array $data) {
+    }
+}
+
+hex_dump(fromPHP(new MyClass))
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+     0 : 28 00 00 00 05 5f 5f 70 63 6c 61 73 73 00 07 00  [(....__pclass...]
+    10 : 00 00 80 4d 79 43 6c 61 73 73 02 66 6f 6f 00 04  [...MyClass.foo..]
+    20 : 00 00 00 62 61 72 00 00                          [...bar..]
+===DONE===


### PR DESCRIPTION
This PR builds upon #66 and depends on #64 to pass (re: `array` type map overriding `__pclass`).

----

The original test was problematic for HHVM, since it injects the __pclass value differently. Although changing the bsonSerialize() field order should ensure identical hex_dump() output on HHVM, we'll split the test cases.

See: fddd88ff9d83bc44fe610f832c5862cec0ffb23f