### PR TITLE
Split out WriteConcern constructor error test and skip for HHVM

### DIFF
--- a/tests/writeConcern/writeconcern-001.phpt
+++ b/tests/writeConcern/writeconcern-001.phpt
@@ -24,12 +24,6 @@ var_dump(new MongoDB\Driver\WriteConcern("string", 7000, true, true));
 var_dump(new MongoDB\Driver\WriteConcern("string", 8000, true, false));
 var_dump(new MongoDB\Driver\WriteConcern("string", 9000, false, true));
 
-try {
-    new MongoDB\Driver\WriteConcern("string", 10000, false, true, 1);
-} catch(InvalidArgumentException $e) {
-    echo $e->getMessage(), "\n";
-}
-
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -178,5 +172,4 @@ object(MongoDB\Driver\WriteConcern)#%d (%d) {
   ["journal"]=>
   bool(false)
 }
-MongoDB\Driver\WriteConcern::__construct() expects at most 4 parameters, 5 given
 ===DONE===

--- a/tests/writeConcern/writeconcern_error-001.phpt
+++ b/tests/writeConcern/writeconcern_error-001.phpt
@@ -1,0 +1,21 @@
+--TEST--
+MongoDB\Driver\WriteConcern construction (invalid arguments)
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM throws Exception instead of InvalidArgumentException"); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+try {
+    new MongoDB\Driver\WriteConcern("string", 10000, false, true, 1);
+} catch(InvalidArgumentException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+MongoDB\Driver\WriteConcern::__construct() expects at most 4 parameters, 5 given
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-129

I am adding an equivalent test to the HHVM suite, that is going to be skipped by non-HHVM.