### PR TITLE
Fixed PHPC-357: The exception for "invalid namespace" does not list the broken name

### DIFF
--- a/php_phongo.c
+++ b/php_phongo.c
@@ -597,7 +597,7 @@ bool phongo_execute_write(mongoc_client_t *client, const char *namespace, mongoc
 	php_phongo_writeresult_t *writeresult;
 
 	if (!phongo_split_namespace(namespace, &dbname, &collname)) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "%s", "Invalid namespace provided");
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "%s: %s", "Invalid namespace provided", namespace);
 		return false;
 	}
 
@@ -664,7 +664,7 @@ int phongo_execute_query(mongoc_client_t *client, const char *namespace, const p
 	mongoc_collection_t *collection;
 
 	if (!phongo_split_namespace(namespace, &dbname, &collname)) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "%s", "Invalid namespace provided");
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT TSRMLS_CC, "%s: %s", "Invalid namespace provided", namespace);
 		return false;
 	}
 	collection = mongoc_client_get_collection(client, dbname, collname);

--- a/tests/manager/bug0357.phpt
+++ b/tests/manager/bug0357.phpt
@@ -1,7 +1,10 @@
 --TEST--
 PHPC-357: The exception for "invalid namespace" does not list the broken name
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 --FILE--
 <?php
+require_once __DIR__ . "/../utils/basic.inc";
 $m = new MongoDB\Driver\Manager("mongodb://localhost:44444");
 
 $c = new MongoDB\Driver\Query( [] );

--- a/tests/manager/bug0357.phpt
+++ b/tests/manager/bug0357.phpt
@@ -1,0 +1,19 @@
+--TEST--
+PHPC-357: The exception for "invalid namespace" does not list the broken name
+--FILE--
+<?php
+$m = new MongoDB\Driver\Manager("mongodb://localhost:44444");
+
+$c = new MongoDB\Driver\Query( [] );
+
+try {
+	$m->executeQuery( 'demo', $c );
+	echo "Expected exception not thrown\n";
+}
+catch ( InvalidArgumentException $e )
+{
+	echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+Invalid namespace provided: demo


### PR DESCRIPTION
The test case is copied over from HHVM