### PR TITLE
PHP5/7 compatability changes

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -112,3 +112,8 @@
 # endif
 #endif
 
+#if PHP_VERSION_ID >= 70000
+# define SUPPRESS_UNUSED_WARNING(x)
+#else
+# define SUPPRESS_UNUSED_WARNING(x) (void)x;
+#endif

--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -114,6 +114,8 @@
 
 #if PHP_VERSION_ID >= 70000
 # define SUPPRESS_UNUSED_WARNING(x)
+# define DECLARE_RETURN_VALUE_USED int return_value_used = 1;
 #else
 # define SUPPRESS_UNUSED_WARNING(x) (void)x;
+# define DECLARE_RETURN_VALUE_USED
 #endif

--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -1,3 +1,5 @@
+#include <php.h>
+
 #ifdef PHP_WIN32
 # include "config.w32.h"
 #else
@@ -114,8 +116,18 @@
 
 #if PHP_VERSION_ID >= 70000
 # define SUPPRESS_UNUSED_WARNING(x)
-# define DECLARE_RETURN_VALUE_USED int return_value_used = 1;
+static inline void *x509_from_zval(zval *zval) {
+	return Z_RES_P(zval)->ptr;
+}
+#define DECLARE_RETURN_VALUE_USED int return_value_used = 1;
 #else
 # define SUPPRESS_UNUSED_WARNING(x) (void)x;
 # define DECLARE_RETURN_VALUE_USED
+static inline void *x509_from_zval(zval *zval TSRMLS_DC) {
+	int resource_type;
+	int type;
+
+	zend_list_find(Z_LVAL_P(zval), &resource_type);
+	return zend_fetch_resource(&zval TSRMLS_CC, -1, "OpenSSL X.509", &type, 1, resource_type);
+}
 #endif

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -1078,9 +1078,7 @@ bool php_phongo_ssl_verify(php_stream *stream, const char *hostname, bson_error_
 {
 	zval **zcert;
 	zval **verify_expiry;
-	int resource_type;
 	X509 *cert;
-	int type;
 
 	if (!stream->context) {
 		return true;
@@ -1091,11 +1089,7 @@ bool php_phongo_ssl_verify(php_stream *stream, const char *hostname, bson_error_
 		return false;
 	}
 
-
-
-	zend_list_find(Z_LVAL_PP(zcert), &resource_type);
-	cert = (X509 *)zend_fetch_resource(zcert TSRMLS_CC, -1, "OpenSSL X.509", &type, 1, resource_type);
-
+	cert = (X509 *)x509_from_zval(*zcert TSRMLS_CC);
 	if (!cert) {
 		bson_set_error(error, MONGOC_ERROR_STREAM, MONGOC_ERROR_STREAM_CONNECT, "Could not get certificate of %s", hostname);
 		return false;

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -276,7 +276,7 @@ void phongo_cursor_init(zval *return_value, mongoc_cursor_t *cursor, mongoc_clie
 
 	object_init_ex(return_value, php_phongo_cursor_ce);
 
-	intern = (php_phongo_cursor_t *)zend_object_store_get_object(return_value TSRMLS_CC);
+	intern = Z_CURSOR_OBJ_P(return_value);
 	intern->cursor = cursor;
 	intern->server_id = mongoc_cursor_get_hint(cursor);
 	intern->client = client;
@@ -288,7 +288,7 @@ void phongo_server_init(zval *return_value, mongoc_client_t *client, int server_
 
 	object_init_ex(return_value, php_phongo_server_ce);
 
-	server = (php_phongo_server_t *)zend_object_store_get_object(return_value TSRMLS_CC);
+	server = Z_SERVER_OBJ_P(return_value);
 	server->client = client;
 	server->server_id = server_id;
 }
@@ -378,7 +378,7 @@ zend_bool phongo_writeconcernerror_init(zval *return_value, bson_t *bson TSRMLS_
 	bson_iter_t iter;
 	php_phongo_writeconcernerror_t *writeconcernerror;
 
-	writeconcernerror = (php_phongo_writeconcernerror_t *)zend_object_store_get_object(return_value TSRMLS_CC);
+	writeconcernerror = Z_WRITECONCERNERROR_OBJ_P(return_value);
 
 	if (bson_iter_init_find(&iter, bson, "code") && BSON_ITER_HOLDS_INT32(&iter)) {
 		writeconcernerror->code = bson_iter_int32(&iter);
@@ -416,7 +416,7 @@ zend_bool phongo_writeerror_init(zval *return_value, bson_t *bson TSRMLS_DC) /* 
 	bson_iter_t iter;
 	php_phongo_writeerror_t *writeerror;
 
-	writeerror = (php_phongo_writeerror_t *)zend_object_store_get_object(return_value TSRMLS_CC);
+	writeerror = Z_WRITEERROR_OBJ_P(return_value);
 
 	if (bson_iter_init_find(&iter, bson, "code") && BSON_ITER_HOLDS_INT32(&iter)) {
 		writeerror->code = bson_iter_int32(&iter);
@@ -453,7 +453,7 @@ php_phongo_writeresult_t *phongo_writeresult_init(zval *return_value, mongoc_wri
 
 	object_init_ex(return_value, php_phongo_writeresult_ce);
 
-	writeresult = (php_phongo_writeresult_t *)zend_object_store_get_object(return_value TSRMLS_CC);
+	writeresult = Z_WRITERESULT_OBJ_P(return_value);
 	writeresult->client    = client;
 	writeresult->server_id = server_id;
 
@@ -1273,7 +1273,7 @@ mongoc_stream_t* phongo_stream_initiator(const mongoc_uri_t *uri, const mongoc_h
 const mongoc_write_concern_t* phongo_write_concern_from_zval(zval *zwrite_concern TSRMLS_DC) /* {{{ */
 {
 	if (zwrite_concern) {
-		php_phongo_writeconcern_t *intern = (php_phongo_writeconcern_t *)zend_object_store_get_object(zwrite_concern TSRMLS_CC);
+		php_phongo_writeconcern_t *intern = Z_WRITECONCERN_OBJ_P(zwrite_concern);
 
 		if (intern) {
 			return intern->write_concern;
@@ -1286,7 +1286,7 @@ const mongoc_write_concern_t* phongo_write_concern_from_zval(zval *zwrite_concer
 const mongoc_read_prefs_t* phongo_read_preference_from_zval(zval *zread_preference TSRMLS_DC) /* {{{ */
 {
 	if (zread_preference) {
-		php_phongo_readpreference_t *intern = (php_phongo_readpreference_t *)zend_object_store_get_object(zread_preference TSRMLS_CC);
+		php_phongo_readpreference_t *intern = Z_READPREFERENCE_OBJ_P(zread_preference);
 
 		if (intern) {
 			return intern->read_preference;
@@ -1298,7 +1298,7 @@ const mongoc_read_prefs_t* phongo_read_preference_from_zval(zval *zread_preferen
 
 const php_phongo_query_t* phongo_query_from_zval(zval *zquery TSRMLS_DC) /* {{{ */
 {
-	php_phongo_query_t *intern = (php_phongo_query_t *)zend_object_store_get_object(zquery TSRMLS_CC);
+	php_phongo_query_t *intern = Z_QUERY_OBJ_P(zquery);
 
 	return intern;
 } /* }}} */
@@ -1311,7 +1311,7 @@ void php_phongo_cursor_id_new_from_id(zval *object, int64_t cursorid TSRMLS_DC) 
 
 	object_init_ex(object, php_phongo_cursorid_ce);
 
-	intern = (php_phongo_cursorid_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_CURSORID_OBJ_P(object);
 	intern->id = cursorid;
 } /* }}} */
 
@@ -1321,7 +1321,7 @@ void php_phongo_objectid_new_from_oid(zval *object, const bson_oid_t *oid TSRMLS
 
 	object_init_ex(object, php_phongo_objectid_ce);
 
-	intern = (php_phongo_objectid_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_OBJECTID_OBJ_P(object);
 	bson_oid_to_string(oid, intern->oid);
 } /* }}} */
 
@@ -1890,7 +1890,7 @@ void php_phongo_new_utcdatetime_from_epoch(zval *object, int64_t msec_since_epoc
 
 	object_init_ex(object, php_phongo_utcdatetime_ce);
 
-	intern = (php_phongo_utcdatetime_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_UTCDATETIME_OBJ_P(object);
 	intern->milliseconds = msec_since_epoch;
 } /* }}} */
 
@@ -1919,7 +1919,7 @@ void php_phongo_new_timestamp_from_increment_and_timestamp(zval *object, int32_t
 
 	object_init_ex(object, php_phongo_timestamp_ce);
 
-	intern = (php_phongo_timestamp_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_TIMESTAMP_OBJ_P(object);
 	intern->increment = increment;
 	intern->timestamp = timestamp;
 } /* }}} */
@@ -1935,7 +1935,7 @@ void php_phongo_new_javascript_from_javascript_and_scope(int init, zval *object,
 		object_init_ex(object, php_phongo_javascript_ce);
 	}
 
-	intern = (php_phongo_javascript_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_JAVASCRIPT_OBJ_P(object);
 	intern->javascript = estrndup(code, code_len);
 	intern->javascript_len = code_len;
 	intern->document = scope ? bson_copy(scope) : NULL;
@@ -1946,7 +1946,7 @@ void php_phongo_new_binary_from_binary_and_type(zval *object, const char *data, 
 
 	object_init_ex(object, php_phongo_binary_ce);
 
-	intern = (php_phongo_binary_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_BINARY_OBJ_P(object);
 	intern->data = estrndup(data, data_len);
 	intern->data_len = data_len;
 	intern->type = type;
@@ -1957,7 +1957,7 @@ void php_phongo_new_regex_from_regex_and_options(zval *object, const char *patte
 
 	object_init_ex(object, php_phongo_regex_ce);
 
-	intern = (php_phongo_regex_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_REGEX_OBJ_P(object);
 	intern->pattern_len = strlen(pattern);
 	intern->pattern = estrndup(pattern, intern->pattern_len);
 	intern->flags_len = strlen(flags);

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -130,10 +130,7 @@ void php_phongo_read_preference_to_zval(zval *retval, const mongoc_read_prefs_t 
 void php_phongo_write_concern_to_zval(zval *retval, const mongoc_write_concern_t *write_concern);
 void php_phongo_cursor_to_zval(zval *retval, php_phongo_cursor_t *cursor);
 
-bool php_phongo_apply_rp_options_to_client(mongoc_client_t *client, bson_t *options TSRMLS_DC);
-bool php_phongo_apply_wc_options_to_client(mongoc_client_t *client, bson_t *options TSRMLS_DC);
-mongoc_uri_t *php_phongo_make_uri(const char *uri_string, bson_t *options TSRMLS_DC);
-mongoc_client_t *php_phongo_make_mongo_client(const mongoc_uri_t *uri, zval *driverOptions TSRMLS_DC);
+bool phongo_manager_init(php_phongo_manager_t *manager, const char *uri_string, bson_t *bson_options, zval *driverOptions TSRMLS_DC);
 void php_phongo_objectid_new_from_oid(zval *object, const bson_oid_t *oid TSRMLS_DC);
 void php_phongo_cursor_id_new_from_id(zval *object, int64_t cursorid TSRMLS_DC);
 void php_phongo_new_utcdatetime_from_epoch(zval *object, int64_t msec_since_epoch TSRMLS_DC);

--- a/php_phongo_classes.h
+++ b/php_phongo_classes.h
@@ -16,32 +16,61 @@
   +----------------------------------------------------------------------+
 */
 
-/* $Id$ */
-
 #ifndef PHONGO_CLASSES_H
 #define PHONGO_CLASSES_H
 
-/* PHP Core stuff */
-#include <php.h>
-#include <mongoc-bulk-operation-private.h>
+#if PHP_VERSION_ID >= 70000
+# include "php_phongo_structs-7.h"
+# define Z_COMMAND_OBJ_P(zv)           php_command_fetch_object(Z_OBJ_P(zv));
+# define Z_CURSOR_OBJ_P(zv)            php_cursor_fetch_object(Z_OBJ_P(zv));
+# define Z_CURSORID_OBJ_P(zv)          php_cursorid_fetch_object(Z_OBJ_P(zv));
+# define Z_MANAGER_OBJ_P(zv)           php_manager_fetch_object(Z_OBJ_P(zv));
+# define Z_QUERY_OBJ_P(zv)             php_query_fetch_object(Z_OBJ_P(zv));
+# define Z_READPREFERENCE_OBJ_P(zv)    php_readpreference_fetch_object(Z_OBJ_P(zv));
+# define Z_SERVER_OBJ_P(zv)            php_server_fetch_object(Z_OBJ_P(zv));
+# define Z_BULKWRITE_OBJ_P(zv)         php_bulkwrite_fetch_object(Z_OBJ_P(zv));
+# define Z_WRITECONCERN_OBJ_P(zv)      php_writeconcern_fetch_object(Z_OBJ_P(zv));
+# define Z_WRITECONCERNERROR_OBJ_P(zv) php_writeconcernerror_fetch_object(Z_OBJ_P(zv));
+# define Z_WRITEERROR_OBJ_P(zv)        php_writeerror_fetch_object(Z_OBJ_P(zv));
+# define Z_WRITERESULT_OBJ_P(zv)       php_writeresult_fetch_object(Z_OBJ_P(zv));
+# define Z_BINARY_OBJ_P(zv)            php_binary_fetch_object(Z_OBJ_P(zv));
+# define Z_INT32_OBJ_P(zv)             php_int32_fetch_object(Z_OBJ_P(zv));
+# define Z_INT64_OBJ_P(zv)             php_int64_fetch_object(Z_OBJ_P(zv));
+# define Z_JAVASCRIPT_OBJ_P(zv)        php_javascript_fetch_object(Z_OBJ_P(zv));
+# define Z_LOG_OBJ_P(zv)               php_log_fetch_object(Z_OBJ_P(zv));
+# define Z_MAXKEY_OBJ_P(zv)            php_maxkey_fetch_object(Z_OBJ_P(zv));
+# define Z_MINKEY_OBJ_P(zv)            php_minkey_fetch_object(Z_OBJ_P(zv));
+# define Z_OBJECTID_OBJ_P(zv)          php_objectid_fetch_object(Z_OBJ_P(zv));
+# define Z_REGEX_OBJ_P(zv)             php_regex_fetch_object(Z_OBJ_P(zv));
+# define Z_TIMESTAMP_OBJ_P(zv)         php_timestamp_fetch_object(Z_OBJ_P(zv));
+# define Z_UTCDATETIME_OBJ_P(zv)       php_utcdatetime_fetch_object(Z_OBJ_P(zv));
+#else
+# include "php_phongo_structs-5.h"
+# define Z_COMMAND_OBJ_P(zv)           (php_phongo_command_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_CURSOR_OBJ_P(zv)            (php_phongo_cursor_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_CURSORID_OBJ_P(zv)          (php_phongo_cursorid_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_MANAGER_OBJ_P(zv)           (php_phongo_manager_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_QUERY_OBJ_P(zv)             (php_phongo_query_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_READPREFERENCE_OBJ_P(zv)    (php_phongo_readpreference_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_SERVER_OBJ_P(zv)            (php_phongo_server_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_BULKWRITE_OBJ_P(zv)         (php_phongo_bulkwrite_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_WRITECONCERN_OBJ_P(zv)      (php_phongo_writeconcern_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_WRITECONCERNERROR_OBJ_P(zv) (php_phongo_writeconcernerror_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_WRITEERROR_OBJ_P(zv)        (php_phongo_writeerror_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_WRITERESULT_OBJ_P(zv)       (php_phongo_writeresult_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_BINARY_OBJ_P(zv)            (php_phongo_binary_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_INT32_OBJ_P(zv)             (php_phongo_int32_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_INT64_OBJ_P(zv)             (php_phongo_int64_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_JAVASCRIPT_OBJ_P(zv)        (php_phongo_javascript_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_LOG_OBJ_P(zv)               (php_phongo_log_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_MAXKEY_OBJ_P(zv)            (php_phongo_maxkey_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_MINKEY_OBJ_P(zv)            (php_phongo_minkey_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_OBJECTID_OBJ_P(zv)          (php_phongo_objectid_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_REGEX_OBJ_P(zv)             (php_phongo_regex_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_TIMESTAMP_OBJ_P(zv)         (php_phongo_timestamp_t *)zend_object_store_get_object(zv TSRMLS_CC);
+# define Z_UTCDATETIME_OBJ_P(zv)       (php_phongo_utcdatetime_t *)zend_object_store_get_object(zv TSRMLS_CC);
 
-/* Our stuffz */
-#include "php_bson.h"
-
-
-typedef struct {
-	zend_object              std;
-	bson_t                  *bson;
-} php_phongo_command_t;
-
-typedef struct {
-	zend_object              std;
-	mongoc_cursor_t         *cursor;
-	mongoc_client_t         *client;
-	int                      server_id;
-	php_phongo_bson_state    visitor_data;
-	int                      got_iterator;
-} php_phongo_cursor_t;
+#endif
 
 typedef struct {
 	zend_object_iterator   intern;
@@ -49,117 +78,6 @@ typedef struct {
 	long                   current;
 } php_phongo_cursor_iterator;
 
-typedef struct {
-	zend_object              std;
-	uint64_t                 id;
-} php_phongo_cursorid_t;
-
-typedef struct {
-	zend_object              std;
-	mongoc_client_t         *client;
-} php_phongo_manager_t;
-
-typedef struct {
-	zend_object              std;
-	bson_t                  *query;
-	bson_t                  *selector;
-	mongoc_query_flags_t     flags;
-	uint32_t                 skip;
-	uint32_t                 limit;
-	uint32_t                 batch_size;
-} php_phongo_query_t;
-
-typedef struct {
-	zend_object              std;
-	mongoc_read_prefs_t     *read_preference;
-} php_phongo_readpreference_t;
-
-typedef struct {
-	zend_object              std;
-	mongoc_client_t         *client;
-	int                      server_id;
-} php_phongo_server_t;
-
-typedef struct {
-	zend_object              std;
-	mongoc_bulk_operation_t *bulk;
-} php_phongo_bulkwrite_t;
-
-typedef struct {
-	zend_object              std;
-	mongoc_write_concern_t  *write_concern;
-} php_phongo_writeconcern_t;
-
-typedef struct {
-	zend_object              std;
-	int                      code;
-	char                    *message;
-	zval                    *info;
-} php_phongo_writeconcernerror_t;
-
-typedef struct {
-	zend_object              std;
-	int                      code;
-	char                    *message;
-	zval                    *info;
-	uint32_t                 index;
-} php_phongo_writeerror_t;
-
-typedef struct {
-	zend_object              std;
-	mongoc_write_concern_t  *write_concern;
-	mongoc_write_result_t    write_result;
-	mongoc_client_t         *client;
-	int                      server_id;
-} php_phongo_writeresult_t;
-
-typedef struct {
-	zend_object              std;
-	char                    *data;
-	int                      data_len;
-	int                      type;
-} php_phongo_binary_t;
-typedef struct {
-	zend_object              std;
-} php_phongo_int32_t;
-typedef struct {
-	zend_object              std;
-} php_phongo_int64_t;
-typedef struct {
-	zend_object              std;
-	char                    *javascript;
-	size_t                   javascript_len;
-	bson_t                  *document;
-} php_phongo_javascript_t;
-typedef struct {
-	zend_object              std;
-} php_phongo_log_t;
-typedef struct {
-	zend_object              std;
-} php_phongo_maxkey_t;
-typedef struct {
-	zend_object              std;
-} php_phongo_minkey_t;
-typedef struct {
-	zend_object              std;
-	char                     oid[25];
-} php_phongo_objectid_t;
-typedef struct {
-	zend_object              std;
-	char                    *pattern;
-	int                      pattern_len;
-	char                    *flags;
-	int                      flags_len;
-} php_phongo_regex_t;
-typedef struct {
-	zend_object              std;
-	int32_t                  increment;
-	int32_t                  timestamp;
-} php_phongo_timestamp_t;
-typedef struct {
-	zend_object              std;
-	int64_t                  milliseconds;
-} php_phongo_utcdatetime_t;
 
 extern PHONGO_API zend_class_entry *php_phongo_command_ce;
 extern PHONGO_API zend_class_entry *php_phongo_cursor_ce;
@@ -253,7 +171,7 @@ PHP_MINIT_FUNCTION(Regex);
 PHP_MINIT_FUNCTION(Timestamp);
 PHP_MINIT_FUNCTION(UTCDateTime);
 
-#endif /* PHONGO_H */
+#endif /* PHONGO_CLASSES_H */
 
 
 /*

--- a/php_phongo_structs-5.h
+++ b/php_phongo_structs-5.h
@@ -1,0 +1,170 @@
+/*
+  +---------------------------------------------------------------------------+
+  | PHP Driver for MongoDB                                                    |
+  +---------------------------------------------------------------------------+
+  | Copyright 2015 MongoDB, Inc.                                              |
+  |                                                                           |
+  | Licensed under the Apache License, Version 2.0 (the "License");           |
+  | you may not use this file except in compliance with the License.          |
+  | You may obtain a copy of the License at                                   |
+  |                                                                           |
+  | http://www.apache.org/licenses/LICENSE-2.0                                |
+  |                                                                           |
+  | Unless required by applicable law or agreed to in writing, software       |
+  | distributed under the License is distributed on an "AS IS" BASIS,         |
+  | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  |
+  | See the License for the specific language governing permissions and       |
+  | limitations under the License.                                            |
+  +---------------------------------------------------------------------------+
+  | Copyright (c) 2015 MongoDB, Inc.                                          |
+  +---------------------------------------------------------------------------+
+*/
+
+
+#ifndef PHONGO_STRUCTS_H
+#define PHONGO_STRUCTS_H
+
+/* PHP Core stuff */
+#include <php.h>
+#include <mongoc-bulk-operation-private.h>
+
+/* Our stuffz */
+#include "php_bson.h"
+
+
+typedef struct {
+	zend_object              std;
+	bson_t                  *bson;
+} php_phongo_command_t;
+
+typedef struct {
+	zend_object              std;
+	mongoc_cursor_t         *cursor;
+	mongoc_client_t         *client;
+	int                      server_id;
+	php_phongo_bson_state    visitor_data;
+	int                      got_iterator;
+} php_phongo_cursor_t;
+
+typedef struct {
+	zend_object              std;
+	uint64_t                 id;
+} php_phongo_cursorid_t;
+
+typedef struct {
+	zend_object              std;
+	mongoc_client_t         *client;
+} php_phongo_manager_t;
+
+typedef struct {
+	zend_object              std;
+	bson_t                  *query;
+	bson_t                  *selector;
+	mongoc_query_flags_t     flags;
+	uint32_t                 skip;
+	uint32_t                 limit;
+	uint32_t                 batch_size;
+} php_phongo_query_t;
+
+typedef struct {
+	zend_object              std;
+	mongoc_read_prefs_t     *read_preference;
+} php_phongo_readpreference_t;
+
+typedef struct {
+	zend_object              std;
+	mongoc_client_t         *client;
+	int                      server_id;
+} php_phongo_server_t;
+
+typedef struct {
+	zend_object              std;
+	mongoc_bulk_operation_t *bulk;
+} php_phongo_bulkwrite_t;
+
+typedef struct {
+	zend_object              std;
+	mongoc_write_concern_t  *write_concern;
+} php_phongo_writeconcern_t;
+
+typedef struct {
+	zend_object              std;
+	int                      code;
+	char                    *message;
+	zval                    *info;
+} php_phongo_writeconcernerror_t;
+
+typedef struct {
+	zend_object              std;
+	int                      code;
+	char                    *message;
+	zval                    *info;
+	uint32_t                 index;
+} php_phongo_writeerror_t;
+
+typedef struct {
+	zend_object              std;
+	mongoc_write_concern_t  *write_concern;
+	mongoc_write_result_t    write_result;
+	mongoc_client_t         *client;
+	int                      server_id;
+} php_phongo_writeresult_t;
+
+typedef struct {
+	zend_object              std;
+	char                    *data;
+	int                      data_len;
+	int                      type;
+} php_phongo_binary_t;
+typedef struct {
+	zend_object              std;
+} php_phongo_int32_t;
+typedef struct {
+	zend_object              std;
+} php_phongo_int64_t;
+typedef struct {
+	zend_object              std;
+	char                    *javascript;
+	size_t                   javascript_len;
+	bson_t                  *document;
+} php_phongo_javascript_t;
+typedef struct {
+	zend_object              std;
+} php_phongo_log_t;
+typedef struct {
+	zend_object              std;
+} php_phongo_maxkey_t;
+typedef struct {
+	zend_object              std;
+} php_phongo_minkey_t;
+typedef struct {
+	zend_object              std;
+	char                     oid[25];
+} php_phongo_objectid_t;
+typedef struct {
+	zend_object              std;
+	char                    *pattern;
+	int                      pattern_len;
+	char                    *flags;
+	int                      flags_len;
+} php_phongo_regex_t;
+typedef struct {
+	zend_object              std;
+	int32_t                  increment;
+	int32_t                  timestamp;
+} php_phongo_timestamp_t;
+typedef struct {
+	zend_object              std;
+	int64_t                  milliseconds;
+} php_phongo_utcdatetime_t;
+
+#endif /* PHONGO_STRUCTS */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/php_phongo_structs-7.h
+++ b/php_phongo_structs-7.h
@@ -1,0 +1,241 @@
+/*
+  +---------------------------------------------------------------------------+
+  | PHP Driver for MongoDB                                                    |
+  +---------------------------------------------------------------------------+
+  | Copyright 2015 MongoDB, Inc.                                              |
+  |                                                                           |
+  | Licensed under the Apache License, Version 2.0 (the "License");           |
+  | you may not use this file except in compliance with the License.          |
+  | You may obtain a copy of the License at                                   |
+  |                                                                           |
+  | http://www.apache.org/licenses/LICENSE-2.0                                |
+  |                                                                           |
+  | Unless required by applicable law or agreed to in writing, software       |
+  | distributed under the License is distributed on an "AS IS" BASIS,         |
+  | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  |
+  | See the License for the specific language governing permissions and       |
+  | limitations under the License.                                            |
+  +---------------------------------------------------------------------------+
+  | Copyright (c) 2015 MongoDB, Inc.                                          |
+  +---------------------------------------------------------------------------+
+*/
+
+
+#ifndef PHONGO_STRUCTS_H
+#define PHONGO_STRUCTS_H
+
+/* PHP Core stuff */
+#include <php.h>
+#include <mongoc-bulk-operation-private.h>
+
+/* Our stuffz */
+#include "php_bson.h"
+
+
+typedef struct {
+	bson_t                  *bson;
+	zend_object              std;
+} php_phongo_command_t;
+
+typedef struct {
+	mongoc_cursor_t         *cursor;
+	mongoc_client_t         *client;
+	int                      server_id;
+	php_phongo_bson_state    visitor_data;
+	int                      got_iterator;
+	zend_object              std;
+} php_phongo_cursor_t;
+
+typedef struct {
+	uint64_t                 id;
+	zend_object              std;
+} php_phongo_cursorid_t;
+
+typedef struct {
+	mongoc_client_t         *client;
+	zend_object              std;
+} php_phongo_manager_t;
+
+typedef struct {
+	bson_t                  *query;
+	bson_t                  *selector;
+	mongoc_query_flags_t     flags;
+	uint32_t                 skip;
+	uint32_t                 limit;
+	uint32_t                 batch_size;
+	zend_object              std;
+} php_phongo_query_t;
+
+typedef struct {
+	mongoc_read_prefs_t     *read_preference;
+	zend_object              std;
+} php_phongo_readpreference_t;
+
+typedef struct {
+	mongoc_client_t         *client;
+	int                      server_id;
+	zend_object              std;
+} php_phongo_server_t;
+
+typedef struct {
+	mongoc_bulk_operation_t *bulk;
+	zend_object              std;
+} php_phongo_bulkwrite_t;
+
+typedef struct {
+	mongoc_write_concern_t  *write_concern;
+	zend_object              std;
+} php_phongo_writeconcern_t;
+
+typedef struct {
+	int                      code;
+	char                    *message;
+	zval                    *info;
+	zend_object              std;
+} php_phongo_writeconcernerror_t;
+
+typedef struct {
+	int                      code;
+	char                    *message;
+	zval                    *info;
+	uint32_t                 index;
+	zend_object              std;
+} php_phongo_writeerror_t;
+
+typedef struct {
+	mongoc_write_concern_t  *write_concern;
+	mongoc_write_result_t    write_result;
+	mongoc_client_t         *client;
+	int                      server_id;
+	zend_object              std;
+} php_phongo_writeresult_t;
+
+typedef struct {
+	char                    *data;
+	int                      data_len;
+	int                      type;
+	zend_object              std;
+} php_phongo_binary_t;
+typedef struct {
+	zend_object              std;
+} php_phongo_int32_t;
+typedef struct {
+	zend_object              std;
+} php_phongo_int64_t;
+typedef struct {
+	char                    *javascript;
+	size_t                   javascript_len;
+	bson_t                  *document;
+	zend_object              std;
+} php_phongo_javascript_t;
+typedef struct {
+	zend_object              std;
+} php_phongo_log_t;
+typedef struct {
+	zend_object              std;
+} php_phongo_maxkey_t;
+typedef struct {
+	zend_object              std;
+} php_phongo_minkey_t;
+typedef struct {
+	char                     oid[25];
+	zend_object              std;
+} php_phongo_objectid_t;
+typedef struct {
+	char                    *pattern;
+	int                      pattern_len;
+	char                    *flags;
+	int                      flags_len;
+	zend_object              std;
+} php_phongo_regex_t;
+typedef struct {
+	int32_t                  increment;
+	int32_t                  timestamp;
+	zend_object              std;
+} php_phongo_timestamp_t;
+typedef struct {
+	int64_t                  milliseconds;
+	zend_object              std;
+} php_phongo_utcdatetime_t;
+
+static inline php_phongo_command_t* php_command_fetch_object(zend_object *obj) {
+    return (php_phongo_command_t *)((char *)obj - XtOffsetOf(php_phongo_command_t, std));
+}
+static inline php_phongo_cursor_t* php_cursor_fetch_object(zend_object *obj) {
+    return (php_phongo_cursor_t *)((char *)obj - XtOffsetOf(php_phongo_cursor_t, std));
+}
+static inline php_phongo_cursorid_t* php_cursorid_fetch_object(zend_object *obj) {
+    return (php_phongo_cursorid_t *)((char *)obj - XtOffsetOf(php_phongo_cursorid_t, std));
+}
+static inline php_phongo_manager_t* php_manager_fetch_object(zend_object *obj) {
+    return (php_phongo_manager_t *)((char *)obj - XtOffsetOf(php_phongo_manager_t, std));
+}
+static inline php_phongo_query_t* php_query_fetch_object(zend_object *obj) {
+    return (php_phongo_query_t *)((char *)obj - XtOffsetOf(php_phongo_query_t, std));
+}
+static inline php_phongo_readpreference_t* php_readpreference_fetch_object(zend_object *obj) {
+    return (php_phongo_readpreference_t *)((char *)obj - XtOffsetOf(php_phongo_readpreference_t, std));
+}
+static inline php_phongo_server_t* php_server_fetch_object(zend_object *obj) {
+    return (php_phongo_server_t *)((char *)obj - XtOffsetOf(php_phongo_server_t, std));
+}
+static inline php_phongo_bulkwrite_t* php_bulkwrite_fetch_object(zend_object *obj) {
+    return (php_phongo_bulkwrite_t *)((char *)obj - XtOffsetOf(php_phongo_bulkwrite_t, std));
+}
+static inline php_phongo_writeconcern_t* php_writeconcern_fetch_object(zend_object *obj) {
+    return (php_phongo_writeconcern_t *)((char *)obj - XtOffsetOf(php_phongo_writeconcern_t, std));
+}
+static inline php_phongo_writeconcernerror_t* php_writeconcernerror_fetch_object(zend_object *obj) {
+    return (php_phongo_writeconcernerror_t *)((char *)obj - XtOffsetOf(php_phongo_writeconcernerror_t, std));
+}
+static inline php_phongo_writeerror_t* php_writeerror_fetch_object(zend_object *obj) {
+    return (php_phongo_writeerror_t *)((char *)obj - XtOffsetOf(php_phongo_writeerror_t, std));
+}
+static inline php_phongo_writeresult_t* php_writeresult_fetch_object(zend_object *obj) {
+    return (php_phongo_writeresult_t *)((char *)obj - XtOffsetOf(php_phongo_writeresult_t, std));
+}
+static inline php_phongo_binary_t* php_binary_fetch_object(zend_object *obj) {
+    return (php_phongo_binary_t *)((char *)obj - XtOffsetOf(php_phongo_binary_t, std));
+}
+static inline php_phongo_int32_t* php_int32_fetch_object(zend_object *obj) {
+    return (php_phongo_int32_t *)((char *)obj - XtOffsetOf(php_phongo_int32_t, std));
+}
+static inline php_phongo_int64_t* php_int64_fetch_object(zend_object *obj) {
+    return (php_phongo_int64_t *)((char *)obj - XtOffsetOf(php_phongo_int64_t, std));
+}
+static inline php_phongo_javascript_t* php_javascript_fetch_object(zend_object *obj) {
+    return (php_phongo_javascript_t *)((char *)obj - XtOffsetOf(php_phongo_javascript_t, std));
+}
+static inline php_phongo_log_t* php_log_fetch_object(zend_object *obj) {
+    return (php_phongo_log_t *)((char *)obj - XtOffsetOf(php_phongo_log_t, std));
+}
+static inline php_phongo_maxkey_t* php_maxkey_fetch_object(zend_object *obj) {
+    return (php_phongo_maxkey_t *)((char *)obj - XtOffsetOf(php_phongo_maxkey_t, std));
+}
+static inline php_phongo_minkey_t* php_minkey_fetch_object(zend_object *obj) {
+    return (php_phongo_minkey_t *)((char *)obj - XtOffsetOf(php_phongo_minkey_t, std));
+}
+static inline php_phongo_objectid_t* php_objectid_fetch_object(zend_object *obj) {
+    return (php_phongo_objectid_t *)((char *)obj - XtOffsetOf(php_phongo_objectid_t, std));
+}
+static inline php_phongo_regex_t* php_regex_fetch_object(zend_object *obj) {
+    return (php_phongo_regex_t *)((char *)obj - XtOffsetOf(php_phongo_regex_t, std));
+}
+static inline php_phongo_timestamp_t* php_timestamp_fetch_object(zend_object *obj) {
+    return (php_phongo_timestamp_t *)((char *)obj - XtOffsetOf(php_phongo_timestamp_t, std));
+}
+static inline php_phongo_utcdatetime_t* php_utcdatetime_fetch_object(zend_object *obj) {
+    return (php_phongo_utcdatetime_t *)((char *)obj - XtOffsetOf(php_phongo_utcdatetime_t, std));
+}
+
+#endif /* PHONGO_STRUCTS */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */
+

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -58,7 +58,7 @@ PHP_METHOD(Binary, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_binary_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_BINARY_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl", &data, &data_len, &type) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -78,7 +78,7 @@ PHP_METHOD(Binary, getData)
 	php_phongo_binary_t      *intern;
 
 
-	intern = (php_phongo_binary_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_BINARY_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -94,7 +94,7 @@ PHP_METHOD(Binary, getType)
 	php_phongo_binary_t      *intern;
 
 
-	intern = (php_phongo_binary_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_BINARY_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -164,7 +164,7 @@ HashTable *php_phongo_binary_get_debug_info(zval *object, int *is_temp TSRMLS_DC
 	php_phongo_binary_t *intern;
 	zval                 retval = zval_used_for_init;
 
-	intern = (php_phongo_binary_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_BINARY_OBJ_P(object);
 	*is_temp = 1;
 	array_init_size(&retval, 2);
 

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -59,7 +59,7 @@ PHP_METHOD(Javascript, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_javascript_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_JAVASCRIPT_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|A!", &javascript, &javascript_len, &document) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);

--- a/src/BSON/ObjectID.c
+++ b/src/BSON/ObjectID.c
@@ -58,7 +58,7 @@ PHP_METHOD(ObjectID, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_objectid_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_OBJECTID_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s!", &id, &id_len) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -91,7 +91,7 @@ PHP_METHOD(ObjectID, __toString)
 	php_phongo_objectid_t    *intern;
 
 
-	intern = (php_phongo_objectid_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_OBJECTID_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -153,8 +153,8 @@ static int php_phongo_objectid_compare_objects(zval *o1, zval *o2 TSRMLS_DC) /* 
 	php_phongo_objectid_t *intern1;
 	php_phongo_objectid_t *intern2;
 
-	intern1 = (php_phongo_objectid_t *)zend_object_store_get_object(o1 TSRMLS_CC);
-	intern2 = (php_phongo_objectid_t *)zend_object_store_get_object(o2 TSRMLS_CC);
+	intern1 = Z_OBJECTID_OBJ_P(o1);
+	intern2 = Z_OBJECTID_OBJ_P(o2);
 
 	return strcmp(intern1->oid, intern2->oid);
 } /* }}} */
@@ -166,7 +166,7 @@ HashTable *php_phongo_objectid_get_debug_info(zval *object, int *is_temp TSRMLS_
 
 
 	*is_temp = 1;
-	intern = (php_phongo_objectid_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_OBJECTID_OBJ_P(object);
 
 	array_init(&retval);
 

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -57,7 +57,7 @@ PHP_METHOD(Regex, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_regex_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_REGEX_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &pattern, &pattern_len, &flags, &flags_len) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -79,7 +79,7 @@ PHP_METHOD(Regex, getPattern)
 	php_phongo_regex_t       *intern;
 
 
-	intern = (php_phongo_regex_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_REGEX_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -96,7 +96,7 @@ PHP_METHOD(Regex, getFlags)
 	php_phongo_regex_t       *intern;
 
 
-	intern = (php_phongo_regex_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_REGEX_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -115,7 +115,7 @@ PHP_METHOD(Regex, __toString)
 	int                       regex_len;
 
 
-	intern = (php_phongo_regex_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_REGEX_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -55,7 +55,7 @@ PHP_METHOD(Timestamp, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_timestamp_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_TIMESTAMP_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &increment, &timestamp) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -76,7 +76,7 @@ PHP_METHOD(Timestamp, __toString)
 	int                        retval_len;
 
 
-	intern = (php_phongo_timestamp_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_TIMESTAMP_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -58,7 +58,7 @@ PHP_METHOD(UTCDateTime, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_utcdatetime_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_UTCDATETIME_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &milliseconds) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -88,7 +88,7 @@ PHP_METHOD(UTCDateTime, __toString)
 	int tmp_len;
 
 
-	intern = (php_phongo_utcdatetime_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_UTCDATETIME_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -105,7 +105,7 @@ PHP_METHOD(UTCDateTime, toDateTime)
 	php_phongo_utcdatetime_t    *intern;
 
 
-	intern = (php_phongo_utcdatetime_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_UTCDATETIME_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -62,7 +62,7 @@ PHP_METHOD(BulkWrite, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_bulkwrite_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_BULKWRITE_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|b", &ordered) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -86,7 +86,7 @@ PHP_METHOD(BulkWrite, insert)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_bulkwrite_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_BULKWRITE_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "A", &document) == FAILURE) {
 		return;
@@ -130,7 +130,7 @@ PHP_METHOD(BulkWrite, update)
 	(void)return_value_ptr; (void)return_value; (void)return_value_used;
 
 
-	intern = (php_phongo_bulkwrite_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_BULKWRITE_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "AA|a!", &query, &newObj, &updateOptions) == FAILURE) {
 		return;
@@ -184,7 +184,7 @@ PHP_METHOD(BulkWrite, delete)
 	(void)return_value_ptr; (void)return_value; (void)return_value_used;
 
 
-	intern = (php_phongo_bulkwrite_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_BULKWRITE_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "A|a!", &query, &deleteOptions) == FAILURE) {
 		return;
@@ -211,7 +211,7 @@ PHP_METHOD(BulkWrite, count)
 	(void)return_value_ptr; (void)return_value; (void)return_value_used;
 
 
-	intern = (php_phongo_bulkwrite_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_BULKWRITE_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -296,7 +296,7 @@ HashTable *php_phongo_bulkwrite_get_debug_info(zval *object, int *is_temp TSRMLS
 
 
 	*is_temp = 1;
-	intern = (php_phongo_bulkwrite_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_BULKWRITE_OBJ_P(object);
 	array_init(&retval);
 
 	if (intern->bulk->database) {

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -83,7 +83,8 @@ PHP_METHOD(BulkWrite, insert)
 	bson_t                   *bson;
 	bson_t                   *bson_out = NULL;
 	int                       bson_flags = PHONGO_BSON_ADD_ID;
-	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
+	DECLARE_RETURN_VALUE_USED
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
 	intern = Z_BULKWRITE_OBJ_P(getThis());

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -58,7 +58,7 @@ PHP_METHOD(BulkWrite, __construct)
 	php_phongo_bulkwrite_t  *intern;
 	zend_error_handling       error_handling;
 	zend_bool                 ordered = 1;
-	(void)return_value_ptr; (void)return_value; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
@@ -83,7 +83,7 @@ PHP_METHOD(BulkWrite, insert)
 	bson_t                   *bson;
 	bson_t                   *bson_out = NULL;
 	int                       bson_flags = PHONGO_BSON_ADD_ID;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_BULKWRITE_OBJ_P(getThis());
@@ -127,7 +127,7 @@ PHP_METHOD(BulkWrite, update)
 	mongoc_update_flags_t     flags = MONGOC_UPDATE_NONE;
 	bson_t                   *bquery;
 	bson_t                   *bupdate;
-	(void)return_value_ptr; (void)return_value; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_BULKWRITE_OBJ_P(getThis());
@@ -181,7 +181,7 @@ PHP_METHOD(BulkWrite, delete)
 	zval                     *query;
 	zval                     *deleteOptions = NULL;
 	bson_t                   *bson;
-	(void)return_value_ptr; (void)return_value; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_BULKWRITE_OBJ_P(getThis());
@@ -208,7 +208,7 @@ PHP_METHOD(BulkWrite, delete)
 PHP_METHOD(BulkWrite, count)
 {
 	php_phongo_bulkwrite_t  *intern;
-	(void)return_value_ptr; (void)return_value; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_BULKWRITE_OBJ_P(getThis());

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -54,7 +54,7 @@ PHP_METHOD(Command, __construct)
 	zend_error_handling       error_handling;
 	zval                     *document;
 	bson_t                   *bson = bson_new();
-	(void)return_value; (void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -58,7 +58,7 @@ PHP_METHOD(Command, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_command_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_COMMAND_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "A", &document) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -128,7 +128,7 @@ HashTable *php_phongo_command_get_debug_info(zval *object, int *is_temp TSRMLS_D
 
 
 	*is_temp = 1;
-	intern = (php_phongo_command_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_COMMAND_OBJ_P(object);
 
 	array_init_size(&retval, 1);
 

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -58,7 +58,7 @@ PHP_METHOD(Cursor, setTypeMap)
 	(void)return_value; (void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_cursor_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_CURSOR_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a!", &typemap) == FAILURE) {
 		return;
@@ -114,7 +114,7 @@ PHP_METHOD(Cursor, getId)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_cursor_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_CURSOR_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -132,7 +132,7 @@ PHP_METHOD(Cursor, getServer)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_cursor_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_CURSOR_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -151,7 +151,7 @@ PHP_METHOD(Cursor, isDead)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_cursor_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_CURSOR_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -229,7 +229,7 @@ HashTable *php_phongo_cursor_get_debug_info(zval *object, int *is_temp TSRMLS_DC
 
 
 	*is_temp = 1;
-	intern = (php_phongo_cursor_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_CURSOR_OBJ_P(object);
 
 	php_phongo_cursor_to_zval(&retval, intern);
 

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -55,7 +55,7 @@ PHP_METHOD(Cursor, setTypeMap)
 	php_phongo_cursor_t *intern;
 	php_phongo_bson_state     state = PHONGO_BSON_STATE_INITIALIZER;
 	zval                     *typemap = NULL;
-	(void)return_value; (void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_CURSOR_OBJ_P(getThis());
@@ -91,7 +91,7 @@ static int php_phongo_cursor_to_array_apply(zend_object_iterator *iter, void *pu
    Returns an array of all result documents for this cursor */
 PHP_METHOD(Cursor, toArray)
 {
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -111,7 +111,7 @@ PHP_METHOD(Cursor, toArray)
 PHP_METHOD(Cursor, getId)
 {
 	php_phongo_cursor_t      *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_CURSOR_OBJ_P(getThis());
@@ -129,7 +129,7 @@ PHP_METHOD(Cursor, getId)
 PHP_METHOD(Cursor, getServer)
 {
 	php_phongo_cursor_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_CURSOR_OBJ_P(getThis());
@@ -148,7 +148,7 @@ PHP_METHOD(Cursor, getServer)
 PHP_METHOD(Cursor, isDead)
 {
 	php_phongo_cursor_t      *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_CURSOR_OBJ_P(getThis());

--- a/src/MongoDB/CursorId.c
+++ b/src/MongoDB/CursorId.c
@@ -51,7 +51,7 @@ zend_object_handlers php_phongo_handler_cursorid;
 PHP_METHOD(CursorId, __toString)
 {
 	php_phongo_cursorid_t    *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_CURSORID_OBJ_P(getThis());

--- a/src/MongoDB/CursorId.c
+++ b/src/MongoDB/CursorId.c
@@ -54,7 +54,7 @@ PHP_METHOD(CursorId, __toString)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_cursorid_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_CURSORID_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -114,7 +114,7 @@ HashTable *php_phongo_cursorid_get_debug_info(zval *object, int *is_temp TSRMLS_
 
 
 	*is_temp = 1;
-	intern = (php_phongo_cursorid_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_CURSORID_OBJ_P(object);
 
 	array_init(&retval);
 

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -92,7 +92,8 @@ PHP_METHOD(Manager, executeCommand)
 	int                       db_len;
 	zval                     *command;
 	zval                     *readPreference = NULL;
-	php_phongo_command_t    *cmd;
+	php_phongo_command_t     *cmd;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
@@ -116,6 +117,7 @@ PHP_METHOD(Manager, executeQuery)
 	int                       namespace_len;
 	zval                     *zquery;
 	zval                     *readPreference = NULL;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
@@ -138,7 +140,8 @@ PHP_METHOD(Manager, executeBulkWrite)
 	int                        namespace_len;
 	zval                      *zbulk;
 	zval                      *zwrite_concern = NULL;
-	php_phongo_bulkwrite_t   *bulk;
+	php_phongo_bulkwrite_t    *bulk;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
@@ -163,6 +166,7 @@ PHP_METHOD(Manager, executeInsert)
 	zval                     *document;
 	zval                     *zwrite_concern = NULL;
 	bson_t                   *bson;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
@@ -193,6 +197,7 @@ PHP_METHOD(Manager, executeUpdate)
 	bson_t                   *query;
 	bson_t                   *update;
 	mongoc_update_flags_t     flags = MONGOC_UPDATE_NONE;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
@@ -230,6 +235,7 @@ PHP_METHOD(Manager, executeDelete)
 	zval                     *zwrite_concern = NULL;
 	bson_t                   *bson;
 	mongoc_delete_flags_t     flags = MONGOC_DELETE_NONE;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
@@ -254,6 +260,7 @@ PHP_METHOD(Manager, executeDelete)
 PHP_METHOD(Manager, getReadPreference)
 {
 	php_phongo_manager_t *intern;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -300,6 +307,7 @@ PHP_METHOD(Manager, getServers)
 PHP_METHOD(Manager, getWriteConcern)
 {
 	php_phongo_manager_t *intern;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 	intern = Z_MANAGER_OBJ_P(getThis());

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -67,7 +67,7 @@ PHP_METHOD(Manager, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|a!a!", &uri_string, &uri_string_len, &options, &driverOptions) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -96,14 +96,14 @@ PHP_METHOD(Manager, executeCommand)
 	(void)return_value_ptr;
 
 
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO|O!", &db, &db_len, &command, php_phongo_command_ce, &readPreference, php_phongo_readpreference_ce) == FAILURE) {
 		return;
 	}
 
 
-	cmd = (php_phongo_command_t *)zend_object_store_get_object(command TSRMLS_CC);
+	cmd = Z_COMMAND_OBJ_P(command);
 	phongo_execute_command(intern->client, db, cmd->bson, phongo_read_preference_from_zval(readPreference TSRMLS_CC), -1, return_value, return_value_used TSRMLS_CC);
 }
 /* }}} */
@@ -119,7 +119,7 @@ PHP_METHOD(Manager, executeQuery)
 	(void)return_value_ptr;
 
 
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO|O!", &namespace, &namespace_len, &zquery, php_phongo_query_ce, &readPreference, php_phongo_readpreference_ce) == FAILURE) {
 		return;
@@ -142,14 +142,14 @@ PHP_METHOD(Manager, executeBulkWrite)
 	(void)return_value_ptr;
 
 
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO|O!", &namespace, &namespace_len, &zbulk, php_phongo_bulkwrite_ce, &zwrite_concern, php_phongo_writeconcern_ce) == FAILURE) {
 		return;
 	}
 
 
-	bulk = (php_phongo_bulkwrite_t *)zend_object_store_get_object(zbulk TSRMLS_CC);
+	bulk = Z_BULKWRITE_OBJ_P(zbulk);
 	phongo_execute_write(intern->client, namespace, bulk->bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), -1, return_value, return_value_used TSRMLS_CC);
 }
 /* }}} */
@@ -166,7 +166,7 @@ PHP_METHOD(Manager, executeInsert)
 	(void)return_value_ptr;
 
 
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sA|O!", &namespace, &namespace_len, &document, &zwrite_concern, php_phongo_writeconcern_ce) == FAILURE) {
 		return;
@@ -196,7 +196,7 @@ PHP_METHOD(Manager, executeUpdate)
 	(void)return_value_ptr;
 
 
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sAA|a!O!", &namespace, &namespace_len, &zquery, &newObj, &updateOptions, &zwrite_concern, php_phongo_writeconcern_ce) == FAILURE) {
 		return;
@@ -233,7 +233,7 @@ PHP_METHOD(Manager, executeDelete)
 	(void)return_value_ptr;
 
 
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sA|a!O!", &namespace, &namespace_len, &query, &deleteOptions, &zwrite_concern, php_phongo_writeconcern_ce) == FAILURE) {
 		return;
@@ -256,7 +256,7 @@ PHP_METHOD(Manager, getReadPreference)
 	php_phongo_manager_t *intern;
 	(void)return_value_ptr;
 
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -277,7 +277,7 @@ PHP_METHOD(Manager, getServers)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -302,7 +302,7 @@ PHP_METHOD(Manager, getWriteConcern)
 	php_phongo_manager_t *intern;
 	(void)return_value_ptr;
 
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -324,7 +324,7 @@ PHP_METHOD(Manager, selectServer)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &zreadPreference, php_phongo_readpreference_ce) == FAILURE) {
 		return;
@@ -492,7 +492,7 @@ HashTable *php_phongo_manager_get_debug_info(zval *object, int *is_temp TSRMLS_D
 
 
 	*is_temp = 1;
-	intern = (php_phongo_manager_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_MANAGER_OBJ_P(object);
 
 
 	array_init(&retval);

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -63,7 +63,7 @@ PHP_METHOD(Manager, __construct)
 	zval                     *options = NULL;
 	bson_t                    bson_options = BSON_INITIALIZER;
 	zval                     *driverOptions = NULL;
-	(void)return_value; (void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
@@ -93,7 +93,7 @@ PHP_METHOD(Manager, executeCommand)
 	zval                     *command;
 	zval                     *readPreference = NULL;
 	php_phongo_command_t    *cmd;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -116,7 +116,7 @@ PHP_METHOD(Manager, executeQuery)
 	int                       namespace_len;
 	zval                     *zquery;
 	zval                     *readPreference = NULL;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -139,7 +139,7 @@ PHP_METHOD(Manager, executeBulkWrite)
 	zval                      *zbulk;
 	zval                      *zwrite_concern = NULL;
 	php_phongo_bulkwrite_t   *bulk;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -163,7 +163,7 @@ PHP_METHOD(Manager, executeInsert)
 	zval                     *document;
 	zval                     *zwrite_concern = NULL;
 	bson_t                   *bson;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -193,7 +193,7 @@ PHP_METHOD(Manager, executeUpdate)
 	bson_t                   *query;
 	bson_t                   *update;
 	mongoc_update_flags_t     flags = MONGOC_UPDATE_NONE;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -230,7 +230,7 @@ PHP_METHOD(Manager, executeDelete)
 	zval                     *zwrite_concern = NULL;
 	bson_t                   *bson;
 	mongoc_delete_flags_t     flags = MONGOC_DELETE_NONE;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -254,7 +254,7 @@ PHP_METHOD(Manager, executeDelete)
 PHP_METHOD(Manager, getReadPreference)
 {
 	php_phongo_manager_t *intern;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 	intern = Z_MANAGER_OBJ_P(getThis());
 
@@ -274,7 +274,7 @@ PHP_METHOD(Manager, getServers)
 	php_phongo_manager_t         *intern;
 	mongoc_set_t                 *set;
 	size_t                        i;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -300,7 +300,7 @@ PHP_METHOD(Manager, getServers)
 PHP_METHOD(Manager, getWriteConcern)
 {
 	php_phongo_manager_t *intern;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 	intern = Z_MANAGER_OBJ_P(getThis());
 
@@ -321,7 +321,7 @@ PHP_METHOD(Manager, selectServer)
 	zval                         *zreadPreference = NULL;
 	const mongoc_read_prefs_t    *readPreference;
 	uint32_t                      server_id;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_MANAGER_OBJ_P(getThis());
@@ -339,7 +339,7 @@ PHP_METHOD(Manager, selectServer)
  * Throws MongoDB\Driver\RuntimeException as it cannot be serialized */
 PHP_METHOD(Manager, __wakeUp)
 {
-	(void)return_value_ptr; (void)return_value_used; (void)return_value; (void)this_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used) SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(this_ptr)
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -58,7 +58,7 @@ PHP_METHOD(Query, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_query_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_QUERY_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "A|a!", &filter, &options) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);
@@ -129,7 +129,7 @@ HashTable *php_phongo_query_get_debug_info(zval *object, int *is_temp TSRMLS_DC)
 
 
 	*is_temp = 1;
-	intern = (php_phongo_query_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_QUERY_OBJ_P(object);
 
 	array_init_size(&retval, 6);
 

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -54,7 +54,7 @@ PHP_METHOD(Query, __construct)
 	zend_error_handling       error_handling;
 	zval                     *filter;
 	zval                     *options = NULL;
-	(void)return_value_ptr; (void)return_value; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -59,7 +59,7 @@ PHP_METHOD(ReadPreference, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_readpreference_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_READPREFERENCE_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|a!", &readPreference, &tagSets) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -55,7 +55,7 @@ PHP_METHOD(ReadPreference, __construct)
 	zend_error_handling       error_handling;
 	long                      readPreference;
 	zval                     *tagSets = NULL;
-	(void)return_value_ptr; (void)return_value; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -67,6 +67,7 @@ PHP_METHOD(Server, executeCommand)
 	int                       db_len;
 	zval                     *command;
 	php_phongo_command_t     *cmd;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
@@ -89,6 +90,7 @@ PHP_METHOD(Server, executeQuery)
 	char                     *namespace;
 	int                       namespace_len;
 	zval                     *zquery;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
@@ -111,7 +113,8 @@ PHP_METHOD(Server, executeBulkWrite)
 	int                       namespace_len;
 	zval                     *zbulk;
 	zval                     *zwrite_concern = NULL;
-	php_phongo_bulkwrite_t  *bulk;
+	php_phongo_bulkwrite_t   *bulk;
+	DECLARE_RETURN_VALUE_USED
 	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -70,14 +70,14 @@ PHP_METHOD(Server, executeCommand)
 	(void)return_value_ptr;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO", &db, &db_len, &command, php_phongo_command_ce) == FAILURE) {
 		return;
 	}
 
 
-	cmd = (php_phongo_command_t *)zend_object_store_get_object(command TSRMLS_CC);
+	cmd = Z_COMMAND_OBJ_P(command);
 	phongo_execute_command(intern->client, db, cmd->bson, NULL, intern->server_id, return_value, return_value_used TSRMLS_CC);
 }
 /* }}} */
@@ -92,7 +92,7 @@ PHP_METHOD(Server, executeQuery)
 	(void)return_value_ptr;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO", &namespace, &namespace_len, &zquery, php_phongo_query_ce) == FAILURE) {
 		return;
@@ -115,14 +115,14 @@ PHP_METHOD(Server, executeBulkWrite)
 	(void)return_value_ptr;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO|O!", &namespace, &namespace_len, &zbulk, php_phongo_bulkwrite_ce, &zwrite_concern, php_phongo_writeconcern_ce) == FAILURE) {
 		return;
 	}
 
 
-	bulk = (php_phongo_bulkwrite_t *)zend_object_store_get_object(zbulk TSRMLS_CC);
+	bulk = Z_BULKWRITE_OBJ_P(zbulk);
 	phongo_execute_write(intern->client, namespace, bulk->bulk, phongo_write_concern_from_zval(zwrite_concern TSRMLS_CC), intern->server_id, return_value, return_value_used TSRMLS_CC);
 }
 /* }}} */
@@ -134,7 +134,7 @@ PHP_METHOD(Server, getHost)
 	mongoc_server_description_t *sd;
 	(void)return_value_ptr; (void)return_value_used;
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -156,7 +156,7 @@ PHP_METHOD(Server, getTags)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -185,7 +185,7 @@ PHP_METHOD(Server, getInfo)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -214,7 +214,7 @@ PHP_METHOD(Server, getLatency)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -236,7 +236,7 @@ PHP_METHOD(Server, getPort)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -258,7 +258,7 @@ PHP_METHOD(Server, getType)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -280,7 +280,7 @@ PHP_METHOD(Server, isPrimary)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -302,7 +302,7 @@ PHP_METHOD(Server, isSecondary)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -324,7 +324,7 @@ PHP_METHOD(Server, isArbiter)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -346,7 +346,7 @@ PHP_METHOD(Server, isHidden)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -370,7 +370,7 @@ PHP_METHOD(Server, isPassive)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_server_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -468,8 +468,8 @@ static int php_phongo_server_compare_objects(zval *o1, zval *o2 TSRMLS_DC) /* {{
     php_phongo_server_t *intern2;
 	mongoc_server_description_t *sd1, *sd2;
 
-    intern1 = (php_phongo_server_t *)zend_object_store_get_object(o1 TSRMLS_CC);
-    intern2 = (php_phongo_server_t *)zend_object_store_get_object(o2 TSRMLS_CC);
+    intern1 = Z_SERVER_OBJ_P(o1);
+    intern2 = Z_SERVER_OBJ_P(o2);
 
 	sd1 = mongoc_topology_description_server_by_id(&intern1->client->topology->description, intern1->server_id);
 	sd2 = mongoc_topology_description_server_by_id(&intern2->client->topology->description, intern2->server_id);
@@ -516,7 +516,7 @@ HashTable *php_phongo_server_get_debug_info(zval *object, int *is_temp TSRMLS_DC
 
 
 	*is_temp = 1;
-	intern = (php_phongo_server_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_SERVER_OBJ_P(object);
 
 
 	if (!(sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id))) {

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -53,7 +53,7 @@ zend_object_handlers php_phongo_handler_server;
    Throws exception -- can only be created internally */
 PHP_METHOD(Server, __construct)
 {
-	(void)return_value; (void)return_value_used; (void)return_value_ptr; (void)ZEND_NUM_ARGS(); (void)getThis();
+	SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_used) SUPPRESS_UNUSED_WARNING(return_value_ptr) (void)ZEND_NUM_ARGS(); (void)getThis();
 
 	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "Accessing private constructor");
 }
@@ -67,7 +67,7 @@ PHP_METHOD(Server, executeCommand)
 	int                       db_len;
 	zval                     *command;
 	php_phongo_command_t     *cmd;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -89,7 +89,7 @@ PHP_METHOD(Server, executeQuery)
 	char                     *namespace;
 	int                       namespace_len;
 	zval                     *zquery;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -112,7 +112,7 @@ PHP_METHOD(Server, executeBulkWrite)
 	zval                     *zbulk;
 	zval                     *zwrite_concern = NULL;
 	php_phongo_bulkwrite_t  *bulk;
-	(void)return_value_ptr;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -132,7 +132,7 @@ PHP_METHOD(Server, getHost)
 {
 	php_phongo_server_t      *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 	intern = Z_SERVER_OBJ_P(getThis());
 
@@ -153,7 +153,7 @@ PHP_METHOD(Server, getTags)
 {
 	php_phongo_server_t      *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -182,7 +182,7 @@ PHP_METHOD(Server, getInfo)
 {
 	php_phongo_server_t      *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -211,7 +211,7 @@ PHP_METHOD(Server, getLatency)
 {
 	php_phongo_server_t      *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -233,7 +233,7 @@ PHP_METHOD(Server, getPort)
 {
 	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -255,7 +255,7 @@ PHP_METHOD(Server, getType)
 {
 	php_phongo_server_t      *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -277,7 +277,7 @@ PHP_METHOD(Server, isPrimary)
 {
 	php_phongo_server_t      *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -299,7 +299,7 @@ PHP_METHOD(Server, isSecondary)
 {
 	php_phongo_server_t      *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -321,7 +321,7 @@ PHP_METHOD(Server, isArbiter)
 {
 	php_phongo_server_t      *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -343,7 +343,7 @@ PHP_METHOD(Server, isHidden)
 {
 	php_phongo_server_t      *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());
@@ -367,7 +367,7 @@ PHP_METHOD(Server, isPassive)
 {
 	php_phongo_server_t         *intern;
 	mongoc_server_description_t *sd;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_SERVER_OBJ_P(getThis());

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -60,7 +60,7 @@ PHP_METHOD(WriteConcern, __construct)
 	zend_bool                 journal = 0;
 	zend_bool                 fsync = 0;
 	long                      w;
-	(void)return_value; (void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value) SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -64,7 +64,7 @@ PHP_METHOD(WriteConcern, __construct)
 
 
 	zend_replace_error_handling(EH_THROW, phongo_exception_from_phongo_domain(PHONGO_ERROR_INVALID_ARGUMENT), &error_handling TSRMLS_CC);
-	intern = (php_phongo_writeconcern_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITECONCERN_OBJ_P(getThis());
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|lbb", &wstring, &wstring_len, &wtimeout, &journal, &fsync) == FAILURE) {
 		zend_restore_error_handling(&error_handling TSRMLS_CC);

--- a/src/MongoDB/WriteConcernError.c
+++ b/src/MongoDB/WriteConcernError.c
@@ -53,7 +53,7 @@ PHP_METHOD(WriteConcernError, getCode)
 	php_phongo_writeconcernerror_t *intern;
 
 
-	intern = (php_phongo_writeconcernerror_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITECONCERNERROR_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -70,7 +70,7 @@ PHP_METHOD(WriteConcernError, getInfo)
 	php_phongo_writeconcernerror_t *intern;
 
 
-	intern = (php_phongo_writeconcernerror_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITECONCERNERROR_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -89,7 +89,7 @@ PHP_METHOD(WriteConcernError, getMessage)
 	php_phongo_writeconcernerror_t *intern;
 
 
-	intern = (php_phongo_writeconcernerror_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITECONCERNERROR_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -168,7 +168,7 @@ HashTable *php_phongo_writeconcernerror_get_debug_info(zval *object, int *is_tem
 
 
 	*is_temp = 1;
-	intern = (php_phongo_writeconcernerror_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_WRITECONCERNERROR_OBJ_P(object);
 
 	array_init_size(&retval, 3);
 	add_assoc_string_ex(&retval, ZEND_STRS("message"), intern->message, 1);

--- a/src/MongoDB/WriteError.c
+++ b/src/MongoDB/WriteError.c
@@ -53,7 +53,7 @@ PHP_METHOD(WriteError, getCode)
 	php_phongo_writeerror_t  *intern;
 
 
-	intern = (php_phongo_writeerror_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITEERROR_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -70,7 +70,7 @@ PHP_METHOD(WriteError, getIndex)
 	php_phongo_writeerror_t  *intern;
 
 
-	intern = (php_phongo_writeerror_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITEERROR_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -87,7 +87,7 @@ PHP_METHOD(WriteError, getMessage)
 	php_phongo_writeerror_t  *intern;
 
 
-	intern = (php_phongo_writeerror_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITEERROR_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -104,7 +104,7 @@ PHP_METHOD(WriteError, getInfo)
 	php_phongo_writeerror_t *intern;
 
 
-	intern = (php_phongo_writeerror_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITEERROR_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -191,7 +191,7 @@ HashTable *php_phongo_writeerror_get_debug_info(zval *object, int *is_temp TSRML
 
 
 	*is_temp = 1;
-	intern = (php_phongo_writeerror_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_WRITEERROR_OBJ_P(object);
 
 	array_init_size(&retval, 3);
 	add_assoc_string_ex(&retval, ZEND_STRS("message"), intern->message, 1);

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -52,7 +52,7 @@ zend_object_handlers php_phongo_handler_writeresult;
 PHP_METHOD(WriteResult, getInsertedCount)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());
@@ -70,7 +70,7 @@ PHP_METHOD(WriteResult, getInsertedCount)
 PHP_METHOD(WriteResult, getMatchedCount)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());
@@ -88,7 +88,7 @@ PHP_METHOD(WriteResult, getMatchedCount)
 PHP_METHOD(WriteResult, getModifiedCount)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());
@@ -109,7 +109,7 @@ PHP_METHOD(WriteResult, getModifiedCount)
 PHP_METHOD(WriteResult, getDeletedCount)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());
@@ -127,7 +127,7 @@ PHP_METHOD(WriteResult, getDeletedCount)
 PHP_METHOD(WriteResult, getUpsertedCount)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());
@@ -146,7 +146,7 @@ PHP_METHOD(WriteResult, getUpsertedCount)
 PHP_METHOD(WriteResult, getInfo)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());
@@ -164,7 +164,7 @@ PHP_METHOD(WriteResult, getInfo)
 PHP_METHOD(WriteResult, getServer)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());
@@ -182,7 +182,7 @@ PHP_METHOD(WriteResult, getServer)
 PHP_METHOD(WriteResult, getUpsertedIds)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());
@@ -240,7 +240,7 @@ PHP_METHOD(WriteResult, getUpsertedIds)
 PHP_METHOD(WriteResult, getWriteConcernError)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());
@@ -263,7 +263,7 @@ PHP_METHOD(WriteResult, getWriteConcernError)
 PHP_METHOD(WriteResult, getWriteErrors)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());
@@ -314,7 +314,7 @@ PHP_METHOD(WriteResult, getWriteErrors)
 PHP_METHOD(WriteResult, isAcknowledged)
 {
 	php_phongo_writeresult_t *intern;
-	(void)return_value_ptr; (void)return_value_used;
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(return_value_used)
 
 
 	intern = Z_WRITERESULT_OBJ_P(getThis());

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -55,7 +55,7 @@ PHP_METHOD(WriteResult, getInsertedCount)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -73,7 +73,7 @@ PHP_METHOD(WriteResult, getMatchedCount)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -91,7 +91,7 @@ PHP_METHOD(WriteResult, getModifiedCount)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -112,7 +112,7 @@ PHP_METHOD(WriteResult, getDeletedCount)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -130,7 +130,7 @@ PHP_METHOD(WriteResult, getUpsertedCount)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -149,7 +149,7 @@ PHP_METHOD(WriteResult, getInfo)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -167,7 +167,7 @@ PHP_METHOD(WriteResult, getServer)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -185,7 +185,7 @@ PHP_METHOD(WriteResult, getUpsertedIds)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -243,7 +243,7 @@ PHP_METHOD(WriteResult, getWriteConcernError)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -266,7 +266,7 @@ PHP_METHOD(WriteResult, getWriteErrors)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -317,7 +317,7 @@ PHP_METHOD(WriteResult, isAcknowledged)
 	(void)return_value_ptr; (void)return_value_used;
 
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(getThis());
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		return;
@@ -430,7 +430,7 @@ HashTable *php_phongo_writeresult_get_debug_info(zval *object, int *is_temp TSRM
 	zval                      retval = zval_used_for_init;
 	php_phongo_bson_state     state = PHONGO_BSON_STATE_INITIALIZER;
 
-	intern = (php_phongo_writeresult_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_WRITERESULT_OBJ_P(object);
 	*is_temp = 1;
 	array_init_size(&retval, 9);
 

--- a/src/bson.c
+++ b/src/bson.c
@@ -83,7 +83,7 @@ void php_phongo_objectid_get_id(zval *object, bson_oid_t *oid TSRMLS_DC)
 {
 	php_phongo_objectid_t     *intern;
 
-	intern = (php_phongo_objectid_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_OBJECTID_OBJ_P(object);
 
 	bson_oid_init_from_string(oid, intern->oid);
 }
@@ -91,7 +91,7 @@ int64_t php_phongo_utcdatetime_get_milliseconds(zval *object TSRMLS_DC)
 {
 	php_phongo_utcdatetime_t     *intern;
 
-	intern = (php_phongo_utcdatetime_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_UTCDATETIME_OBJ_P(object);
 
 	return intern->milliseconds;
 }
@@ -99,7 +99,7 @@ int32_t php_phongo_timestamp_get_increment(zval *object TSRMLS_DC)
 {
 	php_phongo_timestamp_t     *intern;
 
-	intern = (php_phongo_timestamp_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_TIMESTAMP_OBJ_P(object);
 
 	return intern->increment;
 }
@@ -107,7 +107,7 @@ int32_t php_phongo_timestamp_get_timestamp(zval *object TSRMLS_DC)
 {
 	php_phongo_timestamp_t     *intern;
 
-	intern = (php_phongo_timestamp_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_TIMESTAMP_OBJ_P(object);
 
 	return intern->timestamp;
 }
@@ -115,7 +115,7 @@ bool php_phongo_javascript_has_scope(zval *object TSRMLS_DC)
 {
 	php_phongo_javascript_t *intern;
 
-	intern = (php_phongo_javascript_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_JAVASCRIPT_OBJ_P(object);
 
 	return !!intern->document;
 }
@@ -123,7 +123,7 @@ char *php_phongo_javascript_get_javascript(zval *object TSRMLS_DC)
 {
 	php_phongo_javascript_t *intern;
 
-	intern = (php_phongo_javascript_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_JAVASCRIPT_OBJ_P(object);
 
 	return intern->javascript;
 }
@@ -131,7 +131,7 @@ bson_t *php_phongo_javascript_get_scope(zval *object TSRMLS_DC)
 {
 	php_phongo_javascript_t *intern;
 
-	intern = (php_phongo_javascript_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_JAVASCRIPT_OBJ_P(object);
 
 	return intern->document;
 }
@@ -139,7 +139,7 @@ int php_phongo_binary_get_data(zval *object, char **data TSRMLS_DC)
 {
 	php_phongo_binary_t *intern;
 
-	intern = (php_phongo_binary_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_BINARY_OBJ_P(object);
 
 	*data = intern->data;
 	return intern->data_len;
@@ -148,7 +148,7 @@ int php_phongo_binary_get_type(zval *object TSRMLS_DC)
 {
 	php_phongo_binary_t *intern;
 
-	intern = (php_phongo_binary_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_BINARY_OBJ_P(object);
 
 	return intern->type;
 }
@@ -156,7 +156,7 @@ char *php_phongo_regex_get_pattern(zval *object TSRMLS_DC)
 {
 	php_phongo_regex_t *intern;
 
-	intern = (php_phongo_regex_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_REGEX_OBJ_P(object);
 
 	return intern->pattern;
 }
@@ -164,7 +164,7 @@ char *php_phongo_regex_get_flags(zval *object TSRMLS_DC)
 {
 	php_phongo_regex_t *intern;
 
-	intern = (php_phongo_regex_t *)zend_object_store_get_object(object TSRMLS_CC);
+	intern = Z_REGEX_OBJ_P(object);
 
 	return intern->flags;
 }

--- a/src/bson.c
+++ b/src/bson.c
@@ -962,7 +962,7 @@ PHP_FUNCTION(fromPHP)
 	zval   *data;
 	bson_t *bson;
 
-	(void)return_value_ptr; (void)this_ptr; (void)return_value_used; /* We don't use these */
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(this_ptr) SUPPRESS_UNUSED_WARNING(return_value_used) /* We don't use these */
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "A", &data) == FAILURE) {
 		return;
@@ -1042,7 +1042,7 @@ PHP_FUNCTION(toPHP)
 	zval                  *typemap = NULL;
 	php_phongo_bson_state  state = PHONGO_BSON_STATE_INITIALIZER;
 
-	(void)return_value_ptr; (void)this_ptr; (void)return_value_used; /* We don't use these */
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(this_ptr) SUPPRESS_UNUSED_WARNING(return_value_used) /* We don't use these */
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|a!", &data, &data_len, &typemap) == FAILURE) {
 		return;
@@ -1068,7 +1068,7 @@ PHP_FUNCTION(toJSON)
 	const bson_t        *b;
 	      bson_reader_t *reader;
 
-	(void)return_value_ptr; (void)this_ptr; (void)return_value_used; /* We don't use these */
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(this_ptr) SUPPRESS_UNUSED_WARNING(return_value_used) /* We don't use these */
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &data, &data_len) == FAILURE) {
 		return;
@@ -1099,7 +1099,7 @@ PHP_FUNCTION(fromJSON)
 	bson_t         b = BSON_INITIALIZER;
 	bson_error_t   error;
 
-	(void)return_value_ptr; (void)this_ptr; (void)return_value_used; /* We don't use these */
+	SUPPRESS_UNUSED_WARNING(return_value_ptr) SUPPRESS_UNUSED_WARNING(this_ptr) SUPPRESS_UNUSED_WARNING(return_value_used) /* We don't use these */
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &data, &data_len) == FAILURE) {
 		return;

--- a/src/contrib/php_array_api.h
+++ b/src/contrib/php_array_api.h
@@ -359,7 +359,7 @@ char *php_array_zval_to_string(zval *z, int *plen, zend_bool *pfree) {
 	switch (Z_TYPE_P(z)) {
 		case IS_NULL:
 			*pfree = 0;
-			return "";
+			return (char *)"";
 		case IS_STRING:
 			*pfree = 0;
 			*plen = Z_STRLEN_P(z);

--- a/src/contrib/php_array_api.h
+++ b/src/contrib/php_array_api.h
@@ -18,13 +18,22 @@
 #ifndef PHP_ARRAY_API_H
 #define PHP_ARRAY_API_H
 
-/* LCOV_EXCL_START */
-
+#include "zend.h"
 #include "zend_execute.h"
 #include "zend_API.h"
 #include "zend_operators.h"
 #include "zend_hash.h"
 #include "zend_list.h"
+
+#ifdef ZEND_ENGINE_3
+# define PAA_LENGTH_ADJ(l) (l)
+# define PAA_SYM_EXISTS zend_symtable_str_exists
+# define PAA_SYM_DEL    zend_symtable_str_del
+#else
+# define PAA_LENGTH_ADJ(l) (l+1)
+# define PAA_SYM_EXISTS zend_symtable_exists
+# define PAA_SYM_DEL    zend_symtable_del
+#endif
 
 /**
  * All APIs in this file follow a general format:
@@ -68,35 +77,47 @@
  */
 static inline
 zend_bool php_array_exists(zval *zarr, const char *key) {
-        return zend_symtable_exists(Z_ARRVAL_P(zarr), key, strlen(key) + 1);
+	return PAA_SYM_EXISTS(Z_ARRVAL_P(zarr), key, PAA_LENGTH_ADJ(strlen(key)));
 }
 #define php_array_existsc(zarr, litstr) \
-	zend_symtable_exists(Z_ARRVAL_P(zarr), litstr, sizeof(litstr))
+	PAA_SYM_EXISTS(Z_ARRVAL_P(zarr), litstr, PAA_LENGTH_ADJ(sizeof(litstr) - 1))
 #define php_array_existsl(zarr, key, len) \
-	zend_symtable_exists(Z_ARRVAL_P(zarr), key, len + 1)
+	PAA_SYM_EXISTS(Z_ARRVAL_P(zarr), key, PAA_LENGTH_ADJ(len))
 static inline
 zend_bool php_array_existsl_safe(zval *zarr, const char *key, int key_len) {
+#ifdef ZEND_ENGINE_3
+	zend_string *keystr = zend_string_init(key, key_len, 0);
+	zend_bool ret = zend_symtable_exists(Z_ARRVAL_P(zarr), keystr);
+	zend_string_release(keystr);
+#else
 	char *k = estrndup(key, key_len);
 	zend_bool ret = zend_symtable_exists(Z_ARRVAL_P(zarr), k, key_len + 1);
 	efree(k);
+#endif
 	return ret;
 }
 #define php_array_existsn(zarr, idx) \
-	zend_hash_index_exists(Z_ARRVAL_P(zarr), idx)
+	zend_hash_index_exists(Z_ARRVAL_P(zarr), idx) 
 static inline
 zend_bool php_array_existsz(zval *zarr, zval *key) {
 	switch (Z_TYPE_P(key)) {
 		case IS_NULL:
-			return zend_symtable_exists(Z_ARRVAL_P(zarr), "", 1);
-		case IS_BOOL:
+			return php_array_existsc(zarr, "");
+#ifdef ZEND_ENGINE_3
+		case IS_FALSE:
+			return zend_hash_index_exists(Z_ARRVAL_P(zarr), 0);
+		case IS_TRUE:
+			return zend_hash_index_exists(Z_ARRVAL_P(zarr), 1);
+#else
+		case IS_BOOL: /* fallthrough */
+#endif
 		case IS_LONG:
 			return zend_hash_index_exists(Z_ARRVAL_P(zarr), Z_LVAL_P(key));
 		case IS_DOUBLE:
 			return zend_hash_index_exists(Z_ARRVAL_P(zarr),
 			                              zend_dval_to_lval(Z_DVAL_P(key)));
 		case IS_STRING:
-			return zend_symtable_exists(Z_ARRVAL_P(zarr),
-			                            Z_STRVAL_P(key), Z_STRLEN_P(key)+1);
+			return php_array_existsl(zarr, Z_STRVAL_P(key), Z_STRLEN_P(key));
 		default:
 			return 0;
 	}
@@ -149,6 +170,9 @@ zend_bool php_array_existsz(zval *zarr, zval *key) {
  */
 static inline
 zval *php_array_fetchl(zval *zarr, const char *key, int key_len) {
+#ifdef ZEND_ENGINE_3
+	return zend_symtable_str_find(Z_ARRVAL_P(zarr), key, key_len);
+#else
 	zval **ppzval;
 	if (FAILURE == zend_symtable_find(Z_ARRVAL_P(zarr),
                                           key, key_len + 1,
@@ -156,6 +180,7 @@ zval *php_array_fetchl(zval *zarr, const char *key, int key_len) {
 		return NULL;
 	}
 	return *ppzval;
+#endif
 }
 static inline
 zval *php_array_fetch(zval *zarr, const char *key) {
@@ -164,26 +189,43 @@ zval *php_array_fetch(zval *zarr, const char *key) {
 #define php_array_fetchc(zarr, litstr) php_array_fetchl(zarr, litstr, sizeof(litstr)-1)
 static inline
 zval *php_array_fetchl_safe(zval *zarr, const char *key, int key_len) {
+#ifdef ZEND_ENGINE_3
+	zend_string *keystr = zend_string_init(key, key_len, 0);
+	zval *ret = zend_symtable_find(Z_ARRVAL_P(zarr), keystr);
+	zend_string_release(keystr);
+#else
 	char *k = estrndup(key, key_len);
 	zval *ret = php_array_fetchl(zarr, k, key_len);
 	efree(k);
+#endif
 	return ret;
 }
 static inline
 zval *php_array_fetchn(zval *zarr, long idx) {
+#ifdef ZEND_ENGINE_3
+	return zend_hash_index_find(Z_ARRVAL_P(zarr), idx);
+#else
 	zval **ppzval;
 	if (FAILURE == zend_hash_index_find(Z_ARRVAL_P(zarr),
 	                                    idx, (void**)&ppzval)) {
 		return NULL;
 	}
 	return *ppzval;
+#endif
 }
 static inline
 zval *php_array_fetchz(zval *zarr, zval *key) {
 	switch (Z_TYPE_P(key)) {
 		case IS_NULL:
 			return php_array_fetchn(zarr, 0);
-		case IS_BOOL:
+#ifdef ZEND_ENGINE_3
+		case IS_FALSE:
+			return php_array_fetchn(zarr, 0);
+		case IS_TRUE:
+			return php_array_fetchn(zarr, 1);
+#else
+		case IS_BOOL: /* fallthrough */
+#endif
 		case IS_LONG:
 			return php_array_fetchn(zarr, Z_LVAL_P(key));
 		case IS_DOUBLE:
@@ -238,7 +280,12 @@ long php_array_zval_to_long(zval *z) {
 	if (!z) { return 0; }
 	switch(Z_TYPE_P(z)) {
 		case IS_NULL: return 0;
+#ifdef ZEND_ENGINE_3
+		case IS_FALSE: return 0;
+		case IS_TRUE: return 1;
+#else
 		case IS_BOOL: return Z_BVAL_P(z);
+#endif
 		case IS_LONG: return Z_LVAL_P(z);
 		case IS_DOUBLE: return (long)Z_DVAL_P(z);
 		default:
@@ -268,7 +315,12 @@ double php_array_zval_to_double(zval *z) {
 	if (!z) { return 0.0; }
 	switch (Z_TYPE_P(z)) {
 		case IS_NULL: return 0.0;
+#ifdef ZEND_ENGINE_3
+		case IS_FALSE: return 0.0;
+		case IS_TRUE: return 1.0;
+#else
 		case IS_BOOL: return (double)Z_BVAL_P(z);
+#endif
 		case IS_LONG: return (double)Z_LVAL_P(z);
 		case IS_DOUBLE: return Z_DVAL_P(z);
 		default:
@@ -305,7 +357,9 @@ char *php_array_zval_to_string(zval *z, int *plen, zend_bool *pfree) {
 	if (!z) { return NULL; }
 	*pfree = 1;
 	switch (Z_TYPE_P(z)) {
-		case IS_NULL: return STR_EMPTY_ALLOC();
+		case IS_NULL:
+			*pfree = 0;
+			return "";
 		case IS_STRING:
 			*pfree = 0;
 			*plen = Z_STRLEN_P(z);
@@ -381,6 +435,9 @@ PHP_ARRAY_FETCH_TYPE_MAP(zval*, array)
  */
 static inline
 void *php_array_zval_to_resource(zval *z, int le TSRMLS_DC) {
+#ifdef ZEND_ENGINE_3
+	return zend_fetch_resource_ex(z, NULL, le);
+#else
 	void *ret;
 	int rtype;
  	if (!z || Z_TYPE_P(z) != IS_RESOURCE) { return NULL; }
@@ -389,6 +446,7 @@ void *php_array_zval_to_resource(zval *z, int le TSRMLS_DC) {
 		return NULL;
 	}
 	return ret;
+#endif
 }
 #define php_array_fetch_resource(zarr, key, le) \
 	php_array_zval_to_resource(php_array_fetch(zarr, key), le TSRMLS_CC)
@@ -445,26 +503,35 @@ zval *php_array_zval_to_object(zval *z, zend_class_entry *ce TSRMLS_DC) {
  */
 static inline
 void php_array_unset(zval *zarr, const char *key) {
-  zend_hash_del(Z_ARRVAL_P(zarr), key, strlen(key) + 1);
+	PAA_SYM_DEL(Z_ARRVAL_P(zarr), key, PAA_LENGTH_ADJ(strlen(key)));
 }
 #define php_array_unsetl(zarr, key, len) \
-	zend_hash_del(Z_ARRVAL_P(zarr), key, len + 1)
+	PAA_SYM_DEL(Z_ARRVAL_P(zarr), key, PAA_LENGTH_ADJ(len))
 static inline
 void php_array_unsetl_safe(zval *zarr, const char *key, int key_len) {
 	char *k = estrndup(key, key_len);
-	zend_hash_del(Z_ARRVAL_P(zarr), k, key_len + 1);
+	PAA_SYM_DEL(Z_ARRVAL_P(zarr), k, PAA_LENGTH_ADJ(key_len));
 	efree(k);
 }
 #define php_array_unsetn(zarr, idx) \
-	zend_hash_index_del(Z_ARRVAL_P(zarr), idx)
+	zend_symtable_index_del(Z_ARRVAL_P(zarr), idx)
 #define php_array_unsetc(zarr, litstr) \
-	zend_hash_del(Z_ARRVAL_P(zarr), litstr, sizeof(litstr))
+	zend_symtable_del(Z_ARRVAL_P(zarr), litstr, PAA_LENGTH_ADJ(sizeof(litstr) - 1))
 static inline void php_array_unsetz(zval *zarr, zval *key) {
 	switch (Z_TYPE_P(key)) {
 		case IS_NULL:
 			zend_hash_index_del(Z_ARRVAL_P(zarr), 0);
 			return;
-		case IS_BOOL:
+#ifdef ZEND_ENGINE_3
+		case IS_FALSE:
+			zend_hash_index_del(Z_ARRVAL_P(zarr), 0);
+			return;
+		case IS_TRUE:
+			zend_hash_index_del(Z_ARRVAL_P(zarr), 1);
+			return;
+#else
+		case IS_BOOL: /* fallthrough */
+#endif
 		case IS_LONG:
 			zend_hash_index_del(Z_ARRVAL_P(zarr), Z_LVAL_P(key));
 			return;
@@ -472,9 +539,9 @@ static inline void php_array_unsetz(zval *zarr, zval *key) {
 			zend_hash_index_del(Z_ARRVAL_P(zarr), (long)Z_DVAL_P(key));
 			break;
 		case IS_STRING:
-			zend_hash_del(Z_ARRVAL_P(zarr), Z_STRVAL_P(key), Z_STRLEN_P(key) + 1);
+			php_array_unsetl(zarr, Z_STRVAL_P(key), Z_STRLEN_P(key));
+			break;
 	}
 }
-/* LCOV_EXCL_STOP */
 
 #endif /* PHP_ARRAY_API_H */


### PR DESCRIPTION
PHPC-368: Move MongoDB\Manager->__construct work to _init method
PHPC-369: Split object structures and retrieval
PHPC-370: return_value_ptr and return_value_used removed in PHP7
PHPC-371: Accessing resources changes


Nowhere near compiling on PHP7 yet though :)
