### PR TITLE
Split tests for invalid arguments out into their own files, and ignore them for HHVM

### DIFF
--- a/tests/bson/bson-binary-001.phpt
+++ b/tests/bson/bson-binary-001.phpt
@@ -26,13 +26,6 @@ foreach($types as $type) {
     $tests[] = array("binary" => $binary);
 }
 
-throws(function() use($classname) {
-    $b = new $classname("random binary data without type");
-    echo "FAIL: Constructed BSON\Binary without type!\n";
-}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
-
-
-
 foreach($tests as $n => $test) {
     $s = fromPHP($test);
     echo "Test#{$n} ", $json = toJSON($s), "\n";
@@ -41,9 +34,6 @@ foreach($tests as $n => $test) {
     var_dump(toJSON(fromPHP($test)), toJSON(fromPHP($testagain)));
     var_dump((object)$test == (object)$testagain);
 }
-
-$binary->getData(2);
-$binary->getType(2);
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -64,7 +54,6 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
-OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Test#0 { "binary" : { "$type" : "00", "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh" } }
 string(73) "{ "binary" : { "$type" : "00", "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh" } }"
 string(73) "{ "binary" : { "$type" : "00", "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh" } }"
@@ -97,8 +86,4 @@ Test#7 { "binary" : { "$type" : "85", "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh" } }
 string(73) "{ "binary" : { "$type" : "85", "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh" } }"
 string(73) "{ "binary" : { "$type" : "85", "$binary" : "cmFuZG9tIGJpbmFyeSBkYXRh" } }"
 bool(true)
-
-Warning: %s\Binary::getData() expects exactly 0 parameters, 1 given in %s on line %d
-
-Warning: %s\Binary::getType() expects exactly 0 parameters, 1 given in %s on line %d
 ===DONE===

--- a/tests/bson/bson-binary_error-001.phpt
+++ b/tests/bson/bson-binary_error-001.phpt
@@ -1,0 +1,31 @@
+--TEST--
+BSON BSON\Binary #001 error
+--SKIPIF--
+<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$classname = BSON_NAMESPACE . "\\Binary";
+
+$binary = new $classname("random binary data", $classname::TYPE_GENERIC);
+
+throws(function() use($classname) {
+    $b = new $classname("random binary data without type");
+    echo "FAIL: Constructed BSON\Binary without type!\n";
+}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
+
+$binary->getData(2);
+$binary->getType(2);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+
+Warning: %s\Binary::getData() expects exactly 0 parameters, 1 given in %s on line %d
+
+Warning: %s\Binary::getType() expects exactly 0 parameters, 1 given in %s on line %d
+===DONE===
+

--- a/tests/bson/bson-javascript-001.phpt
+++ b/tests/bson/bson-javascript-001.phpt
@@ -12,15 +12,15 @@ $js = new $classname("function foo(bar) {var baz = bar; var bar = foo; return ba
 $jswscope = new $classname("function foo(bar) {var baz = bar; var bar = foo; return bar; }", array("foo" => 42));
 $tests = array(
     array("js" => $js),
-    array("jswscope" => $jswscope),
+    array("js" => $jswscope),
 );
 
 foreach($tests as $n => $test) {
     echo "Test#{$n}", "\n";
     $s = fromPHP($test);
     $testagain = toPHP($s);
-    var_dump(current($test) instanceof $classname);
-    var_dump(current($testagain) instanceof $classname);
+    var_dump($test['js'] instanceof $classname);
+    var_dump($testagain->js instanceof $classname);
 }
 
 ?>

--- a/tests/bson/bson-javascript_error-001.phpt
+++ b/tests/bson/bson-javascript_error-001.phpt
@@ -1,6 +1,7 @@
 --TEST--
-BSON BSON\Javascript #001
+BSON BSON\Javascript #001 error
 --SKIPIF--
+<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
 <?php require __DIR__ . "/../utils/basic-skipif.inc"?>
 --FILE--
 <?php
@@ -15,22 +16,12 @@ $tests = array(
     array("jswscope" => $jswscope),
 );
 
-foreach($tests as $n => $test) {
-    echo "Test#{$n}", "\n";
-    $s = fromPHP($test);
-    $testagain = toPHP($s);
-    var_dump(current($test) instanceof $classname);
-    var_dump(current($testagain) instanceof $classname);
-}
-
+throws(function() use($classname) {
+    $j = new $classname;
+}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-Test#0
-bool(true)
-bool(true)
-Test#1
-bool(true)
-bool(true)
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 ===DONE===

--- a/tests/bson/bson-objectid-001.phpt
+++ b/tests/bson/bson-objectid-001.phpt
@@ -53,9 +53,6 @@ $id = new $classname("-3e28b650640fd3162152da1");
 throws(function() use($classname) {
 $id = new $classname(" 3e28b650640fd3162152da1");
 }, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
-throws(function() use($classname) {
-$id = new $classname(new stdclass);
-}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
 
 
 
@@ -86,7 +83,6 @@ Test#4 { "pregenerated" : { "$oid" : "53e28b650640fd3162152de1" } }
 string(60) "{ "pregenerated" : { "$oid" : "53e28b650640fd3162152de1" } }"
 string(60) "{ "pregenerated" : { "$oid" : "53e28b650640fd3162152de1" } }"
 bool(true)
-OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 OK: Got MongoDB\Driver\Exception\InvalidArgumentException

--- a/tests/bson/bson-objectid_error-001.phpt
+++ b/tests/bson/bson-objectid_error-001.phpt
@@ -1,0 +1,20 @@
+--TEST--
+BSON BSON\ObjectID #001 error
+--SKIPIF--
+<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$classname = BSON_NAMESPACE . "\\ObjectID";
+throws(function() use($classname) {
+$id = new $classname(new stdclass);
+}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+===DONE===
+

--- a/tests/bson/bson-regex-001.phpt
+++ b/tests/bson/bson-regex-001.phpt
@@ -17,11 +17,6 @@ $tests = array(
     array("regex" => $regexp),
 );
 
-throws(function() use($classname) {
-    $regexp = new $classname;
-}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
-
-
 foreach($tests as $n => $test) {
     $s = fromPHP($test);
     echo "Test#{$n} ", $json = toJSON($s), "\n";
@@ -30,9 +25,6 @@ foreach($tests as $n => $test) {
     var_dump(toJSON(fromPHP($test)), toJSON(fromPHP($testagain)));
     var_dump((object)$test == (object)$testagain);
 }
-
-$regexp->getPattern(true);
-$regexp->getFlags(true);
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -40,13 +32,8 @@ $regexp->getFlags(true);
 Pattern: regexp
 Flags: i
 String representation: /regexp/i
-OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Test#0 { "regex" : { "$regex" : "regexp", "$options" : "i" } }
 string(55) "{ "regex" : { "$regex" : "regexp", "$options" : "i" } }"
 string(55) "{ "regex" : { "$regex" : "regexp", "$options" : "i" } }"
 bool(true)
-
-Warning: %s\Regex::getPattern() expects exactly 0 parameters, 1 given in %s on line %d
-
-Warning: %s\Regex::getFlags() expects exactly 0 parameters, 1 given in %s on line %d
 ===DONE===

--- a/tests/bson/bson-regex_error-001.phpt
+++ b/tests/bson/bson-regex_error-001.phpt
@@ -1,0 +1,29 @@
+--TEST--
+BSON BSON\Regex #001 error
+--SKIPIF--
+<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$classname = BSON_NAMESPACE . "\\Regex";
+$regexp = new $classname("regexp", "i");
+
+throws(function() use($classname) {
+    $regexp = new $classname;
+}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
+
+$regexp->getPattern(true);
+$regexp->getFlags(true);
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+
+Warning: %s\Regex::getPattern() expects exactly 0 parameters, 1 given in %s on line %d
+
+Warning: %s\Regex::getFlags() expects exactly 0 parameters, 1 given in %s on line %d
+===DONE===
+

--- a/tests/bson/bson-timestamp-001.phpt
+++ b/tests/bson/bson-timestamp-001.phpt
@@ -12,10 +12,6 @@ $tests = array(
     array("timestamp" => $timestamp),
 );
 
-throws(function() use($classname) {
-    $s = new $classname;
-}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
-
 $s = new $classname(1234, 5678);
 echo $s, "\n";
 
@@ -31,7 +27,6 @@ foreach($tests as $n => $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 [1234:5678]
 Test#0 { "timestamp" : { "$timestamp" : { "t" : 5678, "i" : 1234 } } }
 string(63) "{ "timestamp" : { "$timestamp" : { "t" : 5678, "i" : 1234 } } }"

--- a/tests/bson/bson-timestamp_error-001.phpt
+++ b/tests/bson/bson-timestamp_error-001.phpt
@@ -1,0 +1,21 @@
+--TEST--
+BSON BSON\Timestamp #001 error
+--SKIPIF--
+<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$classname = BSON_NAMESPACE . "\\Timestamp";
+
+throws(function() use($classname) {
+    $s = new $classname;
+}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+===DONE===
+

--- a/tests/bson/bson-utcdatetime-001.phpt
+++ b/tests/bson/bson-utcdatetime-001.phpt
@@ -23,10 +23,6 @@ var_dump($date->format(DATE_RSS));
 
 echo $utcdatetime, "\n";
 
-throws(function() use($classname) {
-    $d = new $classname;
-}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
-
 $tests = array(
     array($utcdatetime),
     array($array[0]->x),
@@ -47,7 +43,6 @@ foreach($tests as $n => $test) {
 --EXPECTF--
 string(31) "Thu, 20 Nov 2014 01:03:31 +0000"
 1416445411987
-OK: Got MongoDB\Driver\Exception\InvalidArgumentException
 Test#0 { "0" : { "$date" : 1416445411987 } }
 string(37) "{ "0" : { "$date" : 1416445411987 } }"
 string(37) "{ "0" : { "$date" : 1416445411987 } }"

--- a/tests/bson/bson-utcdatetime_error-001.phpt
+++ b/tests/bson/bson-utcdatetime_error-001.phpt
@@ -1,0 +1,24 @@
+--TEST--
+BSON BSON\UTCDateTime #001 error
+--INI--
+date.timezone=America/Los_Angeles
+--SKIPIF--
+<?php if (defined("HHVM_VERSION_ID")) exit("skip HHVM handles parameter parsing differently"); ?>
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; CLEANUP(STANDALONE) ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = new MongoDB\Driver\Manager(STANDALONE);
+
+$classname = BSON_NAMESPACE . "\\UTCDateTime";
+
+throws(function() use($classname) {
+    $d = new $classname;
+}, "MongoDB\\Driver\\Exception\\InvalidArgumentException");
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+===DONE===


### PR DESCRIPTION
And we also add a cast because of HHVM not allowing current() on an object