### PR TITLE
PHP7: Change create_object functions to support new PHP7 function prototype

### DIFF
--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -171,6 +171,9 @@
 # define Z_PHPDATE_P(object) zend_object_store_get_object(object TSRMLS_CC)
 # define Z_ISUNDEF(x) !x
 # define phongo_free_object_arg void
+# define ZEND_HASH_INC_APPLY_COUNT(ht) (ht)->nApplyCount++
+# define ZEND_HASH_DEC_APPLY_COUNT(ht) (ht)->nApplyCount--
+# define ZEND_HASH_GET_APPLY_COUNT(ht) (ht)->nApplyCount
 #endif
 
 

--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -177,26 +177,6 @@
 void *x509_from_zval(zval *zval TSRMLS_DC);
 void phongo_add_exception_prop(const char *prop, int prop_len, zval *value TSRMLS_DC);
 
-#if PHP_VERSION_ID >= 70000
-#define ALLOC_ZVAL(z) 									\
-	do {												\
-		(z) = (zval*)ecalloc(1, sizeof(zval));		\
-	} while (0)
-
-#define INIT_PZVAL(z)		\
-        Z_SET_REFCOUNT_P(z, 1)
-
-#define INIT_ZVAL(z) z = zval_used_for_init;
-
-#define ALLOC_INIT_ZVAL(zp)						\
-	ALLOC_ZVAL(zp);		\
-	INIT_ZVAL(*zp);
-
-#define MAKE_STD_ZVAL(zv)				 \
-	ALLOC_ZVAL(zv); \
-	INIT_PZVAL(zv);
-#endif
-
 #endif /* PHONGO_COMPAT_H */
 
 

--- a/phongo_compat.h
+++ b/phongo_compat.h
@@ -48,7 +48,9 @@
 		zend_hash_copy(*_std.properties, &class_type->default_properties, (copy_ctor_func_t) zval_add_ref, NULL, sizeof(zval *));
 #endif
 
-#if PHP_VERSION_ID < 50400
+#if PHP_VERSION_ID >= 70000
+# define str_efree(s) efree((char*)s)
+#elif PHP_VERSION_ID < 50400
 # define str_efree(s) efree((char*)s)
 #else
 # include <Zend/zend_string.h>
@@ -154,6 +156,7 @@
 # define EXCEPTION_P(_ex, _zp) ZVAL_OBJ(_zp, _ex)
 # define PHONGO_STREAM_ID(stream) stream->res->handle
 # define ADD_ASSOC_STRING(_zv, _key, _value) add_assoc_string_ex(_zv, ZEND_STRS(_key), _value);
+# define phongo_free_object_arg zend_object
 #else
 # define phongo_char char
 # define phongo_char_pdup(str) pestrdup(filename, 1)
@@ -167,12 +170,32 @@
 # define ADD_ASSOC_STRING(_zv, _key, _value) add_assoc_string_ex(_zv, ZEND_STRS(_key), _value, 1);
 # define Z_PHPDATE_P(object) zend_object_store_get_object(object TSRMLS_CC)
 # define Z_ISUNDEF(x) !x
+# define phongo_free_object_arg void
 #endif
 
 
 void *x509_from_zval(zval *zval TSRMLS_DC);
 void phongo_add_exception_prop(const char *prop, int prop_len, zval *value TSRMLS_DC);
 
+#if PHP_VERSION_ID >= 70000
+#define ALLOC_ZVAL(z) 									\
+	do {												\
+		(z) = (zval*)ecalloc(1, sizeof(zval));		\
+	} while (0)
+
+#define INIT_PZVAL(z)		\
+        Z_SET_REFCOUNT_P(z, 1)
+
+#define INIT_ZVAL(z) z = zval_used_for_init;
+
+#define ALLOC_INIT_ZVAL(zp)						\
+	ALLOC_ZVAL(zp);		\
+	INIT_ZVAL(*zp);
+
+#define MAKE_STD_ZVAL(zv)				 \
+	ALLOC_ZVAL(zv); \
+	INIT_PZVAL(zv);
+#endif
 
 #endif /* PHONGO_COMPAT_H */
 

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2271,7 +2271,11 @@ void _phongo_debug_bson(bson_t *bson)
 /* {{{ INI entries */
 #ifdef PHONGO_TODO_INI
 PHP_INI_BEGIN()
+#if PHP_VERSION_ID >= 70000
+	STD_PHP_INI_ENTRY(PHONGO_DEBUG_INI, PHONGO_DEBUG_INI_DEFAULT, PHP_INI_ALL, OnUpdateString, debug, zend_mongodb_globals, mglo)
+#else
 	{ 0, PHP_INI_ALL, (char *)PHONGO_DEBUG_INI, sizeof(PHONGO_DEBUG_INI), OnUpdateString, (void *) XtOffsetOf(zend_mongodb_globals, debug), (void *) &mglo, NULL, (char *)PHONGO_DEBUG_INI_DEFAULT, sizeof(PHONGO_DEBUG_INI_DEFAULT)-1, NULL, 0, 0, 0, NULL },
+#endif
 PHP_INI_END()
 #endif
 /* }}} */

--- a/php_phongo.c
+++ b/php_phongo.c
@@ -2105,7 +2105,6 @@ static void php_phongo_cursor_iterator_dtor(zend_object_iterator *iter TSRMLS_DC
 		cursor_it->intern.data = NULL;
 #endif
 	}
-#endif
 
 	efree(cursor_it);
 } /* }}} */

--- a/php_phongo.h
+++ b/php_phongo.h
@@ -150,11 +150,18 @@ zend_bool phongo_writeconcernerror_init(zval *return_value, bson_t *bson TSRMLS_
 void php_phongo_cursor_free(php_phongo_cursor_t *cursor);
 zend_object_iterator* php_phongo_cursor_get_iterator(zend_class_entry *ce, zval *object, int by_ref TSRMLS_DC);
 
+#if PHP_VERSION_ID >= 70000
+#define PHONGO_CE_INIT(ce) do {                     \
+        ce->serialize    = zend_class_serialize_deny;   \
+        ce->unserialize  = zend_class_unserialize_deny; \
+} while(0);
+#else
 #define PHONGO_CE_INIT(ce) do {                     \
 	ce->ce_flags    |= ZEND_ACC_FINAL_CLASS;        \
 	ce->serialize    = zend_class_serialize_deny;   \
 	ce->unserialize  = zend_class_unserialize_deny; \
 } while(0);
+#endif
 
 
 #ifdef PHP_DEBUG

--- a/php_phongo_classes.h
+++ b/php_phongo_classes.h
@@ -44,6 +44,30 @@
 # define Z_REGEX_OBJ_P(zv)             php_regex_fetch_object(Z_OBJ_P(zv));
 # define Z_TIMESTAMP_OBJ_P(zv)         php_timestamp_fetch_object(Z_OBJ_P(zv));
 # define Z_UTCDATETIME_OBJ_P(zv)       php_utcdatetime_fetch_object(Z_OBJ_P(zv));
+
+# define Z_COMMAND_OBJ(zo)           php_command_fetch_object((zo));
+# define Z_CURSOR_OBJ(zo)            php_cursor_fetch_object((zo));
+# define Z_CURSORID_OBJ(zo)          php_cursorid_fetch_object((zo));
+# define Z_MANAGER_OBJ(zo)           php_manager_fetch_object((zo));
+# define Z_QUERY_OBJ(zo)             php_query_fetch_object((zo));
+# define Z_READPREFERENCE_OBJ(zo)    php_readpreference_fetch_object((zo));
+# define Z_SERVER_OBJ(zo)            php_server_fetch_object((zo));
+# define Z_BULKWRITE_OBJ(zo)         php_bulkwrite_fetch_object((zo));
+# define Z_WRITECONCERN_OBJ(zo)      php_writeconcern_fetch_object((zo));
+# define Z_WRITECONCERNERROR_OBJ(zo) php_writeconcernerror_fetch_object((zo));
+# define Z_WRITEERROR_OBJ(zo)        php_writeerror_fetch_object((zo));
+# define Z_WRITERESULT_OBJ(zo)       php_writeresult_fetch_object((zo));
+# define Z_BINARY_OBJ(zo)            php_binary_fetch_object((zo));
+# define Z_INT32_OBJ(zo)             php_int32_fetch_object((zo));
+# define Z_INT64_OBJ(zo)             php_int64_fetch_object((zo));
+# define Z_JAVASCRIPT_OBJ(zo)        php_javascript_fetch_object((zo));
+# define Z_LOG_OBJ(zo)               php_log_fetch_object((zo));
+# define Z_MAXKEY_OBJ(zo)            php_maxkey_fetch_object((zo));
+# define Z_MINKEY_OBJ(zo)            php_minkey_fetch_object((zo));
+# define Z_OBJECTID_OBJ(zo)          php_objectid_fetch_object((zo));
+# define Z_REGEX_OBJ(zo)             php_regex_fetch_object((zo));
+# define Z_TIMESTAMP_OBJ(zo)         php_timestamp_fetch_object((zo));
+# define Z_UTCDATETIME_OBJ(zo)       php_utcdatetime_fetch_object((zo));
 #else
 # include "php_phongo_structs-5.h"
 # define Z_COMMAND_OBJ_P(zv)           (php_phongo_command_t *)zend_object_store_get_object(zv TSRMLS_CC);
@@ -70,6 +94,29 @@
 # define Z_TIMESTAMP_OBJ_P(zv)         (php_phongo_timestamp_t *)zend_object_store_get_object(zv TSRMLS_CC);
 # define Z_UTCDATETIME_OBJ_P(zv)       (php_phongo_utcdatetime_t *)zend_object_store_get_object(zv TSRMLS_CC);
 
+# define Z_COMMAND_OBJ(zo)           (php_phongo_command_t *)(zo);
+# define Z_CURSOR_OBJ(zo)            (php_phongo_cursor_t *)(zo);
+# define Z_CURSORID_OBJ(zo)          (php_phongo_cursorid_t *)(zo);
+# define Z_MANAGER_OBJ(zo)           (php_phongo_manager_t *)(zo);
+# define Z_QUERY_OBJ(zo)             (php_phongo_query_t *)(zo);
+# define Z_READPREFERENCE_OBJ(zo)    (php_phongo_readpreference_t *)(zo);
+# define Z_SERVER_OBJ(zo)            (php_phongo_server_t *)(zo);
+# define Z_BULKWRITE_OBJ(zo)         (php_phongo_bulkwrite_t *)(zo);
+# define Z_WRITECONCERN_OBJ(zo)      (php_phongo_writeconcern_t *)(zo);
+# define Z_WRITECONCERNERROR_OBJ(zo) (php_phongo_writeconcernerror_t *)(zo);
+# define Z_WRITEERROR_OBJ(zo)        (php_phongo_writeerror_t *)(zo);
+# define Z_WRITERESULT_OBJ(zo)       (php_phongo_writeresult_t *)(zo);
+# define Z_BINARY_OBJ(zo)            (php_phongo_binary_t *)(zo);
+# define Z_INT32_OBJ(zo)             (php_phongo_int32_t *)(zo);
+# define Z_INT64_OBJ(zo)             (php_phongo_int64_t *)(zo);
+# define Z_JAVASCRIPT_OBJ(zo)        (php_phongo_javascript_t *)(zo);
+# define Z_LOG_OBJ(zo)               (php_phongo_log_t *)(zo);
+# define Z_MAXKEY_OBJ(zo)            (php_phongo_maxkey_t *)(zo);
+# define Z_MINKEY_OBJ(zo)            (php_phongo_minkey_t *)(zo);
+# define Z_OBJECTID_OBJ(zo)          (php_phongo_objectid_t *)(zo);
+# define Z_REGEX_OBJ(zo)             (php_phongo_regex_t *)(zo);
+# define Z_TIMESTAMP_OBJ(zo)         (php_phongo_timestamp_t *)(zo);
+# define Z_UTCDATETIME_OBJ(zo)       (php_phongo_utcdatetime_t *)(zo);
 #endif
 
 typedef struct {

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -84,7 +84,11 @@ PHP_METHOD(Binary, getData)
 		return;
 	}
 
+#if PHP_VERSION_ID >= 70000
+        RETURN_STRINGL(intern->data, intern->data_len);
+#else
 	RETURN_STRINGL(intern->data, intern->data_len, 1);
+#endif
 }
 /* }}} */
 /* {{{ proto integer Binary::getType()
@@ -130,18 +134,34 @@ static zend_function_entry php_phongo_binary_me[] = {
 
 
 /* {{{ php_phongo_binary_t object handlers */
-static void php_phongo_binary_free_object(void *object TSRMLS_DC) /* {{{ */
+static void php_phongo_binary_free_object(phongo_free_object_arg* object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_binary_t *intern = (php_phongo_binary_t*)object;
+	php_phongo_binary_t *intern = Z_BINARY_OBJ(object);
 
-	zend_object_std_dtor(&intern->std TSRMLS_CC);
+        zend_object_std_dtor(&intern->std TSRMLS_CC);
 
-	if (intern->data) {
-		efree(intern->data);
-	}
-	efree(intern);
+        if (intern->data) {
+                efree(intern->data);
+        }
+#if PHP_VERSION_ID < 70000
+        efree(intern);
+#endif
 } /* }}} */
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_binary_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_binary_t *intern;
 
+        intern = (php_phongo_binary_t *)ecalloc(1, sizeof(php_phongo_binary_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_binary;
+
+        return &intern->std;
+} /* }}} */
+#else
 zend_object_value php_phongo_binary_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -158,6 +178,7 @@ zend_object_value php_phongo_binary_create_object(zend_class_entry *class_type T
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_binary_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {
@@ -168,7 +189,11 @@ HashTable *php_phongo_binary_get_debug_info(zval *object, int *is_temp TSRMLS_DC
 	*is_temp = 1;
 	array_init_size(&retval, 2);
 
+#if PHP_VERSION_ID >= 70000
+        add_assoc_stringl_ex(&retval, ZEND_STRS("data"), intern->data, intern->data_len);
+#else
 	add_assoc_stringl_ex(&retval, ZEND_STRS("data"), intern->data, intern->data_len, 1);
+#endif
 	add_assoc_long_ex(&retval, ZEND_STRS("type"), intern->type);
 
 	return Z_ARRVAL(retval);
@@ -189,6 +214,10 @@ PHP_MINIT_FUNCTION(Binary)
 
 	memcpy(&php_phongo_handler_binary, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_binary.get_debug_info = php_phongo_binary_get_debug_info;
+#if PHP_VERSION_ID >= 70000
+	php_phongo_handler_binary.free_obj = php_phongo_binary_free_object;
+	php_phongo_handler_binary.offset = XtOffsetOf(php_phongo_binary_t, std);
+#endif
 
 	zend_declare_class_constant_long(php_phongo_binary_ce, ZEND_STRL("TYPE_GENERIC"), BSON_SUBTYPE_BINARY TSRMLS_CC);
 	zend_declare_class_constant_long(php_phongo_binary_ce, ZEND_STRL("TYPE_FUNCTION"), BSON_SUBTYPE_FUNCTION TSRMLS_CC);

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -189,11 +189,7 @@ HashTable *php_phongo_binary_get_debug_info(zval *object, int *is_temp TSRMLS_DC
 	*is_temp = 1;
 	array_init_size(&retval, 2);
 
-#if PHP_VERSION_ID >= 70000
-        add_assoc_stringl_ex(&retval, ZEND_STRS("data"), intern->data, intern->data_len);
-#else
-	add_assoc_stringl_ex(&retval, ZEND_STRS("data"), intern->data, intern->data_len, 1);
-#endif
+        ADD_ASSOC_STRING(&retval, "data", intern->data);
 	add_assoc_long_ex(&retval, ZEND_STRS("type"), intern->type);
 
 	return Z_ARRVAL(retval);

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -44,6 +44,8 @@
 
 PHONGO_API zend_class_entry *php_phongo_javascript_ce;
 
+zend_object_handlers php_phongo_handler_javascript;
+
 
 /* {{{ proto BSON\Javascript Javascript::__construct(string $javascript[, array|object $document])
  * The string is JavaScript code. The document is a mapping from identifiers to values, representing the scope in which the string should be evaluated
@@ -107,6 +109,21 @@ static void php_phongo_javascript_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_javascript_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_javascript_t *intern;
+
+        intern = (php_phongo_javascript_t *)ecalloc(1, sizeof(php_phongo_javascript_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_javascript;
+
+        return &intern->std;
+} /* }}} */
+#else
 zend_object_value php_phongo_javascript_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -119,12 +136,13 @@ zend_object_value php_phongo_javascript_create_object(zend_class_entry *class_ty
 	object_properties_init(&intern->std, class_type);
 
 	retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, php_phongo_javascript_free_object, NULL TSRMLS_CC);
-	retval.handlers = phongo_get_std_object_handlers();
+	retval.handlers = &php_phongo_handler_javascript;
 
 	intern->document = NULL;
 
 	return retval;
 } /* }}} */
+#endif
 /* }}} */
 
 /* {{{ PHP_MINIT_FUNCTION */
@@ -139,6 +157,11 @@ PHP_MINIT_FUNCTION(Javascript)
 	php_phongo_javascript_ce = zend_register_internal_class(&ce TSRMLS_CC);
 
 	zend_class_implements(php_phongo_javascript_ce TSRMLS_CC, 1, php_phongo_type_ce);
+
+        memcpy(&php_phongo_handler_javascript, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
+#if PHP_VERSION_ID >= 70000
+        php_phongo_handler_javascript.free_obj = php_phongo_javascript_free_object;
+#endif
 
 
 	return SUCCESS;

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -95,7 +95,7 @@ static zend_function_entry php_phongo_javascript_me[] = {
 /* {{{ php_phongo_javascript_t object handlers */
 static void php_phongo_javascript_free_object(void *object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_javascript_t *intern = (php_phongo_javascript_t*)object;
+        php_phongo_javascript_t *intern = Z_JAVASCRIPT_OBJ(object);
 
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
 
@@ -161,6 +161,7 @@ PHP_MINIT_FUNCTION(Javascript)
         memcpy(&php_phongo_handler_javascript, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 #if PHP_VERSION_ID >= 70000
         php_phongo_handler_javascript.free_obj = php_phongo_javascript_free_object;
+        php_phongo_handler_javascript.offset = XtOffsetOf(php_phongo_javascript_t, std);
 #endif
 
 

--- a/src/BSON/MaxKey.c
+++ b/src/BSON/MaxKey.c
@@ -44,7 +44,7 @@
 
 PHONGO_API zend_class_entry *php_phongo_maxkey_ce;
 
-
+zend_object_handlers php_phongo_handler_maxkey;
 
 /* {{{ BSON\MaxKey */
 
@@ -66,6 +66,21 @@ static void php_phongo_maxkey_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_maxkey_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_regex_t *intern;
+
+        intern = (php_phongo_maxkey_t *)ecalloc(1, sizeof(php_phongo_maxkey_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_maxkey;
+
+        return &intern->std;
+} /* }}} */
+#else
 zend_object_value php_phongo_maxkey_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -78,10 +93,11 @@ zend_object_value php_phongo_maxkey_create_object(zend_class_entry *class_type T
 	object_properties_init(&intern->std, class_type);
 
 	retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, php_phongo_maxkey_free_object, NULL TSRMLS_CC);
-	retval.handlers = phongo_get_std_object_handlers();
+	retval.handlers = &php_phongo_handler_maxkey;
 
 	return retval;
 } /* }}} */
+#endif
 /* }}} */
 
 /* {{{ PHP_MINIT_FUNCTION */
@@ -96,7 +112,10 @@ PHP_MINIT_FUNCTION(MaxKey)
 	php_phongo_maxkey_ce = zend_register_internal_class(&ce TSRMLS_CC);
 
 	zend_class_implements(php_phongo_maxkey_ce TSRMLS_CC, 1, php_phongo_type_ce);
-
+        memcpy(&php_phongo_handler_maxkey, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
+#if PHP_VERSION_ID >= 70000
+        php_phongo_handler_maxkey.free_obj = php_phongo_maxkey_free_object;
+#endif
 
 	return SUCCESS;
 }

--- a/src/BSON/MaxKey.c
+++ b/src/BSON/MaxKey.c
@@ -57,19 +57,20 @@ static zend_function_entry php_phongo_maxkey_me[] = {
 
 
 /* {{{ php_phongo_maxkey_t object handlers */
-static void php_phongo_maxkey_free_object(void *object TSRMLS_DC) /* {{{ */
+static void php_phongo_maxkey_free_object(phongo_free_object_arg *object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_maxkey_t *intern = (php_phongo_maxkey_t*)object;
+	php_phongo_maxkey_t *intern = Z_MAXKEY_OBJ(object);
 
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
-
+#if PHP_VERSION_ID < 70000
 	efree(intern);
+#endif
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70000
 zend_object* php_phongo_maxkey_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
-        php_phongo_regex_t *intern;
+        php_phongo_maxkey_t *intern;
 
         intern = (php_phongo_maxkey_t *)ecalloc(1, sizeof(php_phongo_maxkey_t)+zend_object_properties_size(class_type));
 
@@ -115,6 +116,7 @@ PHP_MINIT_FUNCTION(MaxKey)
         memcpy(&php_phongo_handler_maxkey, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 #if PHP_VERSION_ID >= 70000
         php_phongo_handler_maxkey.free_obj = php_phongo_maxkey_free_object;
+	php_phongo_handler_maxkey.offset = XtOffsetOf(php_phongo_maxkey_t, std);
 #endif
 
 	return SUCCESS;

--- a/src/BSON/MinKey.c
+++ b/src/BSON/MinKey.c
@@ -44,7 +44,7 @@
 
 PHONGO_API zend_class_entry *php_phongo_minkey_ce;
 
-
+zend_object_handlers php_phongo_handler_minkey;
 
 /* {{{ BSON\MinKey */
 
@@ -66,6 +66,21 @@ static void php_phongo_minkey_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_minkey_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_minkey_t *intern;
+
+        intern = (php_phongo_minkey_t *)ecalloc(1, sizeof(php_phongo_minkey_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_minkey;
+
+        return &intern->std;
+} /* }}} */
+#else
 zend_object_value php_phongo_minkey_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -78,10 +93,11 @@ zend_object_value php_phongo_minkey_create_object(zend_class_entry *class_type T
 	object_properties_init(&intern->std, class_type);
 
 	retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, php_phongo_minkey_free_object, NULL TSRMLS_CC);
-	retval.handlers = phongo_get_std_object_handlers();
+	retval.handlers = &php_phongo_handler_minkey;
 
 	return retval;
 } /* }}} */
+#endif
 /* }}} */
 
 /* {{{ PHP_MINIT_FUNCTION */
@@ -96,6 +112,10 @@ PHP_MINIT_FUNCTION(MinKey)
 	php_phongo_minkey_ce = zend_register_internal_class(&ce TSRMLS_CC);
 
 	zend_class_implements(php_phongo_minkey_ce TSRMLS_CC, 1, php_phongo_type_ce);
+        memcpy(&php_phongo_handler_minkey, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
+#if PHP_VERSION_ID >= 70000
+        php_phongo_handler_minkey.free_obj = php_phongo_minkey_free_object;
+#endif
 
 
 	return SUCCESS;

--- a/src/BSON/MinKey.c
+++ b/src/BSON/MinKey.c
@@ -57,13 +57,15 @@ static zend_function_entry php_phongo_minkey_me[] = {
 
 
 /* {{{ php_phongo_minkey_t object handlers */
-static void php_phongo_minkey_free_object(void *object TSRMLS_DC) /* {{{ */
+static void php_phongo_minkey_free_object(phongo_free_object_arg *object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_minkey_t *intern = (php_phongo_minkey_t*)object;
+	php_phongo_minkey_t *intern = Z_MINKEY_OBJ(object);
 
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
 
+#if PHP_VERSION_ID < 70000
 	efree(intern);
+#endif
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70000
@@ -115,6 +117,7 @@ PHP_MINIT_FUNCTION(MinKey)
         memcpy(&php_phongo_handler_minkey, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 #if PHP_VERSION_ID >= 70000
         php_phongo_handler_minkey.free_obj = php_phongo_minkey_free_object;
+	php_phongo_handler_minkey.offset = XtOffsetOf(php_phongo_minkey_t, std);
 #endif
 
 

--- a/src/BSON/ObjectID.c
+++ b/src/BSON/ObjectID.c
@@ -97,8 +97,11 @@ PHP_METHOD(ObjectID, __toString)
 		return;
 	}
 
-
+#if PHP_VERSION_ID >= 70000
+        RETURN_STRINGL(intern->oid, 24);
+#else
 	RETURN_STRINGL(intern->oid, 24, 1);
+#endif
 }
 /* }}} */
 
@@ -132,6 +135,21 @@ static void php_phongo_objectid_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_objectid_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_objectid_t *intern;
+
+        intern = (php_phongo_objectid_t *)ecalloc(1, sizeof(php_phongo_objectid_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_objectid;
+
+        return &intern->std;
+} /* }}} */
+#else
 zend_object_value php_phongo_objectid_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -147,6 +165,7 @@ zend_object_value php_phongo_objectid_create_object(zend_class_entry *class_type
 
 	return retval;
 } /* }}} */
+#endif
 
 static int php_phongo_objectid_compare_objects(zval *o1, zval *o2 TSRMLS_DC) /* {{{ */
 {
@@ -170,7 +189,11 @@ HashTable *php_phongo_objectid_get_debug_info(zval *object, int *is_temp TSRMLS_
 
 	array_init(&retval);
 
+#if PHP_VERSION_ID >= 70000
+        add_assoc_stringl_ex(&retval, ZEND_STRS("oid"), intern->oid, 24);
+#else
 	add_assoc_stringl_ex(&retval, ZEND_STRS("oid"), intern->oid, 24, 1);
+#endif
 
 	return Z_ARRVAL(retval);
 
@@ -192,6 +215,9 @@ PHP_MINIT_FUNCTION(ObjectID)
 	memcpy(&php_phongo_handler_objectid, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	php_phongo_handler_objectid.compare_objects = php_phongo_objectid_compare_objects;
 	php_phongo_handler_objectid.get_debug_info = php_phongo_objectid_get_debug_info;
+#if PHP_VERSION_ID >= 70000
+        php_phongo_handler_objectid.free_obj = php_phongo_objectid_free_object;
+#endif
 
 
 	return SUCCESS;

--- a/src/BSON/ObjectID.c
+++ b/src/BSON/ObjectID.c
@@ -126,13 +126,15 @@ static zend_function_entry php_phongo_objectid_me[] = {
 
 
 /* {{{ php_phongo_objectid_t object handlers */
-static void php_phongo_objectid_free_object(void *object TSRMLS_DC) /* {{{ */
+static void php_phongo_objectid_free_object(phongo_free_object_arg *object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_objectid_t *intern = (php_phongo_objectid_t*)object;
+	php_phongo_objectid_t *intern = Z_OBJECTID_OBJ(object);
 
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
 
+#if PHP_VERSION_ID < 70000
 	efree(intern);
+#endif
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70000
@@ -189,11 +191,7 @@ HashTable *php_phongo_objectid_get_debug_info(zval *object, int *is_temp TSRMLS_
 
 	array_init(&retval);
 
-#if PHP_VERSION_ID >= 70000
-        add_assoc_stringl_ex(&retval, ZEND_STRS("oid"), intern->oid, 24);
-#else
-	add_assoc_stringl_ex(&retval, ZEND_STRS("oid"), intern->oid, 24, 1);
-#endif
+	ADD_ASSOC_STRING(&retval, ZEND_STRS("oid"), intern->oid, 24);
 
 	return Z_ARRVAL(retval);
 

--- a/src/BSON/ObjectID.c
+++ b/src/BSON/ObjectID.c
@@ -191,7 +191,7 @@ HashTable *php_phongo_objectid_get_debug_info(zval *object, int *is_temp TSRMLS_
 
 	array_init(&retval);
 
-	ADD_ASSOC_STRING(&retval, ZEND_STRS("oid"), intern->oid, 24);
+	ADD_ASSOC_STRING(&retval, "oid", intern->oid);
 
 	return Z_ARRVAL(retval);
 
@@ -214,7 +214,8 @@ PHP_MINIT_FUNCTION(ObjectID)
 	php_phongo_handler_objectid.compare_objects = php_phongo_objectid_compare_objects;
 	php_phongo_handler_objectid.get_debug_info = php_phongo_objectid_get_debug_info;
 #if PHP_VERSION_ID >= 70000
-        php_phongo_handler_objectid.free_obj = php_phongo_objectid_free_object;
+	php_phongo_handler_objectid.free_obj = php_phongo_objectid_free_object;
+	php_phongo_handler_objectid.offset = XtOffsetOf(php_phongo_objectid_t, std); 
 #endif
 
 

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -169,20 +169,22 @@ static zend_function_entry php_phongo_regex_me[] = {
 
 
 /* {{{ php_phongo_regex_t object handlers */
-static void php_phongo_regex_free_object(void *object TSRMLS_DC) /* {{{ */
+static void php_phongo_regex_free_object(phongo_free_object_arg *object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_regex_t *intern = (php_phongo_regex_t*)object;
+	php_phongo_regex_t *intern = Z_REGEX_OBJ(object);
 
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
 
-    if (intern->pattern) {
-        efree(intern->pattern);
-    }
+	if (intern->pattern) {
+		efree(intern->pattern);
+	}
 
-    if (intern->flags) {
-        efree(intern->flags);
-    }
+	if (intern->flags) {
+		efree(intern->flags);
+	}
+#if PHP_VERSION_ID < 70000
 	efree(intern);
+#endif
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70000
@@ -232,7 +234,8 @@ PHP_MINIT_FUNCTION(Regex)
 	zend_class_implements(php_phongo_regex_ce TSRMLS_CC, 1, php_phongo_type_ce);
         memcpy(&php_phongo_handler_regex, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 #if PHP_VERSION_ID >= 70000
-        php_phongo_handler_regex.free_obj = php_phongo_regex_free_object;
+	php_phongo_handler_regex.free_obj = php_phongo_regex_free_object;
+	php_phongo_handler_regex.offset = XtOffsetOf(php_phongo_regex_t, std);
 #endif
 
 	return SUCCESS;

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -44,6 +44,8 @@
 
 PHONGO_API zend_class_entry *php_phongo_regex_ce;
 
+zend_object_handlers php_phongo_handler_regex;
+
 /* {{{ proto BSON\Regex Regex::__construct(string $pattern, string $flags)
    Constructs a new regular expression. */
 PHP_METHOD(Regex, __construct)
@@ -85,8 +87,11 @@ PHP_METHOD(Regex, getPattern)
 		return;
 	}
 
-
+#if PHP_VERSION_ID >= 70000
+        RETURN_STRINGL(intern->pattern, intern->pattern_len);
+#else
 	RETURN_STRINGL(intern->pattern, intern->pattern_len, 1);
+#endif
 }
 /* }}} */
 /* {{{ proto void Regex::getFlags()
@@ -102,8 +107,11 @@ PHP_METHOD(Regex, getFlags)
 		return;
 	}
 
-
+#if PHP_VERSION_ID >= 70000
+        RETURN_STRINGL(intern->flags, intern->flags_len);
+#else
 	RETURN_STRINGL(intern->flags, intern->flags_len, 1);
+#endif
 }
 /* }}} */
 /* {{{ proto void Regex::__toString()
@@ -123,7 +131,11 @@ PHP_METHOD(Regex, __toString)
 
 
 	regex_len = spprintf(&regex, 0, "/%s/%s", intern->pattern, intern->flags);
+#if PHP_VERSION_ID >= 70000
+        RETVAL_STRINGL(regex, regex_len);
+#else
 	RETVAL_STRINGL(regex, regex_len, 0);
+#endif
 }
 /* }}} */
 
@@ -173,6 +185,21 @@ static void php_phongo_regex_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_regex_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_regex_t *intern;
+
+        intern = (php_phongo_regex_t *)ecalloc(1, sizeof(php_phongo_regex_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_regex;
+
+        return &intern->std;
+} /* }}} */
+#else
 zend_object_value php_phongo_regex_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -185,10 +212,11 @@ zend_object_value php_phongo_regex_create_object(zend_class_entry *class_type TS
 	object_properties_init(&intern->std, class_type);
 
 	retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, php_phongo_regex_free_object, NULL TSRMLS_CC);
-	retval.handlers = phongo_get_std_object_handlers();
+	retval.handlers = &php_phongo_handler_regex;
 
 	return retval;
 } /* }}} */
+#endif
 /* }}} */
 
 /* {{{ PHP_MINIT_FUNCTION */
@@ -202,7 +230,10 @@ PHP_MINIT_FUNCTION(Regex)
 	php_phongo_regex_ce = zend_register_internal_class(&ce TSRMLS_CC);
 
 	zend_class_implements(php_phongo_regex_ce TSRMLS_CC, 1, php_phongo_type_ce);
-
+        memcpy(&php_phongo_handler_regex, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
+#if PHP_VERSION_ID >= 70000
+        php_phongo_handler_regex.free_obj = php_phongo_regex_free_object;
+#endif
 
 	return SUCCESS;
 }

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -83,7 +83,11 @@ PHP_METHOD(Timestamp, __toString)
 	}
 
 	retval_len = spprintf(&retval, 0, "[%d:%d]", intern->increment, intern->timestamp);
+#if PHP_VERSION_ID >= 70000
+        RETVAL_STRINGL(retval, retval_len);
+#else
 	RETVAL_STRINGL(retval, retval_len, 0);
+#endif
 }
 /* }}} */
 
@@ -117,6 +121,21 @@ static void php_phongo_timestamp_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_timestamp_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_timestamp_t *intern;
+
+        intern = (php_phongo_timestamp_t *)ecalloc(1, sizeof(php_phongo_timestamp_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = phongo_get_std_object_handlers();
+
+        return &intern->std;
+} /* }}} */
+#else
 zend_object_value php_phongo_timestamp_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -133,6 +152,7 @@ zend_object_value php_phongo_timestamp_create_object(zend_class_entry *class_typ
 
 	return retval;
 } /* }}} */
+#endif
 /* }}} */
 
 /* {{{ PHP_MINIT_FUNCTION */

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -95,7 +95,11 @@ PHP_METHOD(UTCDateTime, __toString)
 	}
 
 	tmp_len = spprintf(&tmp, 0, "%" PRId64, intern->milliseconds);
+#if PHP_VERSION_ID >= 70000
+        RETVAL_STRINGL(tmp, tmp_len);
+#else
 	RETVAL_STRINGL(tmp, tmp_len, 0);
+#endif
 }
 /* }}} */
 /* {{{ proto string UTCDateTime::toDateTime()
@@ -149,6 +153,21 @@ static void php_phongo_utcdatetime_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_utcdatetime_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_utcdatetime_t *intern;
+
+        intern = (php_phongo_utcdatetime_t *)ecalloc(1, sizeof(php_phongo_utcdatetime_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = phongo_get_std_object_handlers();
+
+        return &intern->std;
+} /* }}} */
+#else
 zend_object_value php_phongo_utcdatetime_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -165,6 +184,7 @@ zend_object_value php_phongo_utcdatetime_create_object(zend_class_entry *class_t
 
 	return retval;
 } /* }}} */
+#endif
 /* }}} */
 
 /* {{{ PHP_MINIT_FUNCTION */

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -44,6 +44,8 @@
 
 PHONGO_API zend_class_entry *php_phongo_utcdatetime_ce;
 
+zend_object_handlers php_phongo_handler_utcdatetime;
+
 /* {{{ proto BSON\UTCDateTime UTCDateTime::__construct(integer $milliseconds)
    Construct a new UTCDateTime */
 PHP_METHOD(UTCDateTime, __construct)
@@ -144,13 +146,14 @@ static zend_function_entry php_phongo_utcdatetime_me[] = {
 
 
 /* {{{ php_phongo_utcdatetime_t object handlers */
-static void php_phongo_utcdatetime_free_object(void *object TSRMLS_DC) /* {{{ */
+static void php_phongo_utcdatetime_free_object(phongo_free_object_arg *object TSRMLS_DC) /* {{{ */
 {
-	php_phongo_utcdatetime_t *intern = (php_phongo_utcdatetime_t*)object;
+	php_phongo_utcdatetime_t *intern = Z_UTCDATETIME_OBJ(object);
 
 	zend_object_std_dtor(&intern->std TSRMLS_CC);
-
+#if PHP_VERSION_ID < 70000
 	efree(intern);
+#endif
 } /* }}} */
 
 #if PHP_VERSION_ID >= 70000
@@ -163,7 +166,7 @@ zend_object* php_phongo_utcdatetime_create_object(zend_class_entry *class_type T
         zend_object_std_init(&intern->std, class_type TSRMLS_CC);
         object_properties_init(&intern->std, class_type);
 
-        intern->std.handlers = phongo_get_std_object_handlers();
+        intern->std.handlers = &php_phongo_handler_utcdatetime;
 
         return &intern->std;
 } /* }}} */
@@ -180,7 +183,7 @@ zend_object_value php_phongo_utcdatetime_create_object(zend_class_entry *class_t
 	object_properties_init(&intern->std, class_type);
 
 	retval.handle = zend_objects_store_put(intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, php_phongo_utcdatetime_free_object, NULL TSRMLS_CC);
-	retval.handlers = phongo_get_std_object_handlers();
+	retval.handlers = &php_phongo_handler_utcdatetime;
 
 	return retval;
 } /* }}} */
@@ -198,7 +201,11 @@ PHP_MINIT_FUNCTION(UTCDateTime)
 	php_phongo_utcdatetime_ce = zend_register_internal_class(&ce TSRMLS_CC);
 
 	zend_class_implements(php_phongo_utcdatetime_ce TSRMLS_CC, 1, php_phongo_type_ce);
-
+        memcpy(&php_phongo_handler_utcdatetime, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
+#if PHP_VERSION_ID >= 70000
+        php_phongo_handler_utcdatetime.free_obj = php_phongo_utcdatetime_free_object;
+        php_phongo_handler_utcdatetime.offset = XtOffsetOf(php_phongo_utcdatetime_t, std);
+#endif
 
 	return SUCCESS;
 }

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -274,6 +274,21 @@ static void php_phongo_bulkwrite_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_bulkwrite_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_bulkwrite_t *intern;
+
+        intern = (php_phongo_bulkwrite_t *)ecalloc(1, sizeof(php_phongo_bulkwrite_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_bulkwrite;
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_bulkwrite_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -289,6 +304,7 @@ zend_object_value php_phongo_bulkwrite_create_object(zend_class_entry *class_typ
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_bulkwrite_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {
@@ -301,13 +317,21 @@ HashTable *php_phongo_bulkwrite_get_debug_info(zval *object, int *is_temp TSRMLS
 	array_init(&retval);
 
 	if (intern->bulk->database) {
+#if PHP_VERSION_ID >= 70000
+                add_assoc_string_ex(&retval, ZEND_STRS("database"), intern->bulk->database);
+#else
 		add_assoc_string_ex(&retval, ZEND_STRS("database"), intern->bulk->database, 1);
+#endif
 	} else {
 		add_assoc_null_ex(&retval, ZEND_STRS("database"));
 	}
 
 	if (intern->bulk->collection) {
+#if PHP_VERSION_ID >= 70000
+                add_assoc_string_ex(&retval, ZEND_STRS("collection"), intern->bulk->collection);
+#else
 		add_assoc_string_ex(&retval, ZEND_STRS("collection"), intern->bulk->collection, 1);
+#endif
 	} else {
 		add_assoc_null_ex(&retval, ZEND_STRS("collection"));
 	}

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -105,6 +105,21 @@ static void php_phongo_command_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_command_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_command_t *intern;
+
+        intern = (php_phongo_command_t *)ecalloc(1, sizeof(php_phongo_command_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_command;
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_command_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -120,6 +135,7 @@ zend_object_value php_phongo_command_create_object(zend_class_entry *class_type 
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_command_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -92,7 +92,7 @@ static int php_phongo_cursor_to_array_apply(zend_object_iterator *iter, void *pu
 		return ZEND_HASH_APPLY_STOP;
 	}
 #if PHP_VERSION_ID >= 70000
-        Z_ADDREF_P(data);
+        Z_TRY_ADDREF_P(data);
         add_next_index_zval(return_value, data);
 #else
 	Z_ADDREF_PP(data);

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -72,17 +72,32 @@ PHP_METHOD(Cursor, setTypeMap)
 
 static int php_phongo_cursor_to_array_apply(zend_object_iterator *iter, void *puser TSRMLS_DC) /* {{{ */
 {
-	zval **data, *return_value = (zval*)puser;
+#if PHP_VERSION_ID >= 70000
+	zval *data, *return_value = (zval*)puser;
+
+        data = iter->funcs->get_current_data(iter);
+#else
+        zval **data, *return_value = (zval*)puser;
 
 	iter->funcs->get_current_data(iter, &data TSRMLS_CC);
+#endif
 	if (EG(exception)) {
 		return ZEND_HASH_APPLY_STOP;
 	}
+#if PHP_VERSION_ID >= 70000
+        if (data == NULL) {
+#else
 	if (data == NULL || *data == NULL) {
+#endif
 		return ZEND_HASH_APPLY_STOP;
 	}
+#if PHP_VERSION_ID >= 70000
+        Z_ADDREF_P(data);
+        add_next_index_zval(return_value, data);
+#else
 	Z_ADDREF_PP(data);
 	add_next_index_zval(return_value, *data);
+#endif
 	return ZEND_HASH_APPLY_KEEP;
 }
 /* }}} */
@@ -206,6 +221,21 @@ static void php_phongo_cursor_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_cursor_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_cursor_t *intern;
+
+        intern = (php_phongo_cursor_t *)ecalloc(1, sizeof(php_phongo_cursor_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = phongo_get_std_object_handlers();
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_cursor_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value           retval;
@@ -221,6 +251,7 @@ zend_object_value php_phongo_cursor_create_object(zend_class_entry *class_type T
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_cursor_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {

--- a/src/MongoDB/CursorId.c
+++ b/src/MongoDB/CursorId.c
@@ -91,6 +91,21 @@ static void php_phongo_cursorid_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_cursorid_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_cursorid_t *intern;
+
+        intern = (php_phongo_cursorid_t *)ecalloc(1, sizeof(php_phongo_cursorid_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_cursorid;
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_cursorid_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -106,6 +121,7 @@ zend_object_value php_phongo_cursorid_create_object(zend_class_entry *class_type
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_cursorid_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {

--- a/src/MongoDB/Exception/AuthenticationException.c
+++ b/src/MongoDB/Exception/AuthenticationException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(AuthenticationException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "AuthenticationException", php_phongo_authenticationexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_authenticationexception_ce = zend_register_internal_class_ex(&ce, php_phongo_connectionexception_ce);
+#else
 	php_phongo_authenticationexception_ce = zend_register_internal_class_ex(&ce, php_phongo_connectionexception_ce, NULL TSRMLS_CC);
+#endif
 
 	return SUCCESS;
 }

--- a/src/MongoDB/Exception/BulkWriteException.c
+++ b/src/MongoDB/Exception/BulkWriteException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(BulkWriteException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "BulkWriteException", php_phongo_bulkwriteexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_bulkwriteexception_ce = zend_register_internal_class_ex(&ce, php_phongo_writeexception_ce);
+#else
 	php_phongo_bulkwriteexception_ce = zend_register_internal_class_ex(&ce, php_phongo_writeexception_ce, NULL TSRMLS_CC);
+#endif
 
 	return SUCCESS;
 }

--- a/src/MongoDB/Exception/ConnectionException.c
+++ b/src/MongoDB/Exception/ConnectionException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(ConnectionException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ConnectionException", php_phongo_connectionexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_connectionexception_ce = zend_register_internal_class_ex(&ce, php_phongo_runtimeexception_ce);
+#else
 	php_phongo_connectionexception_ce = zend_register_internal_class_ex(&ce, php_phongo_runtimeexception_ce, NULL TSRMLS_CC);
+#endif
 
 	return SUCCESS;
 }

--- a/src/MongoDB/Exception/ConnectionTimeoutException.c
+++ b/src/MongoDB/Exception/ConnectionTimeoutException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(ConnectionTimeoutException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ConnectionTimeoutException", php_phongo_connectiontimeoutexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_connectiontimeoutexception_ce = zend_register_internal_class_ex(&ce, php_phongo_connectionexception_ce);
+#else
 	php_phongo_connectiontimeoutexception_ce = zend_register_internal_class_ex(&ce, php_phongo_connectionexception_ce, NULL TSRMLS_CC);
+#endif
 	PHONGO_CE_INIT(php_phongo_connectiontimeoutexception_ce);
 
 	return SUCCESS;

--- a/src/MongoDB/Exception/DuplicateKeyException.c
+++ b/src/MongoDB/Exception/DuplicateKeyException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(DuplicateKeyException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "DuplicateKeyException", php_phongo_duplicatekeyexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_duplicatekeyexception_ce = zend_register_internal_class_ex(&ce, php_phongo_writeexception_ce);
+#else
 	php_phongo_duplicatekeyexception_ce = zend_register_internal_class_ex(&ce, php_phongo_writeexception_ce, NULL TSRMLS_CC);
+#endif
 	PHONGO_CE_INIT(php_phongo_duplicatekeyexception_ce);
 
 	return SUCCESS;

--- a/src/MongoDB/Exception/ExecutionTimeoutException.c
+++ b/src/MongoDB/Exception/ExecutionTimeoutException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(ExecutionTimeoutException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ExecutionTimeoutException", php_phongo_executiontimeoutexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_executiontimeoutexception_ce = zend_register_internal_class_ex(&ce, php_phongo_runtimeexception_ce);
+#else
 	php_phongo_executiontimeoutexception_ce = zend_register_internal_class_ex(&ce, php_phongo_runtimeexception_ce, NULL TSRMLS_CC);
+#endif
 	PHONGO_CE_INIT(php_phongo_executiontimeoutexception_ce);
 
 	return SUCCESS;

--- a/src/MongoDB/Exception/InvalidArgumentException.c
+++ b/src/MongoDB/Exception/InvalidArgumentException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(InvalidArgumentException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "InvalidArgumentException", php_phongo_invalidargumentexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_invalidargumentexception_ce = zend_register_internal_class_ex(&ce, spl_ce_InvalidArgumentException);
+#else
 	php_phongo_invalidargumentexception_ce = zend_register_internal_class_ex(&ce, spl_ce_InvalidArgumentException, NULL TSRMLS_CC);
+#endif
 	zend_class_implements(php_phongo_invalidargumentexception_ce TSRMLS_CC, 1, php_phongo_exception_ce);
 
 	return SUCCESS;

--- a/src/MongoDB/Exception/LogicException.c
+++ b/src/MongoDB/Exception/LogicException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(LogicException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "LogicException", php_phongo_logicexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_logicexception_ce = zend_register_internal_class_ex(&ce, spl_ce_LogicException);
+#else
 	php_phongo_logicexception_ce = zend_register_internal_class_ex(&ce, spl_ce_LogicException, NULL TSRMLS_CC);
+#endif
 	zend_class_implements(php_phongo_logicexception_ce TSRMLS_CC, 1, php_phongo_exception_ce);
 
 	return SUCCESS;

--- a/src/MongoDB/Exception/RuntimeException.c
+++ b/src/MongoDB/Exception/RuntimeException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(RuntimeException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "RuntimeException", php_phongo_runtimeexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_runtimeexception_ce = zend_register_internal_class_ex(&ce, spl_ce_RuntimeException);
+#else
 	php_phongo_runtimeexception_ce = zend_register_internal_class_ex(&ce, spl_ce_RuntimeException, NULL TSRMLS_CC);
+#endif
 	zend_class_implements(php_phongo_runtimeexception_ce TSRMLS_CC, 1, php_phongo_exception_ce);
 
 	return SUCCESS;

--- a/src/MongoDB/Exception/SSLConnectionException.c
+++ b/src/MongoDB/Exception/SSLConnectionException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(SSLConnectionException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "SSLConnectionException", php_phongo_sslconnectionexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_sslconnectionexception_ce = zend_register_internal_class_ex(&ce, php_phongo_connectionexception_ce);
+#else
 	php_phongo_sslconnectionexception_ce = zend_register_internal_class_ex(&ce, php_phongo_connectionexception_ce, NULL TSRMLS_CC);
+#endif
 	PHONGO_CE_INIT(php_phongo_sslconnectionexception_ce);
 
 	return SUCCESS;

--- a/src/MongoDB/Exception/UnexpectedValueException.c
+++ b/src/MongoDB/Exception/UnexpectedValueException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(UnexpectedValueException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "UnexpectedValueException", php_phongo_unexpectedvalueexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_unexpectedvalueexception_ce = zend_register_internal_class_ex(&ce, spl_ce_UnexpectedValueException);
+#else
 	php_phongo_unexpectedvalueexception_ce = zend_register_internal_class_ex(&ce, spl_ce_UnexpectedValueException, NULL TSRMLS_CC);
+#endif
 	zend_class_implements(php_phongo_unexpectedvalueexception_ce TSRMLS_CC, 1, php_phongo_exception_ce);
 
 	return SUCCESS;

--- a/src/MongoDB/Exception/WriteConcernException.c
+++ b/src/MongoDB/Exception/WriteConcernException.c
@@ -61,7 +61,11 @@ PHP_MINIT_FUNCTION(WriteConcernException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "WriteConcernException", php_phongo_writeconcernexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_writeconcernexception_ce = zend_register_internal_class_ex(&ce, php_phongo_writeexception_ce);
+#else
 	php_phongo_writeconcernexception_ce = zend_register_internal_class_ex(&ce, php_phongo_writeexception_ce, NULL TSRMLS_CC);
+#endif
 
 	return SUCCESS;
 }

--- a/src/MongoDB/Exception/WriteException.c
+++ b/src/MongoDB/Exception/WriteException.c
@@ -57,8 +57,11 @@ PHP_METHOD(WriteException, getWriteResult)
 		return;
 	}
 
-
+#if PHP_VERSION_ID >= 70000
+        zend_read_property(php_phongo_writeexception_ce, getThis(), ZEND_STRL("writeResult"), 0 TSRMLS_CC, writeresult);
+#else
 	writeresult = zend_read_property(php_phongo_writeexception_ce, getThis(), ZEND_STRL("writeResult"), 0 TSRMLS_CC);
+#endif
 
 	RETURN_ZVAL(writeresult, 1, 0);
 }
@@ -88,7 +91,11 @@ PHP_MINIT_FUNCTION(WriteException)
 	(void)type;(void)module_number;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "WriteException", php_phongo_writeexception_me);
+#if PHP_VERSION_ID >= 70000
+        php_phongo_writeexception_ce = zend_register_internal_class_ex(&ce, php_phongo_runtimeexception_ce);
+#else
 	php_phongo_writeexception_ce = zend_register_internal_class_ex(&ce, php_phongo_runtimeexception_ce, NULL TSRMLS_CC);
+#endif
 
 	zend_declare_property_null(php_phongo_writeexception_ce, ZEND_STRL("writeResult"), ZEND_ACC_PROTECTED TSRMLS_CC);
 

--- a/src/MongoDB/Exception/WriteException.c
+++ b/src/MongoDB/Exception/WriteException.c
@@ -50,7 +50,9 @@ PHONGO_API zend_class_entry *php_phongo_writeexception_ce;
 PHP_METHOD(WriteException, getWriteResult)
 {
 	zval *writeresult;
-
+#if PHP_VERSION_ID >= 70000
+        zval  rv;
+#endif
 
 
 	if (zend_parse_parameters_none() == FAILURE) {
@@ -58,7 +60,7 @@ PHP_METHOD(WriteException, getWriteResult)
 	}
 
 #if PHP_VERSION_ID >= 70000
-        zend_read_property(php_phongo_writeexception_ce, getThis(), ZEND_STRL("writeResult"), 0 TSRMLS_CC, writeresult);
+        writeresult = zend_read_property(php_phongo_writeexception_ce, getThis(), ZEND_STRL("writeResult"), 0 TSRMLS_CC, &rv);
 #else
 	writeresult = zend_read_property(php_phongo_writeexception_ce, getThis(), ZEND_STRL("writeResult"), 0 TSRMLS_CC);
 #endif

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -508,17 +508,15 @@ zend_object_value php_phongo_manager_create_object(zend_class_entry *class_type 
 
 bool phongo_add_server_debug(void *item, void *ctx)
 {
-#if PHP_VERSION_ID >= 70000
         mongoc_server_description_t *server = item;
         zval                        *retval = ctx;
+#if PHP_VERSION_ID >= 70000
         zval entry;
 
         php_phongo_server_to_zval(&entry, server);
 
         add_next_index_zval(retval, &entry);
 #else
-	mongoc_server_description_t *server = item;
-	zval                        *retval = ctx;
 	zval *entry = NULL;
 
         MAKE_STD_ZVAL(entry);

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -122,6 +122,21 @@ static void php_phongo_query_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_query_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_query_t *intern;
+
+        intern = (php_phongo_query_t *)ecalloc(1, sizeof(php_phongo_query_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_query;
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_query_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -137,6 +152,7 @@ zend_object_value php_phongo_query_create_object(zend_class_entry *class_type TS
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_query_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -128,6 +128,22 @@ static void php_phongo_readpreference_free_object(void *object TSRMLS_DC) /* {{{
 	efree(intern);
 } /* }}} */
 
+
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_readpreference_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_readpreference_t *intern;
+
+        intern = (php_phongo_readpreference_t *)ecalloc(1, sizeof(php_phongo_readpreference_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_readpreference;
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_readpreference_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -143,6 +159,7 @@ zend_object_value php_phongo_readpreference_create_object(zend_class_entry *clas
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_readpreference_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -144,7 +144,11 @@ PHP_METHOD(Server, getHost)
 	}
 
 	if ((sd = mongoc_topology_description_server_by_id(&intern->client->topology->description, intern->server_id))) {
+#if PHP_VERSION_ID >= 70000
+                RETURN_STRING(sd->host.host);
+#else
 		RETURN_STRING(sd->host.host, 1);
+#endif
 	}
 
 	phongo_throw_exception(PHONGO_ERROR_RUNTIME TSRMLS_CC, "%s", "Failed to get server description, server likely gone");
@@ -493,6 +497,21 @@ static void php_phongo_server_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_server_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_server_t *intern;
+
+        intern = (php_phongo_server_t *)ecalloc(1, sizeof(php_phongo_server_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_server;
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_server_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -508,6 +527,7 @@ zend_object_value php_phongo_server_create_object(zend_class_entry *class_type T
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_server_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -134,6 +134,21 @@ static void php_phongo_writeconcern_free_object(void *object TSRMLS_DC) /* {{{ *
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_writeconcern_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_writeconcern_t *intern;
+
+        intern = (php_phongo_writeconcern_t *)ecalloc(1, sizeof(php_phongo_writeconcern_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_writeconcern;
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_writeconcern_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -149,6 +164,7 @@ zend_object_value php_phongo_writeconcern_create_object(zend_class_entry *class_
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_writeconcern_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {

--- a/src/MongoDB/WriteConcernError.c
+++ b/src/MongoDB/WriteConcernError.c
@@ -95,7 +95,11 @@ PHP_METHOD(WriteConcernError, getMessage)
 		return;
 	}
 
+#if PHP_VERSION_ID >= 70000
+        RETURN_STRING(intern->message);
+#else
 	RETURN_STRING(intern->message, 1);
+#endif
 }
 /* }}} */
 
@@ -138,11 +142,30 @@ static void php_phongo_writeconcernerror_free_object(void *object TSRMLS_DC) /* 
 	}
 
 	if (intern->info) {
+#if PHP_VERSION_ID >= 70000
+                zval_ptr_dtor(intern->info);
+#else
 		zval_ptr_dtor(&intern->info);
+#endif
 	}
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_writeconcernerror_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_writeconcernerror_t *intern;
+
+        intern = (php_phongo_writeconcernerror_t *)ecalloc(1, sizeof(php_phongo_writeconcernerror_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_writeconcernerror;
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_writeconcernerror_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -160,6 +183,7 @@ zend_object_value php_phongo_writeconcernerror_create_object(zend_class_entry *c
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_writeconcernerror_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {
@@ -171,7 +195,11 @@ HashTable *php_phongo_writeconcernerror_get_debug_info(zval *object, int *is_tem
 	intern = Z_WRITECONCERNERROR_OBJ_P(object);
 
 	array_init_size(&retval, 3);
+#if PHP_VERSION_ID >= 70000
+        add_assoc_string_ex(&retval, ZEND_STRS("message"), intern->message);
+#else
 	add_assoc_string_ex(&retval, ZEND_STRS("message"), intern->message, 1);
+#endif
 	add_assoc_long_ex(&retval, ZEND_STRS("code"), intern->code);
 	if (intern->info) {
 		Z_ADDREF_P(intern->info);

--- a/src/MongoDB/WriteError.c
+++ b/src/MongoDB/WriteError.c
@@ -93,8 +93,11 @@ PHP_METHOD(WriteError, getMessage)
 		return;
 	}
 
-
+#if PHP_VERSION_ID >= 70000
+        RETURN_STRING(intern->message);
+#else
 	RETURN_STRING(intern->message, 1);
+#endif
 }
 /* }}} */
 /* {{{ proto mixed WriteError::getInfo()
@@ -160,12 +163,32 @@ static void php_phongo_writeerror_free_object(void *object TSRMLS_DC) /* {{{ */
 	}
 
 	if (intern->info) {
+#if PHP_VERSION_ID >= 70000
+                zval_ptr_dtor(intern->info);
+#else
 		zval_ptr_dtor(&intern->info);
+#endif
 	}
 
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_writeerror_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_writeerror_t *intern;
+
+        intern = (php_phongo_writeerror_t *)ecalloc(1, sizeof(php_phongo_writeerror_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        intern->std.handlers = &php_phongo_handler_writeerror;
+        intern->info = NULL;
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_writeerror_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -183,6 +206,7 @@ zend_object_value php_phongo_writeerror_create_object(zend_class_entry *class_ty
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_writeerror_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {
@@ -194,7 +218,11 @@ HashTable *php_phongo_writeerror_get_debug_info(zval *object, int *is_temp TSRML
 	intern = Z_WRITEERROR_OBJ_P(object);
 
 	array_init_size(&retval, 3);
+#if PHP_VERSION_ID >= 70000
+        add_assoc_string_ex(&retval, ZEND_STRS("message"), intern->message);
+#else
 	add_assoc_string_ex(&retval, ZEND_STRS("message"), intern->message, 1);
+#endif
 	add_assoc_long_ex(&retval, ZEND_STRS("code"), intern->code);
 	add_assoc_long_ex(&retval, ZEND_STRS("index"), intern->index);
 	if (intern->info) {

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -406,6 +406,22 @@ static void php_phongo_writeresult_free_object(void *object TSRMLS_DC) /* {{{ */
 	efree(intern);
 } /* }}} */
 
+#if PHP_VERSION_ID >= 70000
+zend_object* php_phongo_writeresult_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+{
+        php_phongo_writeresult_t *intern;
+
+        intern = (php_phongo_writeresult_t *)ecalloc(1, sizeof(php_phongo_writeresult_t)+zend_object_properties_size(class_type));
+
+        zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+        object_properties_init(&intern->std, class_type);
+
+        _mongoc_write_result_init(&intern->write_result);
+        intern->std.handlers = &php_phongo_handler_writeresult;
+
+        return &intern->std;
+}
+#else
 zend_object_value php_phongo_writeresult_create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
 {
 	zend_object_value retval;
@@ -423,6 +439,7 @@ zend_object_value php_phongo_writeresult_create_object(zend_class_entry *class_t
 
 	return retval;
 } /* }}} */
+#endif
 
 HashTable *php_phongo_writeresult_get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 {

--- a/src/bson.c
+++ b/src/bson.c
@@ -186,8 +186,11 @@ void php_phongo_bson_visit_corrupt(const bson_iter_t *iter ARG_UNUSED, void *dat
 	zval *retval = ((php_phongo_bson_state *)data)->zchild;
 
 	mongoc_log(MONGOC_LOG_LEVEL_TRACE, MONGOC_LOG_DOMAIN, "Corrupt BSON data detected!");
-
+#if PHP_VERSION_ID >= 70000
+	zval_ptr_dtor(retval);
+#else
 	zval_ptr_dtor(&retval);
+#endif
 }
 /* }}} */
 bool php_phongo_bson_visit_double(const bson_iter_t *iter ARG_UNUSED, const char *key, double v_double, void *data) /* {{{ */
@@ -902,8 +905,9 @@ PHONGO_API void zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *
 #endif
 		int          hash_type = HASH_KEY_NON_EXISTENT;
 #if PHP_VERSION_ID >= 70000
+		hash_type = zend_hash_get_current_key_ex(ht_data, &zs_key, &index, &pos);
 #else
-		hash_type = zend_hash_get_current_key_ex(ht_data, &zs_key, &index, 0, &pos);
+		hash_type = zend_hash_get_current_key_ex(ht_data, &key, &key_len, &index, 0, &pos);
 #endif
 
 		if (hash_type == HASH_KEY_NON_EXISTENT) {

--- a/src/bson.c
+++ b/src/bson.c
@@ -222,7 +222,7 @@ bool php_phongo_bson_visit_binary(const bson_iter_t *iter ARG_UNUSED, const char
 
 	if (v_subtype == 0x80 && strcmp(key, PHONGO_ODM_FIELD_NAME) == 0) {
 #if PHP_VERSION_ID >= 70000
-                zend_string *zs_classname = zend_string_init((char *)v_binary, v_binary_len, 0);
+                zend_string *zs_classname = zend_string_init((const char *)v_binary, v_binary_len, 0);
                 zend_class_entry *found_ce = zend_fetch_class(zs_classname, ZEND_FETCH_CLASS_AUTO|ZEND_FETCH_CLASS_SILENT TSRMLS_CC);
                 zend_string_free(zs_classname);
 #else
@@ -877,10 +877,8 @@ PHONGO_API void zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *
 				if (instanceof_function(Z_OBJCE_P(data), php_phongo_persistable_ce TSRMLS_CC)) {
 					if (flags & PHONGO_BSON_ADD_ODS) {
 #if PHP_VERSION_ID >= 70000
-						zend_string* field_name = zend_string_init(PHONGO_ODM_FIELD_NAME, sizeof(PHONGO_ODM_FIELD_NAME)-1, 0);
 						bson_append_binary(bson, PHONGO_ODM_FIELD_NAME, -1, 0x80, (const uint8_t *)ZSTR_VAL(Z_OBJCE_P(data)->name), ZSTR_LEN(Z_OBJCE_P(data)->name));
-                                                zend_hash_del(ht_data, field_name);
-						zend_string_free(field_name);
+                                                zend_hash_str_del(ht_data, PHONGO_ODM_FIELD_NAME, sizeof(PHONGO_ODM_FIELD_NAME)-1);
 #else
 						bson_append_binary(bson, PHONGO_ODM_FIELD_NAME, -1, 0x80, (const uint8_t *)Z_OBJCE_P(data)->name, strlen(Z_OBJCE_P(data)->name));
 						zend_hash_del(ht_data, PHONGO_ODM_FIELD_NAME, sizeof(PHONGO_ODM_FIELD_NAME));

--- a/src/bson.c
+++ b/src/bson.c
@@ -659,8 +659,7 @@ void object_to_bson(zval *object, php_phongo_bson_flags_t flags, const char *key
 			}
 
 			if (Z_TYPE_P(obj_data) != IS_ARRAY && !(Z_TYPE_P(obj_data) == IS_OBJECT && instanceof_function(Z_OBJCE_P(obj_data), zend_standard_class_def TSRMLS_CC))) {
-                                //TODO-PB
-				//phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Expected %s::%s() to return an array or stdClass, %s given", Z_OBJCE_P(object)->name, BSON_SERIALIZE_FUNC_NAME, (Z_TYPE_P(obj_data) == IS_OBJECT ? Z_OBJCE_P(obj_data)->name : zend_get_type_by_const(Z_TYPE_P(obj_data))));
+				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Expected %s::%s() to return an array or stdClass, %s given", Z_OBJCE_P(object)->name, BSON_SERIALIZE_FUNC_NAME, (Z_TYPE_P(obj_data) == IS_OBJECT ? Z_OBJCE_P(obj_data)->name : zend_get_type_by_const(Z_TYPE_P(obj_data))));
 #if PHP_VERSION_ID >= 70000
                                 zval_ptr_dtor(obj_data);
 #else
@@ -682,8 +681,7 @@ void object_to_bson(zval *object, php_phongo_bson_flags_t flags, const char *key
 				bson_append_document_begin(bson, key, key_len, &child);
 				if (instanceof_function(Z_OBJCE_P(object), php_phongo_persistable_ce TSRMLS_CC)) {
 					if (flags & PHONGO_BSON_ADD_CHILD_ODS) {
-                                                //TODO-PB
-						//bson_append_binary(&child, PHONGO_ODM_FIELD_NAME, -1, 0x80, (const uint8_t *)Z_OBJCE_P(object)->name, strlen(Z_OBJCE_P(object)->name));
+						bson_append_binary(&child, PHONGO_ODM_FIELD_NAME, -1, 0x80, (const uint8_t *)Z_OBJCE_P(object)->name, strlen(Z_OBJCE_P(object)->name));
 					}
 				}
 				zval_to_bson(obj_data, flags, &child, NULL TSRMLS_CC);
@@ -852,8 +850,7 @@ PHONGO_API void zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *
 				}
 
 				if (Z_TYPE_P(obj_data) != IS_ARRAY && !(Z_TYPE_P(obj_data) == IS_OBJECT && instanceof_function(Z_OBJCE_P(obj_data), zend_standard_class_def TSRMLS_CC))) {
-                                        //TODO-PB
-					//phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Expected %s::%s() to return an array or stdClass, %s given", Z_OBJCE_P(data)->name, BSON_SERIALIZE_FUNC_NAME, (Z_TYPE_P(obj_data) == IS_OBJECT ? Z_OBJCE_P(obj_data)->name : zend_get_type_by_const(Z_TYPE_P(obj_data))));
+					phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE TSRMLS_CC, "Expected %s::%s() to return an array or stdClass, %s given", Z_OBJCE_P(data)->name, BSON_SERIALIZE_FUNC_NAME, (Z_TYPE_P(obj_data) == IS_OBJECT ? Z_OBJCE_P(obj_data)->name : zend_get_type_by_const(Z_TYPE_P(obj_data))));
 
 					break;
 				}
@@ -862,9 +859,8 @@ PHONGO_API void zval_to_bson(zval *data, php_phongo_bson_flags_t flags, bson_t *
 
 				if (instanceof_function(Z_OBJCE_P(data), php_phongo_persistable_ce TSRMLS_CC)) {
 					if (flags & PHONGO_BSON_ADD_ODS) {
-                                                //TODO-PB
-						//bson_append_binary(bson, PHONGO_ODM_FIELD_NAME, -1, 0x80, (const uint8_t *)Z_OBJCE_P(data)->name, strlen(Z_OBJCE_P(data)->name));
-						//zend_hash_del(ht_data, PHONGO_ODM_FIELD_NAME, sizeof(PHONGO_ODM_FIELD_NAME));
+						bson_append_binary(bson, PHONGO_ODM_FIELD_NAME, -1, 0x80, (const uint8_t *)Z_OBJCE_P(data)->name, strlen(Z_OBJCE_P(data)->name));
+						zend_hash_del(ht_data, PHONGO_ODM_FIELD_NAME, sizeof(PHONGO_ODM_FIELD_NAME));
 					}
 				}
 


### PR DESCRIPTION
This pull change the create_object prototypes for the object classes so that they should work with the new PHP7 create_object prototype as well as a few other miscellaneous changes to the files to compile against PHP7. 