### PR TITLE
PHPC-2381: Allow releasing pre-release versions through the release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "The version to be released. This is checked for consistency with the branch name and configuration"
+        description: "The version to be released in PECL format (e.g. 1.19.1, 1.20.0beta1)"
         required: true
         type: "string"
       jira-version-number:
@@ -76,31 +76,12 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
 
-      - name: "Update version information to stable release"
-        run: ./bin/update-release-version.php to-stable
-
-      - name: "Read current package version"
-        run: echo "PACKAGE_VERSION=$(./bin/update-release-version.php get-version)" >> "$GITHUB_ENV"
-
-      # Sanity check - the version from the input and the one determined by phongo_version.h need to be the same
-      - name: "Check version for consistency"
-        if: ${{ inputs.version != env.PACKAGE_VERSION }}
-        # We exit with an error to abort the workflow. This is only run if the versions don't match
-        run: |
-          echo '❌ Release failed due to version mismatch: expected ${{ inputs.version }}, got ${{ env.PACKAGE_VERSION }} from code' >> $GITHUB_STEP_SUMMARY
-          exit 1
-
-      #
-      # Preliminary checks done - commence the release process
-      #
-
       - name: "Create package commit"
         uses: mongodb-labs/drivers-github-tools/bump-version@v2
         with:
           version: ${{ inputs.version }}
-          # Use get-version as a dummy as a version_bump_script is required
-          # We run the bump script manually earlier so we can sanity-check the version number and print nice output
-          version_bump_script: "./bin/update-release-version.php get-version"
+          # Note: this script will fail and abort if the requested version can't be released
+          version_bump_script: "./bin/update-release-version.php release"
           commit_template: 'Package ${VERSION}'
           # Don't push changes as we're creating a second commit later
           push_commit: false
@@ -117,7 +98,7 @@ jobs:
         uses: mongodb-labs/drivers-github-tools/bump-version@v2
         with:
           version: ${{ inputs.version }}
-          version_bump_script: "./bin/update-release-version.php to-next-patch-dev"
+          version_bump_script: "./bin/update-release-version.php to-next-dev"
           commit_template: 'Back to -dev'
           # Don't push commit, we still need to merge up
           push_commit: false
@@ -155,7 +136,11 @@ jobs:
           EOL
 
       - name: "Create draft release"
-        run: echo "RELEASE_URL=$(gh release create ${{ inputs.version }} --target ${{ github.ref_name }} --title "${{ inputs.version }}" --notes-file release-message --draft)" >> "$GITHUB_ENV"
+        run: |
+          if [[ "${{ inputs.version }}" =~ (alpha|beta) ]]; then
+            PRERELEASE="--prerelease --latest=false"
+          fi
+          echo "RELEASE_URL=$(gh release create ${{ inputs.version }} ${PRERELEASE} --target ${{ github.ref_name }} --title "${{ inputs.version }}" --notes-file release-message --draft)" >> "$GITHUB_ENV"
 
       - name: "Set summary"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: "Create draft release"
         run: |
-          if [[ "${{ inputs.version }}" =~ (alpha|beta) ]]; then
+          if [[ "${{ inputs.version }}" =~ (alpha|beta|RC) ]]; then
             PRERELEASE="--prerelease --latest=false"
           fi
           echo "RELEASE_URL=$(gh release create ${{ inputs.version }} ${PRERELEASE} --target ${{ github.ref_name }} --title "${{ inputs.version }}" --notes-file release-message --draft)" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,13 @@ jobs:
       contents: write
 
     steps:
+      - name: "Check version number format"
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+((alpha|beta|RC)[0-9]+)?$ ]]; then
+            echo '❌ Version ${{ inputs.version }} does not match expected format' >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
       - name: "Create release output"
         run: echo '🎬 Release process for version ${{ inputs.version }} started by @${{ github.triggering_actor }}' >> $GITHUB_STEP_SUMMARY
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -82,14 +82,6 @@ in the MongoDB documentation must be updated to account for new releases. Make
 sure to update both MongoDB and Language compatibility tables, as shown in
 [this pull request](https://github.com/mongodb/docs-ecosystem/pull/642).
 
-## Handle merge-up pull request
-
-After the release automation pushes changes to the stable branch the release was
-created from, the merge automation will create a new pull request to merge these
-changes into the next versioned branch. Since version changes always create a
-conflict, follow the "Ignoring Changes" section in the pull request to resolve
-the conflicts and merge the pull request once the build completes.
-
 ## Announce release
 
 Significant release announcements should also be posted in the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,10 +46,17 @@ enter the version number and the corresponding JIRA version ID for the release.
 This version ID can be obtained from a link in the "Version" column on the
 [PHPC releases page](https://jira.mongodb.org/projects/PHPC?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased).
 
-The automation will then create and push the necessary commits and tag, create a
-draft release, and trigger the packaging builds for the newly created tag. The
-release is created in a draft state and can be published once the release notes
-have been updated.
+The automation will create and push the necessary commits and tag, create a
+draft release, trigger the packaging builds for the newly created tag, and
+publish all required SSDLC assets. The release is created in a draft state and
+can be published once the release notes have been updated.
+
+Pre-releases (e.g. alpha and beta stability) can be released using the
+automation as well. When entering a pre-release version number, make sure to not
+include a dash before the stability, e.g. `1.20.0beta1` not `1.20.0-beta1`. PECL
+versions do not include a dash before the stability. GitHub Releases for
+pre-release versions will be marked as such and will not be marked as "latest"
+release.
 
 Alternatively, you may follow the [manual release process](#manual-release-process)
 before continuing with the next section.


### PR DESCRIPTION
PHPC-2381

This PR adds support for alpha and beta releases in the automated release tool. Note that since PECL doesn't have a stability constant for release candidates, so I haven't yet added support for them. However, it should be easy enough to add in case we want to do so.

This changes the version flow in `phongo_version.h` slightly. When setting the version information for a release (i.e. the "Package x.y.z" commit), the update-version tool exclusively uses the version given in the prompt. This version needs to be in valid PEAR version format, which omits a dash before the stability (e.g. `1.20.0alpha1` instead of `1.20.0-alpha1`). The update-version tool also expects the release version to match the information already in phongo_version.h. For example, if the version is `1.19.4dev`, it will only be able to release `1.19.4` including its pre-releases. Any other versions will yield an error.

After the release is done, the version is updated to the next version depending on the stability. For stable releases, the version is bumped to the next patch release. For all other stabilities, the release version is set back to a dev version of the same number, but the build number is increased. For example:
* `1.19.4` becomes `1.19.5dev`, with the build number reset to 0
* `1.19.4alpha1` or `1.19.4beta1` become `1.19.4dev` with the build number increased

I've tested creating an alpha and a beta release and things work as expected 👍 