### PR TITLE
Update merge-up config

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -28,5 +28,5 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
           branchNamePattern: 'v<major>.<minor>'
-          fallbackBranch: 'master'
+          devBranchNamePattern: 'v<major>.x'
           enableAutoMerge: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
           branchNamePattern: 'v<major>.<minor>'
-          fallbackBranch: 'master'
+          devBranchNamePattern: 'v<major>.x'
 
       - name: "Manually merge up changes"
         if: ${{ steps.get-next-branch.outputs.hasNextBranch }}


### PR DESCRIPTION
This PR updates the configuration for the merge-up workflow. The fallback branch is no longer needed, instead we use `devBranchNamePattern` set to `v<major>.x`.