### PR TITLE
PHPC-2350: Implement JSON methods for PackedArray

### DIFF
--- a/src/BSON/PackedArray.c
+++ b/src/BSON/PackedArray.c
@@ -129,7 +129,9 @@ static PHP_METHOD(MongoDB_BSON_PackedArray, fromJSON)
 	// Check if BSON contains only numeric keys
 	if (!bson_empty(bson)) {
 		bson_iter_t iter;
-		uint64_t    expected_key = 0;
+		uint32_t    expected_key = 0;
+		char        expected_key_str[11];
+		const char* key_str;
 
 		if (!bson_iter_init(&iter, bson)) {
 			phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE, "Received invalid JSON array");
@@ -138,12 +140,11 @@ static PHP_METHOD(MongoDB_BSON_PackedArray, fromJSON)
 		}
 
 		while (bson_iter_next(&iter)) {
-			const char* string_key = bson_iter_key(&iter);
-			char*       string_key_end;
-			uint64_t    int_key = strtoll(string_key, &string_key_end, 10);
+			key_str = bson_iter_key(&iter);
+			snprintf(expected_key_str, sizeof(expected_key_str), "%" PRIu32, expected_key);
 
-			if (*string_key_end != '\0' || int_key != expected_key) {
-				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE, "Received invalid JSON array: expected key %" PRId64 ", but found \"%s\"", expected_key, string_key);
+			if (strcmp(key_str, expected_key_str)) {
+				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE, "Received invalid JSON array: expected key %" PRIu32 ", but found \"%s\"", expected_key, key_str);
 				bson_destroy(bson);
 				return;
 			}

--- a/src/BSON/PackedArray.stub.php
+++ b/src/BSON/PackedArray.stub.php
@@ -11,6 +11,8 @@ final class PackedArray implements \IteratorAggregate, \Serializable, \ArrayAcce
 {
     private function __construct() {}
 
+    final static public function fromJSON(string $json): PackedArray {}
+
     final static public function fromPHP(array $value): PackedArray {}
 
 #if PHP_VERSION_ID >= 80000
@@ -30,6 +32,10 @@ final class PackedArray implements \IteratorAggregate, \Serializable, \ArrayAcce
     /** @return array|object */
     final public function toPHP(?array $typeMap = null) {}
 #endif
+
+    final public function toCanonicalExtendedJSON(): string {}
+
+    final public function toRelaxedExtendedJSON(): string {}
 
 #if PHP_VERSION_ID >= 80000
     public function offsetExists(mixed $offset): bool {}

--- a/src/BSON/PackedArray_arginfo.h
+++ b/src/BSON/PackedArray_arginfo.h
@@ -1,7 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: db49af73e3b8ef35fa6ed70fd8c097e0de69f17e */
+ * Stub hash: 792eeecef52e338fc07db86926729eecc024885a */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray___construct, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_fromJSON, 0, 1, MongoDB\\BSON\\PackedArray, 0)
+	ZEND_ARG_TYPE_INFO(0, json, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_fromPHP, 0, 1, MongoDB\\BSON\\PackedArray, 0)
@@ -38,6 +42,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_toPHP, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, typeMap, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_toCanonicalExtendedJSON, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_MongoDB_BSON_PackedArray_toRelaxedExtendedJSON arginfo_class_MongoDB_BSON_PackedArray_toCanonicalExtendedJSON
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_offsetExists, 0, 1, _IS_BOOL, 0)
@@ -89,14 +98,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_o
 ZEND_END_ARG_INFO()
 #endif
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray___toString, 0, 0, IS_STRING, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_MongoDB_BSON_PackedArray___toString arginfo_class_MongoDB_BSON_PackedArray_toCanonicalExtendedJSON
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray___set_state, 0, 1, MongoDB\\BSON\\PackedArray, 0)
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_MongoDB_BSON_PackedArray_serialize arginfo_class_MongoDB_BSON_PackedArray___toString
+#define arginfo_class_MongoDB_BSON_PackedArray_serialize arginfo_class_MongoDB_BSON_PackedArray_toCanonicalExtendedJSON
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray_unserialize, 0, 1, IS_VOID, 0)
@@ -119,6 +127,7 @@ ZEND_END_ARG_INFO()
 
 
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __construct);
+static ZEND_METHOD(MongoDB_BSON_PackedArray, fromJSON);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, fromPHP);
 #if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_PackedArray, get);
@@ -134,6 +143,8 @@ static ZEND_METHOD(MongoDB_BSON_PackedArray, toPHP);
 #if !(PHP_VERSION_ID >= 80000)
 static ZEND_METHOD(MongoDB_BSON_PackedArray, toPHP);
 #endif
+static ZEND_METHOD(MongoDB_BSON_PackedArray, toCanonicalExtendedJSON);
+static ZEND_METHOD(MongoDB_BSON_PackedArray, toRelaxedExtendedJSON);
 #if PHP_VERSION_ID >= 80000
 static ZEND_METHOD(MongoDB_BSON_PackedArray, offsetExists);
 #endif
@@ -173,6 +184,7 @@ static ZEND_METHOD(MongoDB_BSON_PackedArray, __serialize);
 
 static const zend_function_entry class_MongoDB_BSON_PackedArray_methods[] = {
 	ZEND_ME(MongoDB_BSON_PackedArray, __construct, arginfo_class_MongoDB_BSON_PackedArray___construct, ZEND_ACC_PRIVATE)
+	ZEND_ME(MongoDB_BSON_PackedArray, fromJSON, arginfo_class_MongoDB_BSON_PackedArray_fromJSON, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_BSON_PackedArray, fromPHP, arginfo_class_MongoDB_BSON_PackedArray_fromPHP, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_PackedArray, get, arginfo_class_MongoDB_BSON_PackedArray_get, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -188,6 +200,8 @@ static const zend_function_entry class_MongoDB_BSON_PackedArray_methods[] = {
 #if !(PHP_VERSION_ID >= 80000)
 	ZEND_ME(MongoDB_BSON_PackedArray, toPHP, arginfo_class_MongoDB_BSON_PackedArray_toPHP, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #endif
+	ZEND_ME(MongoDB_BSON_PackedArray, toCanonicalExtendedJSON, arginfo_class_MongoDB_BSON_PackedArray_toCanonicalExtendedJSON, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	ZEND_ME(MongoDB_BSON_PackedArray, toRelaxedExtendedJSON, arginfo_class_MongoDB_BSON_PackedArray_toRelaxedExtendedJSON, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 #if PHP_VERSION_ID >= 80000
 	ZEND_ME(MongoDB_BSON_PackedArray, offsetExists, arginfo_class_MongoDB_BSON_PackedArray_offsetExists, ZEND_ACC_PUBLIC)
 #endif

--- a/tests/bson/bson-packedarray-fromJSON-001.phpt
+++ b/tests/bson/bson-packedarray-fromJSON-001.phpt
@@ -1,0 +1,37 @@
+--TEST--
+MongoDB\BSON\PackedArray::fromJSON(): Decoding JSON
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$tests = [
+    '[]',
+    '[ 1, 2, 3 ]',
+    '[[ 1, 2, 3 ]]',
+    '[{ "bar": 1 }]',
+];
+
+foreach ($tests as $json) {
+    printf("Test %s\n", $json);
+    $bson = MongoDB\BSON\PackedArray::fromJSON($json);
+    hex_dump((string) $bson);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Test []
+     0 : 05 00 00 00 00                                   [.....]
+Test [ 1, 2, 3 ]
+     0 : 1a 00 00 00 10 30 00 01 00 00 00 10 31 00 02 00  [.....0......1...]
+    10 : 00 00 10 32 00 03 00 00 00 00                    [...2......]
+Test [[ 1, 2, 3 ]]
+     0 : 22 00 00 00 04 30 00 1a 00 00 00 10 30 00 01 00  ["....0......0...]
+    10 : 00 00 10 31 00 02 00 00 00 10 32 00 03 00 00 00  [...1......2.....]
+    20 : 00 00                                            [..]
+Test [{ "bar": 1 }]
+     0 : 16 00 00 00 03 30 00 0e 00 00 00 10 62 61 72 00  [.....0......bar.]
+    10 : 01 00 00 00 00 00                                [......]
+===DONE===

--- a/tests/bson/bson-packedarray-fromJSON-002.phpt
+++ b/tests/bson/bson-packedarray-fromJSON-002.phpt
@@ -1,0 +1,50 @@
+--TEST--
+MongoDB\BSON\PackedArray::fromJSON(): Decoding extended JSON types
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$tests = [
+    '[{ "$oid": "56315a7c6118fd1b920270b1" }]',
+    '[{ "$binary": "Zm9v", "$type": "00" }]',
+    '[{ "$date": "2015-10-28T00:00:00Z" }]',
+    '[{ "$timestamp": { "t": 1446084619, "i": 0 }}]',
+    '[{ "$regex": "pattern", "$options": "i" }]',
+    '[{ "$undefined": true }]',
+    '[{ "$minKey": 1 }]',
+    '[{ "$maxKey": 1 }]',
+    '[{ "$numberLong": "1234" }]',
+];
+
+foreach ($tests as $json) {
+    printf("Test %s\n", $json);
+    $bson = MongoDB\BSON\PackedArray::fromJSON($json);
+    hex_dump((string) $bson);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Test [{ "$oid": "56315a7c6118fd1b920270b1" }]
+     0 : 14 00 00 00 07 30 00 56 31 5a 7c 61 18 fd 1b 92  [.....0.V1Z|a....]
+    10 : 02 70 b1 00                                      [.p..]
+Test [{ "$binary": "Zm9v", "$type": "00" }]
+     0 : 10 00 00 00 05 30 00 03 00 00 00 00 66 6f 6f 00  [.....0......foo.]
+Test [{ "$date": "2015-10-28T00:00:00Z" }]
+     0 : 10 00 00 00 09 30 00 00 80 be ab 50 01 00 00 00  [.....0.....P....]
+Test [{ "$timestamp": { "t": 1446084619, "i": 0 }}]
+     0 : 10 00 00 00 11 30 00 00 00 00 00 0b 80 31 56 00  [.....0.......1V.]
+Test [{ "$regex": "pattern", "$options": "i" }]
+     0 : 12 00 00 00 0b 30 00 70 61 74 74 65 72 6e 00 69  [.....0.pattern.i]
+    10 : 00 00                                            [..]
+Test [{ "$undefined": true }]
+     0 : 08 00 00 00 06 30 00 00                          [.....0..]
+Test [{ "$minKey": 1 }]
+     0 : 08 00 00 00 ff 30 00 00                          [.....0..]
+Test [{ "$maxKey": 1 }]
+     0 : 08 00 00 00 7f 30 00 00                          [.....0..]
+Test [{ "$numberLong": "1234" }]
+     0 : 10 00 00 00 12 30 00 d2 04 00 00 00 00 00 00 00  [.....0..........]
+===DONE===

--- a/tests/bson/bson-packedarray-fromJSON_error-001.phpt
+++ b/tests/bson/bson-packedarray-fromJSON_error-001.phpt
@@ -13,6 +13,10 @@ echo throws(function() {
     MongoDB\BSON\PackedArray::fromJSON('{ "foo": "bar" }');
 }, 'MongoDB\Driver\Exception\UnexpectedValueException'), PHP_EOL;
 
+echo throws(function() {
+    MongoDB\BSON\PackedArray::fromJSON('{ "00": "bar", "1": "bar" }');
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), PHP_EOL;
+
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -21,4 +25,6 @@ OK: Got MongoDB\Driver\Exception\UnexpectedValueException
 Got parse error at "o", position 1: "SPECIAL_EXPECTED"
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException
 Received invalid JSON array: expected key 0, but found "foo"
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+Received invalid JSON array: expected key 0, but found "00"
 ===DONE===

--- a/tests/bson/bson-packedarray-fromJSON_error-001.phpt
+++ b/tests/bson/bson-packedarray-fromJSON_error-001.phpt
@@ -17,6 +17,10 @@ echo throws(function() {
     MongoDB\BSON\PackedArray::fromJSON('{ "00": "bar", "1": "bar" }');
 }, 'MongoDB\Driver\Exception\UnexpectedValueException'), PHP_EOL;
 
+echo throws(function() {
+    MongoDB\BSON\PackedArray::fromJSON('{ "0": "bar", "foo": "bar" }');
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), PHP_EOL;
+
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -27,4 +31,6 @@ OK: Got MongoDB\Driver\Exception\UnexpectedValueException
 Received invalid JSON array: expected key 0, but found "foo"
 OK: Got MongoDB\Driver\Exception\UnexpectedValueException
 Received invalid JSON array: expected key 0, but found "00"
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+Received invalid JSON array: expected key 1, but found "foo"
 ===DONE===

--- a/tests/bson/bson-packedarray-fromJSON_error-001.phpt
+++ b/tests/bson/bson-packedarray-fromJSON_error-001.phpt
@@ -1,0 +1,24 @@
+--TEST--
+MongoDB\BSON\PackedArray::fromJSON(): invalid JSON
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+echo throws(function() {
+    MongoDB\BSON\PackedArray::fromJSON('foo');
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), PHP_EOL;
+
+echo throws(function() {
+    MongoDB\BSON\PackedArray::fromJSON('{ "foo": "bar" }');
+}, 'MongoDB\Driver\Exception\UnexpectedValueException'), PHP_EOL;
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+Got parse error at "o", position 1: "SPECIAL_EXPECTED"
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+Received invalid JSON array: expected key 0, but found "foo"
+===DONE===

--- a/tests/bson/bson-packedarray-toCanonicalExtendedJSON-001.phpt
+++ b/tests/bson/bson-packedarray-toCanonicalExtendedJSON-001.phpt
@@ -1,0 +1,41 @@
+--TEST--
+MongoDB\BSON\PackedArray::toCanonicalExtendedJSON(): Encoding JSON
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$tests = [
+    [],
+    [ null ],
+    [ true ],
+    [ 'foo' ],
+    [ 123 ],
+    [ 1.0, ],
+    [ NAN ],
+    [ INF ],
+    [ -INF ],
+    [ [ 'foo', 'bar' ]],
+    [ [ 'foo' => 'bar' ]],
+];
+
+foreach ($tests as $value) {
+    echo MongoDB\BSON\PackedArray::fromPHP($value)->toCanonicalExtendedJSON(), "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+[ ]
+[ null ]
+[ true ]
+[ "foo" ]
+[ { "$numberInt" : "123" } ]
+[ { "$numberDouble" : "1.0" } ]
+[ { "$numberDouble" : "NaN" } ]
+[ { "$numberDouble" : "Infinity" } ]
+[ { "$numberDouble" : "-Infinity" } ]
+[ [ "foo", "bar" ] ]
+[ { "foo" : "bar" } ]
+===DONE===

--- a/tests/bson/bson-packedarray-toCanonicalJSON-002.phpt
+++ b/tests/bson/bson-packedarray-toCanonicalJSON-002.phpt
@@ -1,0 +1,37 @@
+--TEST--
+MongoDB\BSON\PackedArray::toCanonicalExtendedJSON(): Encoding extended JSON types
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$tests = [
+    [new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
+    [new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
+    [new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [new MongoDB\BSON\Timestamp(1234, 5678) ],
+    [new MongoDB\BSON\Regex('pattern', 'i') ],
+    [new MongoDB\BSON\Javascript('function() { return 1; }') ],
+    [new MongoDB\BSON\Javascript('function() { return a; }', ['a' => 1]) ],
+    [new MongoDB\BSON\MinKey ],
+    [new MongoDB\BSON\MaxKey ],
+];
+
+foreach ($tests as $value) {
+    echo MongoDB\BSON\PackedArray::fromPHP($value)->toCanonicalExtendedJSON(), "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+[ { "$oid" : "56315a7c6118fd1b920270b1" } ]
+[ { "$binary" : { "base64" : "Zm9v", "subType" : "00" } } ]
+[ { "$date" : { "$numberLong" : "1445990400000" } } ]
+[ { "$timestamp" : { "t" : 5678, "i" : 1234 } } ]
+[ { "$regularExpression" : { "pattern" : "pattern", "options" : "i" } } ]
+[ { "$code" : "function() { return 1; }" } ]
+[ { "$code" : "function() { return a; }", "$scope" : { "a" : { "$numberInt" : "1" } } } ]
+[ { "$minKey" : 1 } ]
+[ { "$maxKey" : 1 } ]
+===DONE===

--- a/tests/bson/bson-packedarray-toRelaxedExtendedJSON-001.phpt
+++ b/tests/bson/bson-packedarray-toRelaxedExtendedJSON-001.phpt
@@ -1,0 +1,41 @@
+--TEST--
+MongoDB\BSON\PackedArray::toRelaxedExtendedJSON(): Encoding JSON
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$tests = [
+    [],
+    [ null ],
+    [ true ],
+    [ 'foo' ],
+    [ 123 ],
+    [ 1.0, ],
+    [ NAN ],
+    [ INF ],
+    [ -INF ],
+    [ [ 'foo', 'bar' ]],
+    [ [ 'foo' => 'bar' ]],
+];
+
+foreach ($tests as $value) {
+    echo MongoDB\BSON\PackedArray::fromPHP($value)->toRelaxedExtendedJSON(), "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+[ ]
+[ null ]
+[ true ]
+[ "foo" ]
+[ 123 ]
+[ 1.0 ]
+[ { "$numberDouble" : "NaN" } ]
+[ { "$numberDouble" : "Infinity" } ]
+[ { "$numberDouble" : "-Infinity" } ]
+[ [ "foo", "bar" ] ]
+[ { "foo" : "bar" } ]
+===DONE===

--- a/tests/bson/bson-packedarray-toRelaxedExtendedJSON-002.phpt
+++ b/tests/bson/bson-packedarray-toRelaxedExtendedJSON-002.phpt
@@ -1,0 +1,37 @@
+--TEST--
+MongoDB\BSON\PackedArray::toRelaxedExtendedJSON(): Encoding extended JSON types
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$tests = [
+    [ new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
+    [ new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
+    [ new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [ new MongoDB\BSON\Timestamp(1234, 5678) ],
+    [ new MongoDB\BSON\Regex('pattern', 'i') ],
+    [ new MongoDB\BSON\Javascript('function() { return 1; }') ],
+    [ new MongoDB\BSON\Javascript('function() { return a; }', ['a' => 1]) ],
+    [ new MongoDB\BSON\MinKey ],
+    [ new MongoDB\BSON\MaxKey ],
+];
+
+foreach ($tests as $value) {
+    echo MongoDB\BSON\PackedArray::fromPHP($value)->toRelaxedExtendedJSON(), "\n";
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+[ { "$oid" : "56315a7c6118fd1b920270b1" } ]
+[ { "$binary" : { "base64" : "Zm9v", "subType" : "00" } } ]
+[ { "$date" : "2015-10-28T00:00:00Z" } ]
+[ { "$timestamp" : { "t" : 5678, "i" : 1234 } } ]
+[ { "$regularExpression" : { "pattern" : "pattern", "options" : "i" } } ]
+[ { "$code" : "function() { return 1; }" } ]
+[ { "$code" : "function() { return a; }", "$scope" : { "a" : 1 } } ]
+[ { "$minKey" : 1 } ]
+[ { "$maxKey" : 1 } ]
+===DONE===


### PR DESCRIPTION
PHPC-2350

We can leverage `bson_new_from_json` to create a `bson_t` for an array, and `bson_as_json_with_opts` lets us export the `bson_t` to JSON with an array being the root object.

Note that since `bson_new_from_json` was intended to read documents, the resulting `PackedArray` instance will retain the original keys in the object, but iterating it or converting it to JSON will reindex the array. However, when using the `PackedArray` instance in certain ways will cause errors (see `bson-packedarray-fromJSON-003.phpt` which fails the last operation). The only option I see is to iterate the resulting `bson_t` and either re-index it (essentially re-writing a `bson_t` array) or to throw if one of the keys isn't what we expect. Since we have the mantra of "be lenient in what you accept, but strict in what you produce" I'm inclined to go with the first option, despite this potentially causing some overhead. WDYT @jmikola?