### PR TITLE
PHPC-2413: Use new distros for RHEL ppc and Z

### DIFF
--- a/.evergreen/config/build-variants.yml
+++ b/.evergreen/config/build-variants.yml
@@ -30,26 +30,26 @@ buildvariants:
     run_on: rhel90-small
     tasks:
       - name: "build-php-openssl3"
-  - name: build-rhel83-zseries
-    display_name: "Build: RHEL 8.3 Zseries"
+  - name: build-rhel8-zseries
+    display_name: "Build: RHEL 8 Zseries"
     tags: ["build", "rhel", "zseries", "tag"]
-    run_on: rhel83-zseries-small
+    run_on: rhel8-zseries-small
     tasks:
       - name: "build-all-php"
-  - name: build-rhel82-arm64
-    display_name: "Build: RHEL 8.2 ARM64"
+  - name: build-rhel8-arm64
+    display_name: "Build: RHEL 8 ARM64"
     tags: ["build", "rhel", "arm64", "tag"]
     run_on: rhel82-arm64
     tasks:
       - name: "build-all-php"
-  - name: build-rhel81-power8
-    display_name: "Build: RHEL 8.1 Power8"
+  - name: build-rhel8-power8
+    display_name: "Build: RHEL 8 Power8"
     tags: ["build", "rhel", "power8", "tag"]
-    run_on: rhel81-power8-large
+    run_on: rhel8-power-large
     tasks:
       - name: "build-all-php"
-  - name: build-rhel80
-    display_name: "Build: RHEL 8.0"
+  - name: build-rhel8
+    display_name: "Build: RHEL 8 x64"
     tags: ["build", "rhel", "x64", "pr", "tag"]
     run_on: rhel80-small
     tasks:


### PR DESCRIPTION
PHPC-2413

This PR migrates builds and tests from the old RHEL ZSeries/PPC hosts to the new ones. I've scheduled the builds for these new hosts in the evergreen patch definition for this PR.