### PR TITLE
PHPC-2140: Make tentative return types definitive

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -9,3 +9,9 @@ UPGRADE FROM 1.x to 2.0
  * The constants `MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW` and
    `MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW` have been 
    removed. Use the `ALGORITHM_RANGE` and `QUERY_TYPE_RANGE` instead.
+ * All tentative return types defined in interface and non-final classes are now
+   fixed and are required in implementing or extending classes.
+ * `MongoDB\Driver\CursorInterface` now extends `Iterator`, requiring 
+   implementing classes to also implement iterator methods. The return types for
+   the `key` and `current` methods have been narrowed to the types returned by
+   cursor instances.

--- a/src/BSON/BinaryInterface.stub.php
+++ b/src/BSON/BinaryInterface.stub.php
@@ -9,10 +9,8 @@ namespace MongoDB\BSON;
 
 interface BinaryInterface
 {
-    /** @tentative-return-type */
     public function getData(): string;
 
-    /** @tentative-return-type */
     public function getType(): int;
 
     public function __toString(): string;

--- a/src/BSON/BinaryInterface_arginfo.h
+++ b/src/BSON/BinaryInterface_arginfo.h
@@ -1,14 +1,13 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9177931b152386567f53fed87887207971acceaf */
+ * Stub hash: 48817588d8bad80ae873bb654842960e058e81a2 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_BinaryInterface_getData, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_BinaryInterface_getData, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_BinaryInterface_getType, 0, 0, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_BinaryInterface_getType, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_BinaryInterface___toString, 0, 0, IS_STRING, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_MongoDB_BSON_BinaryInterface___toString arginfo_class_MongoDB_BSON_BinaryInterface_getData
 
 
 

--- a/src/BSON/Decimal128Interface.stub.php
+++ b/src/BSON/Decimal128Interface.stub.php
@@ -9,6 +9,5 @@ namespace MongoDB\BSON;
 
 interface Decimal128Interface
 {
-    /** @tentative-return-type */
     public function __toString(): string;
 }

--- a/src/BSON/Decimal128Interface_arginfo.h
+++ b/src/BSON/Decimal128Interface_arginfo.h
@@ -1,7 +1,7 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d6d5d5cf0e586b9d76d208ea72b851da3cd37c34 */
+ * Stub hash: 629d35b8a42f119cefc5563eb015a1e0403b6ac7 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128Interface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128Interface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 

--- a/src/BSON/JavascriptInterface.stub.php
+++ b/src/BSON/JavascriptInterface.stub.php
@@ -9,12 +9,9 @@ namespace MongoDB\BSON;
 
 interface JavascriptInterface
 {
-    /** @tentative-return-type */
     public function getCode(): string;
 
-    /** @tentative-return-type */
     public function getScope(): ?object;
 
-    /** @tentative-return-type */
     public function __toString(): string;
 }

--- a/src/BSON/JavascriptInterface_arginfo.h
+++ b/src/BSON/JavascriptInterface_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 82f701e4bbef2f207a3058c7875991b7a61617a9 */
+ * Stub hash: d2335273fc900e95ba3ce8731fa241792beeec88 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_JavascriptInterface_getCode, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_JavascriptInterface_getCode, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_JavascriptInterface_getScope, 0, 0, IS_OBJECT, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_JavascriptInterface_getScope, 0, 0, IS_OBJECT, 1)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_JavascriptInterface___toString arginfo_class_MongoDB_BSON_JavascriptInterface_getCode

--- a/src/BSON/ObjectIdInterface.stub.php
+++ b/src/BSON/ObjectIdInterface.stub.php
@@ -9,9 +9,7 @@ namespace MongoDB\BSON;
 
 interface ObjectIdInterface
 {
-    /** @tentative-return-type */
     public function getTimestamp(): int;
 
-    /** @tentative-return-type */
     public function __toString(): string;
 }

--- a/src/BSON/ObjectIdInterface_arginfo.h
+++ b/src/BSON/ObjectIdInterface_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b68b5dcd9eb41216be44fbcd5fc80349e6fcefd0 */
+ * Stub hash: 918396361a59962098b767437a61efe5fa2ab259 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectIdInterface_getTimestamp, 0, 0, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectIdInterface_getTimestamp, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectIdInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectIdInterface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 

--- a/src/BSON/Persistable.stub.php
+++ b/src/BSON/Persistable.stub.php
@@ -9,6 +9,5 @@ namespace MongoDB\BSON;
 
 interface Persistable extends Serializable, Unserializable
 {
-    /** @tentative-return-type */
     public function bsonSerialize(): array|\stdClass|Document;
 }

--- a/src/BSON/Persistable_arginfo.h
+++ b/src/BSON/Persistable_arginfo.h
@@ -1,7 +1,7 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ae3ff5f618e86293cdbee0ce419fee2b82c95ed6 */
+ * Stub hash: 8a5634034ae5939cd0c182b80243b246e8bd8558 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Persistable_bsonSerialize, 0, 0, stdClass|MongoDB\\BSON\\Document, MAY_BE_ARRAY)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Persistable_bsonSerialize, 0, 0, stdClass|MongoDB\\BSON\\Document, MAY_BE_ARRAY)
 ZEND_END_ARG_INFO()
 
 

--- a/src/BSON/RegexInterface.stub.php
+++ b/src/BSON/RegexInterface.stub.php
@@ -9,12 +9,9 @@ namespace MongoDB\BSON;
 
 interface RegexInterface
 {
-    /** @tentative-return-type */
     public function getPattern(): string;
 
-    /** @tentative-return-type */
     public function getFlags(): string;
 
-    /** @tentative-return-type */
     public function __toString(): string;
 }

--- a/src/BSON/RegexInterface_arginfo.h
+++ b/src/BSON/RegexInterface_arginfo.h
@@ -1,7 +1,7 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 72a53fb51ca60f8ccb38a73afe74f76fb81bac71 */
+ * Stub hash: 3d2702dde50173adc1d9b3c69257814256f26173 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_RegexInterface_getPattern, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_RegexInterface_getPattern, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_RegexInterface_getFlags arginfo_class_MongoDB_BSON_RegexInterface_getPattern

--- a/src/BSON/Serializable.stub.php
+++ b/src/BSON/Serializable.stub.php
@@ -9,6 +9,5 @@ namespace MongoDB\BSON;
 
 interface Serializable extends Type
 {
-    /** @tentative-return-type */
     public function bsonSerialize(): array|\stdClass|Document|PackedArray;
 }

--- a/src/BSON/Serializable_arginfo.h
+++ b/src/BSON/Serializable_arginfo.h
@@ -1,7 +1,7 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cf790c4aaa9d12777681842564139008ec73218b */
+ * Stub hash: 0d23d26a86f14abf19f9fb44b350a134534df5ac */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, 0, 0, stdClass|MongoDB\\BSON\\Document|MongoDB\\BSON\\PackedArray, MAY_BE_ARRAY)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, 0, 0, stdClass|MongoDB\\BSON\\Document|MongoDB\\BSON\\PackedArray, MAY_BE_ARRAY)
 ZEND_END_ARG_INFO()
 
 

--- a/src/BSON/TimestampInterface.stub.php
+++ b/src/BSON/TimestampInterface.stub.php
@@ -9,12 +9,9 @@ namespace MongoDB\BSON;
 
 interface TimestampInterface
 {
-    /** @tentative-return-type */
     public function getTimestamp(): int;
 
-    /** @tentative-return-type */
     public function getIncrement(): int;
 
-    /** @tentative-return-type */
     public function __toString(): string;
 }

--- a/src/BSON/TimestampInterface_arginfo.h
+++ b/src/BSON/TimestampInterface_arginfo.h
@@ -1,12 +1,12 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2a749d00f223cb25242c2f3a303b183074f5841c */
+ * Stub hash: 6943cf9694dde756ed5ad2b7220c1c39e6157165 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_TimestampInterface_getTimestamp, 0, 0, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_TimestampInterface_getTimestamp, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_BSON_TimestampInterface_getIncrement arginfo_class_MongoDB_BSON_TimestampInterface_getTimestamp
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_TimestampInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_TimestampInterface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 

--- a/src/BSON/UTCDateTimeInterface.stub.php
+++ b/src/BSON/UTCDateTimeInterface.stub.php
@@ -9,9 +9,7 @@ namespace MongoDB\BSON;
 
 interface UTCDateTimeInterface
 {
-    /** @tentative-return-type */
     public function toDateTime(): \DateTime;
 
-    /** @tentative-return-type */
     public function __toString(): string;
 }

--- a/src/BSON/UTCDateTimeInterface_arginfo.h
+++ b/src/BSON/UTCDateTimeInterface_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d6725fe1f1e80ebc13fcc924b0a794b23b44c034 */
+ * Stub hash: e2b2ba7dbdda8c9a7bf9e73a2bb38435955d68b8 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTime, 0, 0, DateTime, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTime, 0, 0, DateTime, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTimeInterface___toString, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTimeInterface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 

--- a/src/BSON/Unserializable.stub.php
+++ b/src/BSON/Unserializable.stub.php
@@ -9,6 +9,5 @@ namespace MongoDB\BSON;
 
 interface Unserializable
 {
-    /** @tentative-return-type */
     public function bsonUnserialize(array $data): void;
 }

--- a/src/BSON/Unserializable_arginfo.h
+++ b/src/BSON/Unserializable_arginfo.h
@@ -1,7 +1,7 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2954181cca6d68d40bf46d5ffad15f3ccbc73b72 */
+ * Stub hash: b9746862d533c46cd8977bde20093fe92d8f4440 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Unserializable_bsonUnserialize, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Unserializable_bsonUnserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 

--- a/src/MongoDB/Cursor.stub.php
+++ b/src/MongoDB/Cursor.stub.php
@@ -14,7 +14,6 @@ final class Cursor implements CursorInterface
 
     public function current(): array|object|null {}
 
-    /** @tentative-return-type */
     final public function getId(bool $asInt64 = false): CursorId|\MongoDB\BSON\Int64 {}
 
     final public function getServer(): Server {}

--- a/src/MongoDB/CursorInterface.stub.php
+++ b/src/MongoDB/CursorInterface.stub.php
@@ -9,18 +9,13 @@ namespace MongoDB\Driver;
 
 interface CursorInterface extends \Iterator
 {
-    /** @tentative-return-type */
     public function getId(): CursorId|\MongoDB\BSON\Int64;
 
-    /** @tentative-return-type */
     public function getServer(): Server;
 
-    /** @tentative-return-type */
     public function isDead(): bool;
 
-    /** @tentative-return-type */
     public function setTypeMap(array $typemap): void;
 
-    /** @tentative-return-type */
     public function toArray(): array;
 }

--- a/src/MongoDB/CursorInterface.stub.php
+++ b/src/MongoDB/CursorInterface.stub.php
@@ -9,11 +9,15 @@ namespace MongoDB\Driver;
 
 interface CursorInterface extends \Iterator
 {
+    public function current(): array|object|null {}
+
     public function getId(): CursorId|\MongoDB\BSON\Int64;
 
     public function getServer(): Server;
 
     public function isDead(): bool;
+
+    public function key(): ?int;
 
     public function setTypeMap(array $typemap): void;
 

--- a/src/MongoDB/CursorInterface_arginfo.h
+++ b/src/MongoDB/CursorInterface_arginfo.h
@@ -1,5 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 71c9e3683a8febbea12d06536568667135a4a6c8 */
+ * Stub hash: 4503d323c3b7e45e21db5d48709c2a469e439a53 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_CursorInterface_current, 0, 0, MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_NULL)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_CursorInterface_getId, 0, 0, MongoDB\\Driver\\CursorId|MongoDB\\BSON\\Int64, 0)
 ZEND_END_ARG_INFO()
@@ -8,6 +11,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterf
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_isDead, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_key, 0, 0, IS_LONG, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_setTypeMap, 0, 1, IS_VOID, 0)
@@ -21,9 +27,11 @@ ZEND_END_ARG_INFO()
 
 
 static const zend_function_entry class_MongoDB_Driver_CursorInterface_methods[] = {
+	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, current, arginfo_class_MongoDB_Driver_CursorInterface_current, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, getId, arginfo_class_MongoDB_Driver_CursorInterface_getId, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, getServer, arginfo_class_MongoDB_Driver_CursorInterface_getServer, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, isDead, arginfo_class_MongoDB_Driver_CursorInterface_isDead, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, key, arginfo_class_MongoDB_Driver_CursorInterface_key, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, setTypeMap, arginfo_class_MongoDB_Driver_CursorInterface_setTypeMap, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, toArray, arginfo_class_MongoDB_Driver_CursorInterface_toArray, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_FE_END

--- a/src/MongoDB/CursorInterface_arginfo.h
+++ b/src/MongoDB/CursorInterface_arginfo.h
@@ -1,20 +1,20 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a349f3142a48084fd7359d202a6384b7927c2936 */
+ * Stub hash: 71c9e3683a8febbea12d06536568667135a4a6c8 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_CursorInterface_getId, 0, 0, MongoDB\\Driver\\CursorId|MongoDB\\BSON\\Int64, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_CursorInterface_getId, 0, 0, MongoDB\\Driver\\CursorId|MongoDB\\BSON\\Int64, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_getServer, 0, 0, MongoDB\\Driver\\Server, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_getServer, 0, 0, MongoDB\\Driver\\Server, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_isDead, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_isDead, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_setTypeMap, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_setTypeMap, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, typemap, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_toArray, 0, 0, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorInterface_toArray, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 

--- a/src/MongoDB/Cursor_arginfo.h
+++ b/src/MongoDB/Cursor_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 00390b38afb06e7361930fa5de69ca2bbfcc30d3 */
+ * Stub hash: 154a75fecea87014fd07315ddec5d9f182dcf768 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Cursor___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -7,7 +7,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_Cursor_current, 0, 0, MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_NULL)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_Cursor_getId, 0, 0, MongoDB\\Driver\\CursorId|MongoDB\\BSON\\Int64, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_Cursor_getId, 0, 0, MongoDB\\Driver\\CursorId|MongoDB\\BSON\\Int64, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, asInt64, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 

--- a/src/MongoDB/Manager.stub.php
+++ b/src/MongoDB/Manager.stub.php
@@ -18,15 +18,15 @@ final class Manager
 
     final public function executeBulkWrite(string $namespace, BulkWrite $bulk, array|WriteConcern|null $options = null): WriteResult {}
 
-    final public function executeCommand(string $db, Command $command, array|ReadPreference|null $options = null): Cursor {}
+    final public function executeCommand(string $db, Command $command, array|ReadPreference|null $options = null): CursorInterface {}
 
-    final public function executeQuery(string $namespace, Query $query, array|ReadPreference|null $options = null): Cursor {}
+    final public function executeQuery(string $namespace, Query $query, array|ReadPreference|null $options = null): CursorInterface {}
 
-    final public function executeReadCommand(string $db, Command $command, ?array $options = null): Cursor {}
+    final public function executeReadCommand(string $db, Command $command, ?array $options = null): CursorInterface {}
 
-    final public function executeReadWriteCommand(string $db, Command $command, ?array $options = null): Cursor {}
+    final public function executeReadWriteCommand(string $db, Command $command, ?array $options = null): CursorInterface {}
 
-    final public function executeWriteCommand(string $db, Command $command, ?array $options = null): Cursor {}
+    final public function executeWriteCommand(string $db, Command $command, ?array $options = null): CursorInterface {}
 
     final public function getEncryptedFieldsMap(): array|object|null {}
 

--- a/src/MongoDB/Manager_arginfo.h
+++ b/src/MongoDB/Manager_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ce2904be644a230dc05dc1427f74c3717035eb06 */
+ * Stub hash: a1a1a6c333ba1919fd648a8786f41d9817850a13 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Manager___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uri, IS_STRING, 1, "null")
@@ -21,19 +21,19 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_exec
 	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\WriteConcern, MAY_BE_ARRAY|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeCommand, 0, 2, MongoDB\\Driver\\Cursor, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeCommand, 0, 2, MongoDB\\Driver\\CursorInterface, 0)
 	ZEND_ARG_TYPE_INFO(0, db, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, command, MongoDB\\Driver\\Command, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeQuery, 0, 2, MongoDB\\Driver\\Cursor, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeQuery, 0, 2, MongoDB\\Driver\\CursorInterface, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, query, MongoDB\\Driver\\Query, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeReadCommand, 0, 2, MongoDB\\Driver\\Cursor, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_executeReadCommand, 0, 2, MongoDB\\Driver\\CursorInterface, 0)
 	ZEND_ARG_TYPE_INFO(0, db, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, command, MongoDB\\Driver\\Command, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")

--- a/src/MongoDB/Monitoring/CommandSubscriber.stub.php
+++ b/src/MongoDB/Monitoring/CommandSubscriber.stub.php
@@ -9,12 +9,9 @@ namespace MongoDB\Driver\Monitoring;
 
 interface CommandSubscriber extends Subscriber
 {
-    /** @tentative-return-type */
     public function commandStarted(CommandStartedEvent $event): void;
 
-    /** @tentative-return-type */
     public function commandSucceeded(CommandSucceededEvent $event): void;
 
-    /** @tentative-return-type */
     public function commandFailed(CommandFailedEvent $event): void;
 }

--- a/src/MongoDB/Monitoring/CommandSubscriber_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandSubscriber_arginfo.h
@@ -1,15 +1,15 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3fb67ff709c10a3a2769af8572075da08cb100b4 */
+ * Stub hash: 9733d9c7cb3460bd7fb85be93cc5c9fbe70e3762 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandStarted, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandStarted, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\CommandStartedEvent, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandSucceeded, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandSucceeded, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\CommandSucceededEvent, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandFailed, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandFailed, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\CommandFailedEvent, 0)
 ZEND_END_ARG_INFO()
 

--- a/src/MongoDB/Monitoring/SDAMSubscriber.stub.php
+++ b/src/MongoDB/Monitoring/SDAMSubscriber.stub.php
@@ -9,30 +9,21 @@ namespace MongoDB\Driver\Monitoring;
 
 interface SDAMSubscriber extends Subscriber
 {
-    /** @tentative-return-type */
     public function serverChanged(ServerChangedEvent $event): void;
 
-    /** @tentative-return-type */
     public function serverClosed(ServerClosedEvent $event): void;
 
-    /** @tentative-return-type */
     public function serverOpening(ServerOpeningEvent $event): void;
 
-    /** @tentative-return-type */
     public function serverHeartbeatFailed(ServerHeartbeatFailedEvent $event): void;
 
-    /** @tentative-return-type */
     public function serverHeartbeatStarted(ServerHeartbeatStartedEvent $event): void;
 
-    /** @tentative-return-type */
     public function serverHeartbeatSucceeded(ServerHeartbeatSucceededEvent $event): void;
 
-    /** @tentative-return-type */
     public function topologyChanged(TopologyChangedEvent $event): void;
 
-    /** @tentative-return-type */
     public function topologyClosed(TopologyClosedEvent $event): void;
 
-    /** @tentative-return-type */
     public function topologyOpening(TopologyOpeningEvent $event): void;
 }

--- a/src/MongoDB/Monitoring/SDAMSubscriber_arginfo.h
+++ b/src/MongoDB/Monitoring/SDAMSubscriber_arginfo.h
@@ -1,39 +1,39 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 19ae065e2a8ad6c8f4945262d6cf58ea723e5aed */
+ * Stub hash: 4288cbc04c5e6f432f960e0964ee7022c4a94ac5 */
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverChanged, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverChanged, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\ServerChangedEvent, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverClosed, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverClosed, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\ServerClosedEvent, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverOpening, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverOpening, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\ServerOpeningEvent, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatFailed, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatFailed, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\ServerHeartbeatFailedEvent, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatStarted, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatStarted, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\ServerHeartbeatStartedEvent, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatSucceeded, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatSucceeded, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\ServerHeartbeatSucceededEvent, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyChanged, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyChanged, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\TopologyChangedEvent, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyClosed, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyClosed, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\TopologyClosedEvent, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyOpening, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyOpening, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\TopologyOpeningEvent, 0)
 ZEND_END_ARG_INFO()
 

--- a/src/MongoDB/Server.stub.php
+++ b/src/MongoDB/Server.stub.php
@@ -74,15 +74,15 @@ final class Server
 
     final public function executeBulkWrite(string $namespace, BulkWrite $bulkWrite, array|WriteConcern|null $options = null): WriteResult {}
 
-    final public function executeCommand(string $db, Command $command, array|ReadPreference|null $options = null): Cursor {}
+    final public function executeCommand(string $db, Command $command, array|ReadPreference|null $options = null): CursorInterface {}
 
-    final public function executeQuery(string $namespace, Query $query, array|ReadPreference|null $options = null): Cursor {}
+    final public function executeQuery(string $namespace, Query $query, array|ReadPreference|null $options = null): CursorInterface {}
 
-    final public function executeReadCommand(string $db, Command $command, ?array $options = null): Cursor {}
+    final public function executeReadCommand(string $db, Command $command, ?array $options = null): CursorInterface {}
 
-    final public function executeReadWriteCommand(string $db, Command $command, ?array $options = null): Cursor {}
+    final public function executeReadWriteCommand(string $db, Command $command, ?array $options = null): CursorInterface {}
 
-    final public function executeWriteCommand(string $db, Command $command, ?array $options = null): Cursor {}
+    final public function executeWriteCommand(string $db, Command $command, ?array $options = null): CursorInterface {}
 
     final public function getHost(): string {}
 

--- a/src/MongoDB/Server_arginfo.h
+++ b/src/MongoDB/Server_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5edd7242100364c5e4beddc89b4d92dda70c09f6 */
+ * Stub hash: 63542fe1821e8a9016e8514924f6aec30e4ea20e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Server___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -10,19 +10,19 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_execu
 	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\WriteConcern, MAY_BE_ARRAY|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeCommand, 0, 2, MongoDB\\Driver\\Cursor, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeCommand, 0, 2, MongoDB\\Driver\\CursorInterface, 0)
 	ZEND_ARG_TYPE_INFO(0, db, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, command, MongoDB\\Driver\\Command, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeQuery, 0, 2, MongoDB\\Driver\\Cursor, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeQuery, 0, 2, MongoDB\\Driver\\CursorInterface, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, query, MongoDB\\Driver\\Query, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, options, MongoDB\\Driver\\ReadPreference, MAY_BE_ARRAY|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeReadCommand, 0, 2, MongoDB\\Driver\\Cursor, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Server_executeReadCommand, 0, 2, MongoDB\\Driver\\CursorInterface, 0)
 	ZEND_ARG_TYPE_INFO(0, db, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, command, MongoDB\\Driver\\Command, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")

--- a/tests/bson/bson-document-fromPHP-001.phpt
+++ b/tests/bson/bson-document-fromPHP-001.phpt
@@ -14,8 +14,7 @@ class MyDocument implements MongoDB\BSON\Serializable
         $this->data = $data;
     }
 
-    #[ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array|\stdClass
     {
         return $this->data;
     }

--- a/tests/bson/bson-encode-002.phpt
+++ b/tests/bson/bson-encode-002.phpt
@@ -7,8 +7,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 
 class AssociativeArray implements MongoDB\BSON\Serializable, MongoDB\BSON\Unserializable
 {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return array("random" => "class", "data");
     }
@@ -22,8 +21,7 @@ class AssociativeArray implements MongoDB\BSON\Serializable, MongoDB\BSON\Unseri
 
 class NumericArray implements MongoDB\BSON\Serializable, MongoDB\BSON\Unserializable
 {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return array(1, 2, 3);
     }

--- a/tests/bson/bson-encode-003.phpt
+++ b/tests/bson/bson-encode-003.phpt
@@ -8,8 +8,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 class MyClass implements MongoDB\BSON\Persistable {
     private $props;
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize() {
+    public function bsonSerialize(): array {
         return array(
             "random" => "class",
             "data"
@@ -22,8 +21,7 @@ class MyClass implements MongoDB\BSON\Persistable {
 class MyClass2 implements MongoDB\BSON\Persistable {
     private $props;
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize() {
+    public function bsonSerialize(): array {
         return array(
             1, 2, 3,
         );

--- a/tests/bson/bug0274.phpt
+++ b/tests/bson/bug0274.phpt
@@ -7,8 +7,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 
 class AssociativeArray implements MongoDB\BSON\Serializable
 {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return array("random" => "class", "data");
     }
@@ -16,8 +15,7 @@ class AssociativeArray implements MongoDB\BSON\Serializable
 
 class NumericArray implements MongoDB\BSON\Serializable
 {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return array(1, 2, 3);
     }

--- a/tests/bson/bug0334-001.phpt
+++ b/tests/bson/bug0334-001.phpt
@@ -6,8 +6,7 @@ PHPC-334: Injected __pclass should override a __pclass key in bsonSerialize() re
 require_once __DIR__ . '/../utils/basic.inc';
 
 class MyClass implements MongoDB\BSON\Persistable {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize() {
+    public function bsonSerialize(): array {
         return array(
             "__pclass" => "baz",
             "foo" => "bar",

--- a/tests/bson/bug0334-002.phpt
+++ b/tests/bson/bug0334-002.phpt
@@ -6,8 +6,7 @@ PHPC-334: Encoded BSON should never have multiple __pclass keys
 require_once __DIR__ . '/../utils/basic.inc';
 
 class MyClass implements MongoDB\BSON\Persistable {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize() {
+    public function bsonSerialize(): array {
         return array(
             "__pclass" => "baz",
             "foo" => "bar",

--- a/tests/bson/bug1006-001.phpt
+++ b/tests/bson/bug1006-001.phpt
@@ -17,8 +17,7 @@ class MyClass implements MongoDB\BSON\Persistable
         ];
     }
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return $this->data;
     }

--- a/tests/bson/bug1006-002.phpt
+++ b/tests/bson/bug1006-002.phpt
@@ -7,8 +7,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 
 class MyClass implements MongoDB\BSON\Serializable
 {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return [
             '__pclass' => 'baz',

--- a/tests/bulk/bulkwrite-ctor-comment_error-001.phpt
+++ b/tests/bulk/bulkwrite-ctor-comment_error-001.phpt
@@ -7,7 +7,6 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 class Comment implements MongoDB\BSON\Serializable
 {
-    #[\ReturnTypeWillChange]
     public function bsonSerialize(): array
     {
         throw new Exception('phongo_zval_to_bson_value fails');

--- a/tests/bulk/bulkwrite-delete-001.phpt
+++ b/tests/bulk/bulkwrite-delete-001.phpt
@@ -19,8 +19,7 @@ class MyClass implements MongoDB\BSON\Persistable
         $this->child = $child;
     }
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return [
             '_id' => $this->id,

--- a/tests/bulk/bulkwrite-insert-001.phpt
+++ b/tests/bulk/bulkwrite-insert-001.phpt
@@ -19,8 +19,7 @@ class MyClass implements MongoDB\BSON\Persistable
         $this->child = $child;
     }
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return [
             '_id' => $this->id,

--- a/tests/bulk/bulkwrite-insert-004.phpt
+++ b/tests/bulk/bulkwrite-insert-004.phpt
@@ -17,8 +17,7 @@ class MySerializableId implements MongoDB\BSON\Serializable
         $this->id = $id;
     }
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return ['id' => $this->id];
     }

--- a/tests/bulk/bulkwrite-update-001.phpt
+++ b/tests/bulk/bulkwrite-update-001.phpt
@@ -19,8 +19,7 @@ class MyClass implements MongoDB\BSON\Persistable
         $this->child = $child;
     }
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return [
             '_id' => $this->id,

--- a/tests/clientEncryption/clientEncryption-encryptExpression_error-001.phpt
+++ b/tests/clientEncryption/clientEncryption-encryptExpression_error-001.phpt
@@ -16,8 +16,7 @@ $clientEncryption = $manager->createClientEncryption([
 ]);
 
 class SerializableError implements MongoDB\BSON\Serializable {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         throw new RuntimeException('bsonSerialize() error');
     }

--- a/tests/clientEncryption/clientEncryption-encrypt_error-001.phpt
+++ b/tests/clientEncryption/clientEncryption-encrypt_error-001.phpt
@@ -16,8 +16,7 @@ $clientEncryption = $manager->createClientEncryption([
 ]);
 
 class SerializableError implements MongoDB\BSON\Serializable {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         throw new RuntimeException('bsonSerialize() error');
     }

--- a/tests/command/command-ctor-001.phpt
+++ b/tests/command/command-ctor-001.phpt
@@ -19,8 +19,7 @@ class MyClass implements MongoDB\BSON\Persistable
         $this->child = $child;
     }
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return [
             '_id' => $this->id,

--- a/tests/cursor/bug0924-001.phpt
+++ b/tests/cursor/bug0924-001.phpt
@@ -17,8 +17,7 @@ class MyDocument implements MongoDB\BSON\Serializable, MongoDB\BSON\Unserializab
         $this->data['_id'] = $id;
     }
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): \stdClass
     {
         return (object) $this->data;
     }

--- a/tests/cursor/bug0924-002.phpt
+++ b/tests/cursor/bug0924-002.phpt
@@ -17,8 +17,7 @@ class MyDocument implements MongoDB\BSON\Persistable
         $this->data['_id'] = $id;
     }
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): \stdClass
     {
         return (object) $this->data;
     }

--- a/tests/query/query-ctor-001.phpt
+++ b/tests/query/query-ctor-001.phpt
@@ -19,8 +19,7 @@ class MyClass implements MongoDB\BSON\Persistable
         $this->child = $child;
     }
 
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return [
             '_id' => $this->id,

--- a/tests/query/query-ctor-comment_error-001.phpt
+++ b/tests/query/query-ctor-comment_error-001.phpt
@@ -7,7 +7,6 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 class Comment implements MongoDB\BSON\Serializable
 {
-    #[\ReturnTypeWillChange]
     public function bsonSerialize(): array
     {
         throw new Exception('phongo_zval_to_bson_value fails');

--- a/tests/standalone/bug0545.phpt
+++ b/tests/standalone/bug0545.phpt
@@ -11,8 +11,7 @@ require_once __DIR__ . "/../utils/basic.inc";
 #[\AllowDynamicProperties]
 class Book implements MongoDB\BSON\Persistable
 {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         $data = get_object_vars($this);
         return $data;
@@ -29,8 +28,7 @@ class Book implements MongoDB\BSON\Persistable
 #[\AllowDynamicProperties]
 class Page implements MongoDB\BSON\Persistable
 {
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         $data = get_object_vars($this);
         return $data;

--- a/tests/utils/classes.inc
+++ b/tests/utils/classes.inc
@@ -19,8 +19,7 @@ class Person implements MongoDB\BSON\Persistable {
     public function addFriend(Person $friend) {
         $this->friends[] = $friend;
     }
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize() {
+    public function bsonSerialize(): array {
         return array(
             "name"    => $this->name,
             "age"     => $this->age,
@@ -43,8 +42,7 @@ class Address implements MongoDB\BSON\Persistable {
         $this->zip = $zip;
         $this->country = $country;
     }
-    #[\ReturnTypeWillChange]
-    public function bsonSerialize() {
+    public function bsonSerialize(): array {
         return array(
             "zip"     => $this->zip,
             "country" => $this->country,


### PR DESCRIPTION
PHPC-2140

This PR removes the `@tentative-return-type` annotation in all stub files, making the return types definitive and causing errors if an extending or implementing class does not have a covariant return type.

It also changes the return types for various methods in `MongoDB\Driver\Manager` and `MongoDB\Driver\Server` from `Cursor` to `CursorInterface`.

Note: currently contains changes from #1653 to avoid fixing tests that will be removed.