### PR TITLE
Remove usage of deprecated E_STRICT

### DIFF
--- a/tests/utils/tools.php
+++ b/tests/utils/tools.php
@@ -602,7 +602,7 @@ function severityToString(int $severity): string {
         'E_USER_ERROR' => E_USER_ERROR,
         'E_USER_WARNING' => E_USER_WARNING,
         'E_USER_NOTICE' => E_USER_NOTICE,
-        'E_STRICT' => E_STRICT,
+        'E_STRICT' => 2048, // E_STRICT was deprecated in PHP 8.4
         'E_RECOVERABLE_ERROR' => E_RECOVERABLE_ERROR,
         'E_DEPRECATED' => E_DEPRECATED,
         'E_USER_DEPRECATED' => E_USER_DEPRECATED,


### PR DESCRIPTION
`E_STRICT` was deprecated in PHP 8.4, causing test failures due to the deprecation warning showing up in tests. To work around this, we can use its literal value instead.