### PR TITLE
PHPC-2309: Remove --with-openssl-dir configure option

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -30,3 +30,5 @@ UPGRADE FROM 1.x to 2.0
  * The constructor of `MongoDB\BSON\UTCDateTime` no longer accepts a `string`
    argument. To pass 64-bit integers on 32-bit platforms, use the
    `MongoDB\BSON\Int64` class instead.
+ * The `--with-openssl-dir` configure option has been removed. If using OpenSSL,
+   ensure that it is detected by `pkg-config`.

--- a/scripts/autotools/libmongoc/CheckSSL.m4
+++ b/scripts/autotools/libmongoc/CheckSSL.m4
@@ -19,13 +19,6 @@ fi
 
 PHP_MONGODB_VALIDATE_ARG([PHP_MONGODB_SSL], [auto openssl libressl darwin no])
 
-PHP_ARG_WITH([openssl-dir],
-             [deprecated option for OpenSSL library path],
-             [AS_HELP_STRING([--with-openssl-dir=@<:@auto/DIR@:>@],
-                             [MongoDB: OpenSSL library path (deprecated for pkg-config) [default=auto]])],
-             [auto],
-             [no])
-
 AS_IF([test "$PHP_MONGODB_SSL" = "openssl" -o "$PHP_MONGODB_SSL" = "auto"],[
   found_openssl="no"
 
@@ -50,13 +43,10 @@ AS_IF([test "$PHP_MONGODB_SSL" = "openssl" -o "$PHP_MONGODB_SSL" = "auto"],[
     unset OPENSSL_INCDIR
     unset OPENSSL_LIBDIR
 
-    dnl Use a list of directories from PHP_SETUP_OPENSSL by default.
-    dnl Support documented "auto" and older, undocumented "yes" options
-    if test "$PHP_OPENSSL_DIR" = "auto" -o "$PHP_OPENSSL_DIR" = "yes"; then
-      PHP_OPENSSL_DIR="/usr/local/ssl /usr/local /usr /usr/local/openssl"
-    fi
+    dnl Use a list of directories from PHP_SETUP_OPENSSL by default. 
+    OPENSSL_SEARCH_PATHS="/usr/local/ssl /usr/local /usr /usr/local/openssl"
 
-    for i in $PHP_OPENSSL_DIR; do
+    for i in $OPENSSL_SEARCH_PATHS; do
       if test -r $i/include/openssl/evp.h; then
         OPENSSL_INCDIR="$i/include"
       fi
@@ -75,7 +65,6 @@ AS_IF([test "$PHP_MONGODB_SSL" = "openssl" -o "$PHP_MONGODB_SSL" = "auto"],[
                       [have_crypto_lib="yes"],
                       [have_crypto_lib="no"],
                       [$OPENSSL_LIBDIR_LDFLAG])
-
 
     dnl Check whether OpenSSL >= 1.1.0 is available
     PHP_CHECK_LIBRARY([ssl],


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2309

For the time being, we will preserve fall back logic to detect OpenSSL with PHP_CHECK_LIBRARY; however, that will be eventually be removed (PHPC-2451).

It should be noted that PHP 7.4+ relies exclusively on pkg-config to detect OpenSSL: php/php-src@fe8fdfa3bd588d80ce60f6b3848058239e0a760f