### PR TITLE
Drop RHEL 7.6 from evergreen testing

### DIFF
--- a/.evergreen/config/build-variants.yml
+++ b/.evergreen/config/build-variants.yml
@@ -60,12 +60,6 @@ buildvariants:
     run_on: rhel80-small
     tasks:
       - name: "build-all-php"
-  - name: build-rhel76
-    display_name: "Build: RHEL 7.6"
-    tags: ["build", "rhel", "x64", "pr", "tag"]
-    run_on: rhel76-small
-    tasks:
-      - name: "build-all-php"
 
   # Ubuntu LTS
   - name: build-ubuntu2204


### PR DESCRIPTION
RHEL 7.6 is extremely outdated and will not support PHP 8.4. Removing it from Evergreen will make it easier for us to test with PHP 8.4 and reduce legacy cruft.