### PR TITLE
PHPC-2456: Correctly dereference arrays in type maps

### DIFF
--- a/src/contrib/php_array_api.h
+++ b/src/contrib/php_array_api.h
@@ -420,7 +420,9 @@ try_again:
  * zval *php_array_fetchz_array(zval *zarr, zval *key)
  */
 static inline zval *php_array_zval_to_array(zval *zarr) {
-	return (zarr && (Z_TYPE_P(zarr) == IS_ARRAY)) ? zarr : NULL;
+	if (!zarr) { return NULL; }
+	ZVAL_DEREF(zarr);
+	return Z_TYPE_P(zarr) == IS_ARRAY ? zarr : NULL;
 }
 PHP_ARRAY_FETCH_TYPE_MAP(zval*, array)
 #define php_array_fetchc_array(zarr, litstr) \
@@ -493,8 +495,10 @@ void *php_array_zval_to_resource(zval *z, int le) {
  */
 static inline
 zval *php_array_zval_to_object(zval *z, zend_class_entry *ce) {
-	return (z && (Z_TYPE_P(z) == IS_OBJECT) &&
-	        ((!ce) || instanceof_function(Z_OBJCE_P(z), ce))) ? z : NULL;
+	if (!z) { return NULL; }
+	ZVAL_DEREF(z);
+	if (Z_TYPE_P(z) != IS_OBJECT) { return NULL; }
+	return (!ce) || instanceof_function(Z_OBJCE_P(z), ce) ? z : NULL;
 }
 #define php_array_fetch_object(zarr, key, ce) \
 	php_array_zval_to_object(php_array_fetch(zarr, key), ce)

--- a/tests/bson/bug2456-001.phpt
+++ b/tests/bson/bug2456-001.phpt
@@ -1,0 +1,22 @@
+--TEST--
+PHPC-2456: References passed in a typeMap
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$fieldPaths = [];
+
+$typeMap = ['fieldPaths' => &$fieldPaths];
+
+var_dump(MongoDB\BSON\Document::fromPHP([])->toPHP($typeMap));
+var_dump(MongoDB\BSON\PackedArray::fromPHP([])->toPHP($typeMap));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(stdClass)#%d (0) {
+}
+array(0) {
+}
+===DONE===


### PR DESCRIPTION
PHPC-2456

This PR adds dereferencing logic to the PHP array API polyfill. This logic has already been added for longs, strings, and doubles, but not for arrays and objects. This can cause issues when passing a reference to an array in a type map, as we extract an array but receive `NULL`. To the user, this makes no sense as from their point of view, a reference to an array is an array like any other.

Note that I'm targeting v1.19 here as that's our current stable branch, but we may opt to not release another 1.19 patch release and only fix this in 1.20.0.