### PR TITLE
PHPC-2417 Add `UTCDateTimeInterface::toDateTimeImmutable()`

### DIFF
--- a/src/BSON/UTCDateTimeInterface.stub.php
+++ b/src/BSON/UTCDateTimeInterface.stub.php
@@ -11,5 +11,7 @@ interface UTCDateTimeInterface
 {
     public function toDateTime(): \DateTime;
 
+    public function toDateTimeImmutable(): \DateTimeImmutable;
+
     public function __toString(): string;
 }

--- a/src/BSON/UTCDateTimeInterface_arginfo.h
+++ b/src/BSON/UTCDateTimeInterface_arginfo.h
@@ -1,7 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e2b2ba7dbdda8c9a7bf9e73a2bb38435955d68b8 */
+ * Stub hash: 9dfbe17b754382e121289ef990984d39b18117ca */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTime, 0, 0, DateTime, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTimeImmutable, 0, 0, DateTimeImmutable, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTimeInterface___toString, 0, 0, IS_STRING, 0)
@@ -12,6 +15,7 @@ ZEND_END_ARG_INFO()
 
 static const zend_function_entry class_MongoDB_BSON_UTCDateTimeInterface_methods[] = {
 	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_UTCDateTimeInterface, toDateTime, arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTime, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_UTCDateTimeInterface, toDateTimeImmutable, arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTimeImmutable, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_UTCDateTimeInterface, __toString, arginfo_class_MongoDB_BSON_UTCDateTimeInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_FE_END
 };


### PR DESCRIPTION
Fix PHPC-2417

The interface is not tested (except for [`UTCDateTime implements UTCDateTimeInterface`](https://github.com/mongodb/mongo-php-driver/blob/v2.x/tests/bson/bson-utcdatetimeinterface-001.phpt)). Other tests pass, so this interface change must be correct.