### PR TITLE
PHPC-2144 Throw a LogicException when getting info from unacknowledged write result

### DIFF
--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -31,10 +31,9 @@
 #include "MongoDB/WriteError.h"
 #include "WriteResult_arginfo.h"
 
-#define PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED(method)                                                                                                                                        \
-	if (!mongoc_write_concern_is_acknowledged(intern->write_concern)) {                                                                                                                      \
-		php_error_docref(NULL, E_DEPRECATED, "Calling MongoDB\\Driver\\WriteResult::" method "() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0"); \
-		RETURN_NULL();                                                                                                                                                                       \
+#define PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED(method)                                                                                                     \
+	if (!mongoc_write_concern_is_acknowledged(intern->write_concern)) {                                                                                   \
+		phongo_throw_exception(PHONGO_ERROR_LOGIC, "MongoDB\\Driver\\WriteResult::" method "() should not be called for an unacknowledged write result"); \
 	}
 
 #define PHONGO_WRITERESULT_RETURN_LONG_FROM_BSON_INT32(iter, bson, key)                \

--- a/src/MongoDB/WriteResult.stub.php
+++ b/src/MongoDB/WriteResult.stub.php
@@ -12,15 +12,15 @@ final class WriteResult
 {
     final private function __construct() {}
 
-    final public function getInsertedCount(): ?int {}
+    final public function getInsertedCount(): int {}
 
-    final public function getMatchedCount(): ?int {}
+    final public function getMatchedCount(): int {}
 
-    final public function getModifiedCount(): ?int {}
+    final public function getModifiedCount(): int {}
 
-    final public function getDeletedCount(): ?int {}
+    final public function getDeletedCount(): int {}
 
-    final public function getUpsertedCount(): ?int {}
+    final public function getUpsertedCount(): int {}
 
     final public function getServer(): Server {}
 

--- a/src/MongoDB/WriteResult_arginfo.h
+++ b/src/MongoDB/WriteResult_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 84f1690181585d88c4e7233a4c959d5f50dc1b40 */
+ * Stub hash: 217742ba620620cfaee2758070ff13e651620f87 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteResult___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteResult_getInsertedCount, 0, 0, IS_LONG, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteResult_getInsertedCount, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_WriteResult_getMatchedCount arginfo_class_MongoDB_Driver_WriteResult_getInsertedCount

--- a/tests/manager/manager-executeBulkWrite-012.phpt
+++ b/tests/manager/manager-executeBulkWrite-012.phpt
@@ -23,17 +23,16 @@ foreach ($writeConcerns as $wc) {
 
     $result = $manager->executeBulkWrite(NS, $bulk, $options);
     var_dump($result->isAcknowledged());
-    var_dump($result->getInsertedCount());
+    if ($result->isAcknowledged()) {
+        var_dump($result->getInsertedCount());
+    }
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 bool(false)
-
-Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
-NULL
 bool(true)
 int(1)
 bool(true)

--- a/tests/server/server-executeBulkWrite-002.phpt
+++ b/tests/server/server-executeBulkWrite-002.phpt
@@ -19,17 +19,16 @@ foreach ($writeConcerns as $writeConcern) {
 
     $result = $primary->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern($writeConcern));
     var_dump($result->isAcknowledged());
-    var_dump($result->getInsertedCount());
+    if ($result->isAcknowledged()) {
+        var_dump($result->getInsertedCount());
+    }
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 bool(false)
-
-Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
-NULL
 bool(true)
 int(1)
 ===DONE===

--- a/tests/server/server-executeBulkWrite-003.phpt
+++ b/tests/server/server-executeBulkWrite-003.phpt
@@ -20,17 +20,16 @@ foreach ($writeConcerns as $wc) {
 
     $result = $server->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern($wc));
     var_dump($result->isAcknowledged());
-    var_dump($result->getInsertedCount());
+    if ($result->isAcknowledged()) {
+        var_dump($result->getInsertedCount());
+    }
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 bool(false)
-
-Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
-NULL
 bool(true)
 int(1)
 bool(true)

--- a/tests/server/server-executeBulkWrite-005.phpt
+++ b/tests/server/server-executeBulkWrite-005.phpt
@@ -25,7 +25,9 @@ foreach ($writeConcerns as $wc) {
 
     $result = $server->executeBulkWrite('local.' . COLLECTION_NAME, $bulk, new MongoDB\Driver\WriteConcern($wc));
     var_dump($result->isAcknowledged());
-    var_dump($result->getInsertedCount());
+    if ($result->isAcknowledged()) {
+        var_dump($result->getInsertedCount());
+    }
 }
 
 $bulk = new MongoDB\Driver\BulkWrite();
@@ -35,11 +37,8 @@ $server->executeBulkWrite('local.' . COLLECTION_NAME, $bulk);
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 bool(false)
-
-Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
-NULL
 bool(true)
 int(1)
 ===DONE===

--- a/tests/server/server-executeBulkWrite-006.phpt
+++ b/tests/server/server-executeBulkWrite-006.phpt
@@ -24,17 +24,16 @@ foreach ($writeConcerns as $wc) {
 
     $result = $server->executeBulkWrite(NS, $bulk, $options);
     var_dump($result->isAcknowledged());
-    var_dump($result->getInsertedCount());
+    if ($result->isAcknowledged()) {
+        var_dump($result->getInsertedCount());
+    }
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
+--EXPECT--
 bool(false)
-
-Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
-NULL
 bool(true)
 int(1)
 bool(true)

--- a/tests/writeResult/writeresult-getdeletedcount-002.phpt
+++ b/tests/writeResult/writeresult-getdeletedcount-002.phpt
@@ -19,12 +19,13 @@ $bulk->delete(['x' => 1]);
 
 $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
 
-var_dump($result->getDeletedCount());
+throws(function() use ($result) {
+    $result->getDeletedCount();
+}, MongoDB\Driver\Exception\LogicException::class, 'getDeletedCount');
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-Deprecated: MongoDB\Driver\WriteResult::getDeletedCount(): Calling MongoDB\Driver\WriteResult::getDeletedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
-NULL
+OK: Got MongoDB\Driver\Exception\LogicException thrown from getDeletedCount
 ===DONE===

--- a/tests/writeResult/writeresult-getdeletedcount-002.phpt
+++ b/tests/writeResult/writeresult-getdeletedcount-002.phpt
@@ -19,13 +19,14 @@ $bulk->delete(['x' => 1]);
 
 $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
 
-throws(function() use ($result) {
+echo throws(function() use ($result) {
     $result->getDeletedCount();
-}, MongoDB\Driver\Exception\LogicException::class, 'getDeletedCount');
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
-OK: Got MongoDB\Driver\Exception\LogicException thrown from getDeletedCount
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\LogicException
+MongoDB\Driver\WriteResult::getDeletedCount() should not be called for an unacknowledged write result
 ===DONE===

--- a/tests/writeResult/writeresult-getinsertedcount-002.phpt
+++ b/tests/writeResult/writeresult-getinsertedcount-002.phpt
@@ -19,12 +19,13 @@ $bulk->delete(['x' => 1]);
 
 $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
 
-var_dump($result->getInsertedCount());
+throws(function() use ($result) {
+    $result->getInsertedCount();
+}, MongoDB\Driver\Exception\LogicException::class, 'getInsertedCount');
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-Deprecated: MongoDB\Driver\WriteResult::getInsertedCount(): Calling MongoDB\Driver\WriteResult::getInsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
-NULL
+OK: Got MongoDB\Driver\Exception\LogicException thrown from getInsertedCount
 ===DONE===

--- a/tests/writeResult/writeresult-getinsertedcount-002.phpt
+++ b/tests/writeResult/writeresult-getinsertedcount-002.phpt
@@ -19,13 +19,14 @@ $bulk->delete(['x' => 1]);
 
 $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
 
-throws(function() use ($result) {
+echo throws(function() use ($result) {
     $result->getInsertedCount();
-}, MongoDB\Driver\Exception\LogicException::class, 'getInsertedCount');
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
-OK: Got MongoDB\Driver\Exception\LogicException thrown from getInsertedCount
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\LogicException
+MongoDB\Driver\WriteResult::getInsertedCount() should not be called for an unacknowledged write result
 ===DONE===

--- a/tests/writeResult/writeresult-getmatchedcount-002.phpt
+++ b/tests/writeResult/writeresult-getmatchedcount-002.phpt
@@ -19,12 +19,13 @@ $bulk->delete(['x' => 1]);
 
 $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
 
-var_dump($result->getMatchedCount());
+throws(function() use ($result) {
+    $result->getMatchedCount();
+}, MongoDB\Driver\Exception\LogicException::class, 'getMatchedCount');
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-Deprecated: MongoDB\Driver\WriteResult::getMatchedCount(): Calling MongoDB\Driver\WriteResult::getMatchedCount() for an unacknowledged write is deprecated and will throw an exception in %s
-NULL
+OK: Got MongoDB\Driver\Exception\LogicException thrown from getMatchedCount
 ===DONE===

--- a/tests/writeResult/writeresult-getmatchedcount-002.phpt
+++ b/tests/writeResult/writeresult-getmatchedcount-002.phpt
@@ -19,13 +19,14 @@ $bulk->delete(['x' => 1]);
 
 $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
 
-throws(function() use ($result) {
+echo throws(function() use ($result) {
     $result->getMatchedCount();
-}, MongoDB\Driver\Exception\LogicException::class, 'getMatchedCount');
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
-OK: Got MongoDB\Driver\Exception\LogicException thrown from getMatchedCount
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\LogicException
+MongoDB\Driver\WriteResult::getMatchedCount() should not be called for an unacknowledged write result
 ===DONE===

--- a/tests/writeResult/writeresult-getmodifiedcount-002.phpt
+++ b/tests/writeResult/writeresult-getmodifiedcount-002.phpt
@@ -19,12 +19,13 @@ $bulk->delete(['x' => 1]);
 
 $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
 
-var_dump($result->getModifiedCount());
+throws(function() use ($result) {
+    $result->getModifiedCount();
+}, MongoDB\Driver\Exception\LogicException::class, 'getModifiedCount');
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-Deprecated: MongoDB\Driver\WriteResult::getModifiedCount(): Calling MongoDB\Driver\WriteResult::getModifiedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
-NULL
+OK: Got MongoDB\Driver\Exception\LogicException thrown from getModifiedCount
 ===DONE===

--- a/tests/writeResult/writeresult-getmodifiedcount-002.phpt
+++ b/tests/writeResult/writeresult-getmodifiedcount-002.phpt
@@ -19,13 +19,14 @@ $bulk->delete(['x' => 1]);
 
 $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
 
-throws(function() use ($result) {
+echo throws(function() use ($result) {
     $result->getModifiedCount();
-}, MongoDB\Driver\Exception\LogicException::class, 'getModifiedCount');
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
-OK: Got MongoDB\Driver\Exception\LogicException thrown from getModifiedCount
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\LogicException
+MongoDB\Driver\WriteResult::getModifiedCount() should not be called for an unacknowledged write result
 ===DONE===

--- a/tests/writeResult/writeresult-getupsertedcount-002.phpt
+++ b/tests/writeResult/writeresult-getupsertedcount-002.phpt
@@ -19,12 +19,13 @@ $bulk->delete(['x' => 1]);
 
 $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
 
-var_dump($result->getUpsertedCount());
+throws(function() use ($result) {
+    $result->getUpsertedCount();
+}, MongoDB\Driver\Exception\LogicException::class, 'getUpsertedCount');
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-Deprecated: MongoDB\Driver\WriteResult::getUpsertedCount(): Calling MongoDB\Driver\WriteResult::getUpsertedCount() for an unacknowledged write is deprecated and will throw an exception in ext-mongodb 2.0 in %s
-NULL
+OK: Got MongoDB\Driver\Exception\LogicException thrown from getUpsertedCount
 ===DONE===

--- a/tests/writeResult/writeresult-getupsertedcount-002.phpt
+++ b/tests/writeResult/writeresult-getupsertedcount-002.phpt
@@ -19,13 +19,14 @@ $bulk->delete(['x' => 1]);
 
 $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
 
-throws(function() use ($result) {
+echo throws(function() use ($result) {
     $result->getUpsertedCount();
-}, MongoDB\Driver\Exception\LogicException::class, 'getUpsertedCount');
+}, MongoDB\Driver\Exception\LogicException::class), "\n";
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
-OK: Got MongoDB\Driver\Exception\LogicException thrown from getUpsertedCount
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\LogicException
+MongoDB\Driver\WriteResult::getUpsertedCount() should not be called for an unacknowledged write result
 ===DONE===


### PR DESCRIPTION
Fix PHPC-2144

Transform deprecation to exception. The exception message comes from PHPLIB: https://github.com/mongodb/mongo-php-library/blob/v1.x/src/Exception/BadMethodCallException.php#L45

And remove nullable return types from `WriteResult::get*Count` accessors