### PR TITLE
PHPC-2458: Deprecate float arg for UTCDateTime constructor

### DIFF
--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -218,6 +218,8 @@ static PHP_METHOD(MongoDB_BSON_UTCDateTime, __construct)
 			return;
 
 		case IS_DOUBLE:
+			php_error_docref(NULL, E_DEPRECATED, "Creating a %s instance with a float is deprecated and will be removed in ext-mongodb 2.0", ZSTR_VAL(php_phongo_utcdatetime_ce->name));
+
 			php_phongo_utcdatetime_init_from_double(intern, Z_DVAL_P(milliseconds));
 			return;
 

--- a/tests/bson/bson-document-toCanonicalJSON-002.phpt
+++ b/tests/bson/bson-document-toCanonicalJSON-002.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 $tests = [
     [ '_id' => new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
     [ 'binary' => new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
-    [ 'date' => new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [ 'date' => new MongoDB\BSON\UTCDateTime(new MongoDB\BSON\Int64('1445990400000')) ],
     [ 'timestamp' => new MongoDB\BSON\Timestamp(1234, 5678) ],
     [ 'regex' => new MongoDB\BSON\Regex('pattern', 'i') ],
     [ 'code' => new MongoDB\BSON\Javascript('function() { return 1; }') ],

--- a/tests/bson/bson-document-toRelaxedJSON-002.phpt
+++ b/tests/bson/bson-document-toRelaxedJSON-002.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 $tests = [
     [ '_id' => new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
     [ 'binary' => new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
-    [ 'date' => new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [ 'date' => new MongoDB\BSON\UTCDateTime(new MongoDB\BSON\Int64('1445990400000')) ],
     [ 'timestamp' => new MongoDB\BSON\Timestamp(1234, 5678) ],
     [ 'regex' => new MongoDB\BSON\Regex('pattern', 'i') ],
     [ 'code' => new MongoDB\BSON\Javascript('function() { return 1; }') ],

--- a/tests/bson/bson-packedarray-toCanonicalJSON-002.phpt
+++ b/tests/bson/bson-packedarray-toCanonicalJSON-002.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 $tests = [
     [new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
     [new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
-    [new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [new MongoDB\BSON\UTCDateTime(new MongoDB\BSON\Int64('1445990400000')) ],
     [new MongoDB\BSON\Timestamp(1234, 5678) ],
     [new MongoDB\BSON\Regex('pattern', 'i') ],
     [new MongoDB\BSON\Javascript('function() { return 1; }') ],

--- a/tests/bson/bson-packedarray-toRelaxedExtendedJSON-002.phpt
+++ b/tests/bson/bson-packedarray-toRelaxedExtendedJSON-002.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 $tests = [
     [ new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
     [ new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
-    [ new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [ new MongoDB\BSON\UTCDateTime(new MongoDB\BSON\Int64('1445990400000')) ],
     [ new MongoDB\BSON\Timestamp(1234, 5678) ],
     [ new MongoDB\BSON\Regex('pattern', 'i') ],
     [ new MongoDB\BSON\Javascript('function() { return 1; }') ],

--- a/tests/bson/bson-toCanonicalJSON-002.phpt
+++ b/tests/bson/bson-toCanonicalJSON-002.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 $tests = [
     [ '_id' => new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
     [ 'binary' => new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
-    [ 'date' => new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [ 'date' => new MongoDB\BSON\UTCDateTime(new MongoDB\BSON\Int64('1445990400000')) ],
     [ 'timestamp' => new MongoDB\BSON\Timestamp(1234, 5678) ],
     [ 'regex' => new MongoDB\BSON\Regex('pattern', 'i') ],
     [ 'code' => new MongoDB\BSON\Javascript('function() { return 1; }') ],

--- a/tests/bson/bson-toJSON-002.phpt
+++ b/tests/bson/bson-toJSON-002.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 $tests = [
     [ '_id' => new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
     [ 'binary' => new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
-    [ 'date' => new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [ 'date' => new MongoDB\BSON\UTCDateTime(new MongoDB\BSON\Int64('1445990400000')) ],
     [ 'timestamp' => new MongoDB\BSON\Timestamp(1234, 5678) ],
     [ 'regex' => new MongoDB\BSON\Regex('pattern', 'i') ],
     [ 'code' => new MongoDB\BSON\Javascript('function() { return 1; }') ],

--- a/tests/bson/bson-toRelaxedJSON-002.phpt
+++ b/tests/bson/bson-toRelaxedJSON-002.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../utils/basic.inc';
 $tests = [
     [ '_id' => new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
     [ 'binary' => new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
-    [ 'date' => new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [ 'date' => new MongoDB\BSON\UTCDateTime(new MongoDB\BSON\Int64('1445990400000')) ],
     [ 'timestamp' => new MongoDB\BSON\Timestamp(1234, 5678) ],
     [ 'regex' => new MongoDB\BSON\Regex('pattern', 'i') ],
     [ 'code' => new MongoDB\BSON\Javascript('function() { return 1; }') ],

--- a/tests/bson/bson-utcdatetime-007.phpt
+++ b/tests/bson/bson-utcdatetime-007.phpt
@@ -17,6 +17,11 @@ foreach ($tests as $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+Deprecated: MongoDB\BSON\UTCDateTime::__construct(): Creating a MongoDB\BSON\UTCDateTime instance with a float is deprecated and will be removed in ext-mongodb 2.0 in %s on line %d
+
+Deprecated: MongoDB\BSON\UTCDateTime::__construct(): Creating a MongoDB\BSON\UTCDateTime instance with a float is deprecated and will be removed in ext-mongodb 2.0 in %s on line %d
+
+Deprecated: MongoDB\BSON\UTCDateTime::__construct(): Creating a MongoDB\BSON\UTCDateTime instance with a float is deprecated and will be removed in ext-mongodb 2.0 in %s on line %d
 object(MongoDB\BSON\UTCDateTime)#%d (%d) {
   ["milliseconds"]=>
   string(13) "1416445411987"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2458

I realized this was overlooked while going through [documentation-needed](https://jira.mongodb.org/issues/?jql=project%20%3D%20PHPC%20AND%20labels%20%3D%20documentation-needed%20ORDER%20BY%20fixVersion%20ASC) tickets for 1.20. Floats, like strings, were only supported as an alternative for 32-bit platforms.

We can discuss whether this should slip into a 1.20.1 patch release (in which case I'll re-target v1.20) or be deferred to 1.21.0. Either way, I'm going to preemptively document this as deprecated along with strings.