### PR TITLE
PHPC-2457: Fix using array items by reference

### DIFF
--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -149,7 +149,7 @@ static inline bool php_phongo_bulkwrite_bson_array_has_valid_keys(bson_t* array)
  * success; otherwise, false is returned and an exception is thrown. */
 static bool php_phongo_bulkwrite_opts_append_array(bson_t* opts, const char* key, zval* zarr)
 {
-	zval*  value = php_array_fetch(zarr, key);
+	zval*  value = php_array_fetch_deref(zarr, key);
 	bson_t b     = BSON_INITIALIZER;
 
 	if (Z_TYPE_P(value) != IS_OBJECT && Z_TYPE_P(value) != IS_ARRAY) {
@@ -185,7 +185,7 @@ static bool php_phongo_bulkwrite_opts_append_array(bson_t* opts, const char* key
  * success; otherwise, false is returned and an exception is thrown. */
 static bool php_phongo_bulkwrite_opts_append_document(bson_t* opts, const char* key, zval* zarr)
 {
-	zval*  value = php_array_fetch(zarr, key);
+	zval*  value = php_array_fetch_deref(zarr, key);
 	bson_t b     = BSON_INITIALIZER;
 
 	if (Z_TYPE_P(value) != IS_OBJECT && Z_TYPE_P(value) != IS_ARRAY) {
@@ -246,10 +246,10 @@ static bool php_phongo_bulkwrite_opt_hint(bson_t* boptions, zval* zoptions)
 	/* The "hint" option (or "$hint" modifier) must be a string or document.
 	 * Check for both types and merge into BSON options accordingly. */
 	if (zoptions && php_array_existsc(zoptions, "hint")) {
-		zend_uchar type = Z_TYPE_P(php_array_fetchc(zoptions, "hint"));
+		zend_uchar type = Z_TYPE_P(php_array_fetchc_deref(zoptions, "hint"));
 
 		if (type == IS_STRING) {
-			zval* value = php_array_fetchc(zoptions, "hint");
+			zval* value = php_array_fetchc_deref(zoptions, "hint");
 
 			if (!bson_append_utf8(boptions, "hint", 4, Z_STRVAL_P(value), Z_STRLEN_P(value))) {
 				phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Error appending \"hint\" option");
@@ -343,7 +343,7 @@ static PHP_METHOD(MongoDB_Driver_BulkWrite, __construct)
 	}
 
 	if (options && php_array_existsc(options, "let")) {
-		zval* value = php_array_fetch(options, "let");
+		zval* value = php_array_fetchc_deref(options, "let");
 
 		if (Z_TYPE_P(value) != IS_OBJECT && Z_TYPE_P(value) != IS_ARRAY) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"let\" option to be array or object, %s given", zend_get_type_by_const(Z_TYPE_P(value)));
@@ -361,7 +361,7 @@ static PHP_METHOD(MongoDB_Driver_BulkWrite, __construct)
 	}
 
 	if (options && php_array_existsc(options, "comment")) {
-		zval* value = php_array_fetch(options, "comment");
+		zval* value = php_array_fetchc_deref(options, "comment");
 
 		intern->comment = ecalloc(1, sizeof(bson_value_t));
 		phongo_zval_to_bson_value(value, intern->comment);

--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -426,7 +426,7 @@ static PHP_METHOD(MongoDB_Driver_ClientEncryption, rewrapManyDataKey)
 	}
 
 	if (options && php_array_existsc(options, "masterKey")) {
-		zval* zmasterkey = php_array_fetchc(options, "masterKey");
+		zval* zmasterkey = php_array_fetchc_deref(options, "masterKey");
 
 		if (Z_TYPE_P(zmasterkey) != IS_OBJECT && Z_TYPE_P(zmasterkey) != IS_ARRAY) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"masterKey\" option to be array or object, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zmasterkey));
@@ -550,7 +550,7 @@ static mongoc_client_encryption_opts_t* phongo_clientencryption_opts_from_zval(z
 	}
 
 	if (php_array_existsc(options, "keyVaultClient")) {
-		zval* key_vault_client = php_array_fetch(options, "keyVaultClient");
+		zval* key_vault_client = php_array_fetchc_deref(options, "keyVaultClient");
 
 		if (Z_TYPE_P(key_vault_client) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(key_vault_client), php_phongo_manager_ce)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyVaultClient\" option to be %s, %s given", ZSTR_VAL(php_phongo_manager_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(key_vault_client));
@@ -598,7 +598,7 @@ static mongoc_client_encryption_opts_t* phongo_clientencryption_opts_from_zval(z
 	}
 
 	if (php_array_existsc(options, "kmsProviders")) {
-		zval*  kms_providers  = php_array_fetchc(options, "kmsProviders");
+		zval*  kms_providers  = php_array_fetchc_deref(options, "kmsProviders");
 		bson_t bson_providers = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(kms_providers) != IS_ARRAY && Z_TYPE_P(kms_providers) != IS_OBJECT) {
@@ -616,7 +616,7 @@ static mongoc_client_encryption_opts_t* phongo_clientencryption_opts_from_zval(z
 	}
 
 	if (php_array_existsc(options, "tlsOptions")) {
-		zval*  tls_options  = php_array_fetchc(options, "tlsOptions");
+		zval*  tls_options  = php_array_fetchc_deref(options, "tlsOptions");
 		bson_t bson_options = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(tls_options) != IS_ARRAY && Z_TYPE_P(tls_options) != IS_OBJECT) {
@@ -707,7 +707,7 @@ static mongoc_client_encryption_datakey_opts_t* phongo_clientencryption_datakey_
 	}
 
 	if (php_array_existsc(options, "keyAltNames")) {
-		zval*      zkeyaltnames = php_array_fetchc(options, "keyAltNames");
+		zval*      zkeyaltnames = php_array_fetchc_deref(options, "keyAltNames");
 		HashTable* ht_data;
 		uint32_t   keyaltnames_count;
 		char**     keyaltnames;
@@ -769,7 +769,7 @@ static mongoc_client_encryption_datakey_opts_t* phongo_clientencryption_datakey_
 	}
 
 	if (php_array_existsc(options, "keyMaterial")) {
-		zval* keyMaterial = php_array_fetchc(options, "keyMaterial");
+		zval* keyMaterial = php_array_fetchc_deref(options, "keyMaterial");
 
 		if (Z_TYPE_P(keyMaterial) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(keyMaterial), php_phongo_binary_ce)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyMaterial\" option to be %s, %s given", ZSTR_VAL(php_phongo_binary_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(keyMaterial));
@@ -780,7 +780,7 @@ static mongoc_client_encryption_datakey_opts_t* phongo_clientencryption_datakey_
 	}
 
 	if (php_array_existsc(options, "masterKey")) {
-		zval*  zmasterkey = php_array_fetchc(options, "masterKey");
+		zval*  zmasterkey = php_array_fetchc_deref(options, "masterKey");
 		bson_t masterkey  = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(zmasterkey) != IS_OBJECT && Z_TYPE_P(zmasterkey) != IS_ARRAY) {
@@ -932,7 +932,7 @@ static mongoc_client_encryption_encrypt_opts_t* phongo_clientencryption_encrypt_
 	}
 
 	if (php_array_existsc(options, "contentionFactor")) {
-		mongoc_client_encryption_encrypt_opts_set_contention_factor(opts, php_array_fetch_long(options, "contentionFactor"));
+		mongoc_client_encryption_encrypt_opts_set_contention_factor(opts, php_array_fetchc_long(options, "contentionFactor"));
 	}
 
 	if (php_array_existsc(options, "keyId")) {
@@ -954,7 +954,7 @@ static mongoc_client_encryption_encrypt_opts_t* phongo_clientencryption_encrypt_
 		int       plen;
 		zend_bool pfree;
 
-		keyaltname = php_array_fetch_string(options, "keyAltName", &plen, &pfree);
+		keyaltname = php_array_fetchc_string(options, "keyAltName", &plen, &pfree);
 		mongoc_client_encryption_encrypt_opts_set_keyaltname(opts, keyaltname);
 
 		if (pfree) {
@@ -967,7 +967,7 @@ static mongoc_client_encryption_encrypt_opts_t* phongo_clientencryption_encrypt_
 		int       plen;
 		zend_bool pfree;
 
-		algorithm = php_array_fetch_string(options, "algorithm", &plen, &pfree);
+		algorithm = php_array_fetchc_string(options, "algorithm", &plen, &pfree);
 		mongoc_client_encryption_encrypt_opts_set_algorithm(opts, algorithm);
 
 		if (pfree) {
@@ -980,7 +980,7 @@ static mongoc_client_encryption_encrypt_opts_t* phongo_clientencryption_encrypt_
 		int       plen;
 		zend_bool pfree;
 
-		querytype = php_array_fetch_string(options, "queryType", &plen, &pfree);
+		querytype = php_array_fetchc_string(options, "queryType", &plen, &pfree);
 		mongoc_client_encryption_encrypt_opts_set_query_type(opts, querytype);
 
 		if (pfree) {
@@ -991,7 +991,7 @@ static mongoc_client_encryption_encrypt_opts_t* phongo_clientencryption_encrypt_
 	if (php_array_existsc(options, "rangeOpts")) {
 		mongoc_client_encryption_encrypt_range_opts_t* range_opts;
 
-		range_opts = phongo_clientencryption_encrypt_range_opts_from_zval(php_array_fetchc(options, "rangeOpts"));
+		range_opts = phongo_clientencryption_encrypt_range_opts_from_zval(php_array_fetchc_deref(options, "rangeOpts"));
 
 		if (!range_opts) {
 			/* Exception already thrown */

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -70,7 +70,7 @@ static bool php_phongo_manager_merge_context_options(zval* zdriverOptions)
 		return true;
 	}
 
-	zcontext = php_array_fetchc(zdriverOptions, "context");
+	zcontext = php_array_fetchc_deref(zdriverOptions, "context");
 	context  = php_stream_context_from_zval(zcontext, 1);
 
 	if (!context) {
@@ -734,7 +734,7 @@ static PHP_METHOD(MongoDB_Driver_Manager, startSession)
 	}
 
 	if (options && php_array_existsc(options, "defaultTransactionOptions")) {
-		zval* txn_options = php_array_fetchc(options, "defaultTransactionOptions");
+		zval* txn_options = php_array_fetchc_deref(options, "defaultTransactionOptions");
 
 		/* Thrown exception and return if the defaultTransactionOptions is not an array */
 		if (Z_TYPE_P(txn_options) != IS_ARRAY) {

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -36,7 +36,7 @@ zend_class_entry* php_phongo_query_ce;
  * otherwise, false is returned and an exception is thrown. */
 static bool php_phongo_query_opts_append_string(bson_t* opts, const char* opts_key, zval* zarr, const char* zarr_key)
 {
-	zval* value = php_array_fetch(zarr, zarr_key);
+	zval* value = php_array_fetch_deref(zarr, zarr_key);
 
 	if (Z_TYPE_P(value) != IS_STRING) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"%s\" %s to be string, %s given", zarr_key, zarr_key[0] == '$' ? "modifier" : "option", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(value));
@@ -55,7 +55,7 @@ static bool php_phongo_query_opts_append_string(bson_t* opts, const char* opts_k
  * success; otherwise, false is returned and an exception is thrown. */
 static bool php_phongo_query_opts_append_document(bson_t* opts, const char* opts_key, zval* zarr, const char* zarr_key)
 {
-	zval*  value = php_array_fetch(zarr, zarr_key);
+	zval*  value = php_array_fetch_deref(zarr, zarr_key);
 	bson_t b     = BSON_INITIALIZER;
 
 	if (Z_TYPE_P(value) != IS_OBJECT && Z_TYPE_P(value) != IS_ARRAY) {
@@ -172,7 +172,7 @@ static bool php_phongo_query_init_hint(php_phongo_query_t* intern, zval* options
 	/* The "hint" option (or "$hint" modifier) must be a string or document.
 	 * Check for both types and merge into BSON options accordingly. */
 	if (php_array_existsc(options, "hint")) {
-		zend_uchar type = Z_TYPE_P(php_array_fetchc(options, "hint"));
+		zend_uchar type = Z_TYPE_P(php_array_fetchc_deref(options, "hint"));
 
 		if (type == IS_STRING) {
 			PHONGO_QUERY_OPT_STRING("hint", options, "hint");
@@ -183,7 +183,7 @@ static bool php_phongo_query_init_hint(php_phongo_query_t* intern, zval* options
 			return false;
 		}
 	} else if (modifiers && php_array_existsc(modifiers, "$hint")) {
-		zend_uchar type = Z_TYPE_P(php_array_fetchc(modifiers, "$hint"));
+		zend_uchar type = Z_TYPE_P(php_array_fetchc_deref(modifiers, "$hint"));
 
 		if (type == IS_STRING) {
 			PHONGO_QUERY_OPT_STRING("hint", modifiers, "$hint");
@@ -244,7 +244,7 @@ static bool php_phongo_query_init_readconcern(php_phongo_query_t* intern, zval* 
 		return true;
 	}
 
-	read_concern = php_array_fetchc(options, "readConcern");
+	read_concern = php_array_fetchc_deref(options, "readConcern");
 
 	if (Z_TYPE_P(read_concern) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(read_concern), php_phongo_readconcern_ce)) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(read_concern));
@@ -331,7 +331,7 @@ bool phongo_query_init(zval* return_value, zval* filter, zval* options)
 	}
 
 	if (php_array_existsc(options, "modifiers")) {
-		modifiers = php_array_fetchc(options, "modifiers");
+		modifiers = php_array_fetchc_deref(options, "modifiers");
 
 		if (Z_TYPE_P(modifiers) != IS_ARRAY) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"modifiers\" option to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(modifiers));

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -273,7 +273,7 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, __construct)
 	}
 
 	if (options && php_array_exists(options, "hedge")) {
-		zval* hedge = php_array_fetchc(options, "hedge");
+		zval* hedge = php_array_fetchc_deref(options, "hedge");
 
 		if (Z_TYPE_P(hedge) == IS_ARRAY || Z_TYPE_P(hedge) == IS_OBJECT) {
 			bson_t* hedge_doc = bson_new();

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -378,7 +378,7 @@ mongoc_transaction_opt_t* php_mongodb_session_parse_transaction_options(zval* op
 	}
 
 	if (php_array_existsc(options, "readConcern")) {
-		zval* read_concern = php_array_fetchc(options, "readConcern");
+		zval* read_concern = php_array_fetchc_deref(options, "readConcern");
 
 		if (Z_TYPE_P(read_concern) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(read_concern), php_phongo_readconcern_ce)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(read_concern));
@@ -396,7 +396,7 @@ mongoc_transaction_opt_t* php_mongodb_session_parse_transaction_options(zval* op
 	}
 
 	if (php_array_existsc(options, "readPreference")) {
-		zval* read_preference = php_array_fetchc(options, "readPreference");
+		zval* read_preference = php_array_fetchc_deref(options, "readPreference");
 
 		if (Z_TYPE_P(read_preference) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(read_preference), php_phongo_readpreference_ce)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readPreference\" option to be %s, %s given", ZSTR_VAL(php_phongo_readpreference_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(read_preference));
@@ -414,7 +414,7 @@ mongoc_transaction_opt_t* php_mongodb_session_parse_transaction_options(zval* op
 	}
 
 	if (php_array_existsc(options, "writeConcern")) {
-		zval* write_concern = php_array_fetchc(options, "writeConcern");
+		zval* write_concern = php_array_fetchc_deref(options, "writeConcern");
 
 		if (Z_TYPE_P(write_concern) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(write_concern), php_phongo_writeconcern_ce)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"writeConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_writeconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(write_concern));

--- a/src/contrib/php_array_api.h
+++ b/src/contrib/php_array_api.h
@@ -187,17 +187,53 @@ zval *php_array_fetchz(zval *zarr, zval *key) {
 	}
 }
 
+static inline zval* zval_deref_safe(zval* z) {
+	if (z) { ZVAL_DEREF(z); }
+	return z;
+}
+
+/* Fetch zval*, resolving references
+ *
+ * zval *php_array_fetch_deref(zval *zarr, const char *key)
+ * zval *php_array_fetchl_deref(zval *zarr, const char *key, int key_len)
+ * zval *php_array_fetchl_safe_deref(zval *zarr, const char *key, int key_len)
+ * zval *php_array_fetchn_deref(zval *zarr, unsigned long idx)
+ * zval *php_array_fetchc_deref(zval *zarr, const char *litstr)
+ * zval *php_array_fetchz_deref(zval *zarr, zval *key)
+ */
+static inline
+	zval *php_array_fetchl_deref(zval *zarr, const char *key, int key_len) {
+	return zval_deref_safe(php_array_fetchl(zarr, key, key_len));
+}
+static inline
+	zval *php_array_fetch_deref(zval *zarr, const char *key) {
+	return zval_deref_safe(php_array_fetch(zarr, key));
+}
+#define php_array_fetchc_deref(zarr, litstr) zval_deref_safe(php_array_fetchl(zarr, litstr, sizeof(litstr)-1))
+static inline
+	zval *php_array_fetchl_safe_deref(zval *zarr, const char *key, int key_len) {
+	return zval_deref_safe(php_array_fetchl_safe(zarr, key, key_len));
+}
+static inline
+	zval *php_array_fetchn_deref(zval *zarr, zend_ulong idx) {
+	return zval_deref_safe(php_array_fetchn(zarr, idx));
+}
+static inline
+	zval *php_array_fetchz_deref(zval *zarr, zval *key) {
+	return zval_deref_safe(php_array_fetchz(zarr, key));
+}
+
 #define PHP_ARRAY_FETCH_TYPE_MAP(ctype, ztype) \
 static inline ctype php_array_fetch_##ztype(zval *zarr, const char *key) \
-  	{ return php_array_zval_to_##ztype(php_array_fetch(zarr, key)); } \
+	{ return php_array_zval_to_##ztype(php_array_fetch_deref(zarr, key)); } \
 static inline ctype php_array_fetchl_##ztype(zval *zarr, const char *key, int key_len) \
-	{ return php_array_zval_to_##ztype(php_array_fetchl(zarr, key, key_len)); } \
+	{ return php_array_zval_to_##ztype(php_array_fetchl_deref(zarr, key, key_len)); } \
 static inline ctype php_array_fetchl_safe_##ztype(zval *zarr, const char *key, int key_len) \
-	{ return php_array_zval_to_##ztype(php_array_fetchl_safe(zarr, key, key_len)); } \
+	{ return php_array_zval_to_##ztype(php_array_fetchl_safe_deref(zarr, key, key_len)); } \
 static inline ctype php_array_fetchn_##ztype(zval *zarr, zend_ulong idx) \
-	{ return php_array_zval_to_##ztype(php_array_fetchn(zarr, idx)); } \
+	{ return php_array_zval_to_##ztype(php_array_fetchn_deref(zarr, idx)); } \
 static inline ctype php_array_fetchz_##ztype(zval *zarr, zval *key) \
-	{ return php_array_zval_to_##ztype(php_array_fetchz(zarr, key)); }
+	{ return php_array_zval_to_##ztype(php_array_fetchz_deref(zarr, key)); }
 
 /* Fetch zend_bool
  *
@@ -214,7 +250,7 @@ zend_bool php_array_zval_to_bool(zval *z) {
 }
 PHP_ARRAY_FETCH_TYPE_MAP(zend_bool, bool)
 #define php_array_fetchc_bool(zarr, litstr) \
-	php_array_zval_to_bool(php_array_fetchc(zarr, litstr))
+	php_array_zval_to_bool(php_array_fetchc_deref(zarr, litstr))
 
 /* Fetch long
  *
@@ -227,16 +263,15 @@ PHP_ARRAY_FETCH_TYPE_MAP(zend_bool, bool)
  */
 static inline
 zend_long php_array_zval_to_long(zval *z) {
-try_again:
 	if (!z) { return 0; }
 	switch(Z_TYPE_P(z)) {
-		case IS_REFERENCE:
-			ZVAL_DEREF(z);
-			goto try_again;
-		case IS_NULL: return 0;
-		case IS_FALSE: return 0;
-		case IS_TRUE: return 1;
-		case IS_LONG: return Z_LVAL_P(z);
+		case IS_NULL:
+		case IS_FALSE:
+			return 0;
+		case IS_TRUE:
+			return 1;
+		case IS_LONG:
+			return Z_LVAL_P(z);
 		default:
 		{
 			zval c = *z;
@@ -248,7 +283,7 @@ try_again:
 }
 PHP_ARRAY_FETCH_TYPE_MAP(zend_long, long)
 #define php_array_fetchc_long(zarr, litstr) \
-	php_array_zval_to_long(php_array_fetchc(zarr, litstr))
+	php_array_zval_to_long(php_array_fetchc_deref(zarr, litstr))
 
 /* Fetch double
  *
@@ -261,17 +296,17 @@ PHP_ARRAY_FETCH_TYPE_MAP(zend_long, long)
  */
 static inline
 double php_array_zval_to_double(zval *z) {
-try_again:
 	if (!z) { return 0.0; }
 	switch (Z_TYPE_P(z)) {
-		case IS_REFERENCE:
-			ZVAL_DEREF(z);
-			goto try_again;
-		case IS_NULL: return 0.0;
-		case IS_FALSE: return 0.0;
-		case IS_TRUE: return 1.0;
-		case IS_LONG: return (double)Z_LVAL_P(z);
-		case IS_DOUBLE: return Z_DVAL_P(z);
+		case IS_NULL:
+		case IS_FALSE:
+			return 0.0;
+		case IS_TRUE:
+			return 1.0;
+		case IS_LONG:
+			return (double) Z_LVAL_P(z);
+		case IS_DOUBLE:
+			return Z_DVAL_P(z);
 		default:
 		{
 			zval c = *z;
@@ -283,7 +318,7 @@ try_again:
 }
 PHP_ARRAY_FETCH_TYPE_MAP(double, double)
 #define php_array_fetchc_double(zarr, litstr) \
-	php_array_zval_to_double(php_array_fetchc(zarr, litstr))
+	php_array_zval_to_double(php_array_fetchc_deref(zarr, litstr))
 
 /* Fetch string
  *
@@ -303,14 +338,10 @@ static inline
 char *php_array_zval_to_string(zval *z, int *plen, zend_bool *pfree) {
 	*plen = 0;
 	*pfree = 0;
-try_again:
 	if (!z) { return NULL; }
 	switch (Z_TYPE_P(z)) {
 		case IS_NULL:
-			return (char *)"";
-		case IS_REFERENCE:
-			ZVAL_DEREF(z);
-			goto try_again;
+			return (char *) "";
 		case IS_STRING:
 			*plen = Z_STRLEN_P(z);
 			return Z_STRVAL_P(z);
@@ -326,17 +357,17 @@ try_again:
 	}
 }
 #define php_array_fetch_string(zarr, key, plen, pfree) \
-	php_array_zval_to_string(php_array_fetch(zarr, key), plen, pfree)
+	php_array_zval_to_string(php_array_fetch_deref(zarr, key), plen, pfree)
 #define php_array_fetchl_string(zarr, key, key_len, plen, pfree) \
-	php_array_zval_to_string(php_array_fetchl(zarr, key, key_len), plen, pfree)
+	php_array_zval_to_string(php_array_fetchl_deref(zarr, key, key_len), plen, pfree)
 #define php_array_fetchl_safe_string(zarr, key, key_len, plen, pfree) \
-	php_array_zval_to_string(php_array_fetchl_safe(zarr, key, key_len), plen, pfree)
+	php_array_zval_to_string(php_array_fetchl_safe_deref(zarr, key, key_le), plen, pfree)
 #define php_array_fetchn_string(zarr, idx, plen, pfree) \
-	php_array_zval_to_string(php_array_fetchn(zarr, idx), plen, pfree)
+	php_array_zval_to_string(php_array_fetchn_deref(zarr, idx), plen, pfree)
 #define php_array_fetchc_string(zarr, litstr, plen, pfree) \
-	php_array_zval_to_string(php_array_fetchc(zarr, litstr), plen, pfree)
+	php_array_zval_to_string(php_array_fetchc_deref(zarr, litstr), plen, pfree)
 #define php_array_fetchz_string(zarr, key, plen, pfree) \
-	php_array_zval_to_string(php_array_fetchz(zarr, key), plen, pfree)
+	php_array_zval_to_string(php_array_fetchz_deref(zarr, key), plen, pfree)
 
 
 /* Fetch array
@@ -354,13 +385,11 @@ try_again:
  * zval *php_array_fetchz_array(zval *zarr, zval *key)
  */
 static inline zval *php_array_zval_to_array(zval *zarr) {
-	if (!zarr) { return NULL; }
-	ZVAL_DEREF(zarr);
-	return Z_TYPE_P(zarr) == IS_ARRAY ? zarr : NULL;
+	return zarr && Z_TYPE_P(zarr) == IS_ARRAY ? zarr : NULL;
 }
 PHP_ARRAY_FETCH_TYPE_MAP(zval*, array)
 #define php_array_fetchc_array(zarr, litstr) \
-	php_array_zval_to_array(php_array_fetchc(zarr, litstr))
+	php_array_zval_to_array(php_array_fetchc_deref(zarr, litstr))
 
 /* count($arr) - Count number of elements in the array
  *
@@ -391,17 +420,17 @@ void *php_array_zval_to_resource(zval *z, int le) {
 	return zend_fetch_resource_ex(z, NULL, le);
 }
 #define php_array_fetch_resource(zarr, key, le) \
-	php_array_zval_to_resource(php_array_fetch(zarr, key), le)
+	php_array_zval_to_resource(php_array_fetch_deref(zarr, key), le)
 #define php_array_fetchl_resource(zarr, key, key_len, le) \
-	php_array_zval_to_resource(php_array_fetchl(zarr, key, key_len), le)
+	php_array_zval_to_resource(php_array_fetchl_deref(zarr, key, key_len), le)
 #define php_array_fetchl_safe_resource(zarr, key, key_len, le) \
-	php_array_zval_to_resource(php_array_fetchl_safe(zarr, key, key_len), le)
+	php_array_zval_to_resource(php_array_fetchl_safe_deref(zarr, key, key_len), le)
 #define php_array_fetchn_resource(zarr, idx, le) \
-	php_array_zval_to_resource(php_array_fetchn(zarr, idx), le)
+	php_array_zval_to_resource(php_array_fetchn_deref(zarr, idx), le)
 #define php_array_fetchc_resource(zarr, litstr, le) \
-	php_array_zval_to_resource(php_array_fetchc(zarr, litstr), le)
+	php_array_zval_to_resource(php_array_fetchc_deref(zarr, litstr), le)
 #define php_array_fetchz_resource(zarr, key, le) \
-        php_array_zval_to_resource(php_array_fetchz(zarr, key), le)
+	php_array_zval_to_resource(php_array_fetchz_deref(zarr, key), le)
 
 /* Fetch Object
  *
@@ -418,23 +447,21 @@ void *php_array_zval_to_resource(zval *z, int le) {
  */
 static inline
 zval *php_array_zval_to_object(zval *z, zend_class_entry *ce) {
-	if (!z) { return NULL; }
-	ZVAL_DEREF(z);
-	if (Z_TYPE_P(z) != IS_OBJECT) { return NULL; }
+	if (!z || Z_TYPE_P(z) != IS_OBJECT) { return NULL; }
 	return (!ce) || instanceof_function(Z_OBJCE_P(z), ce) ? z : NULL;
 }
 #define php_array_fetch_object(zarr, key, ce) \
-	php_array_zval_to_object(php_array_fetch(zarr, key), ce)
+	php_array_zval_to_object(php_array_fetch_deref(zarr, key), ce)
 #define php_array_fetchl_object(zarr, key, len, ce) \
-	php_array_zval_to_object(php_array_fetchl(zarr, key, len), ce)
+	php_array_zval_to_object(php_array_fetchl_deref(zarr, key, len), ce)
 #define php_array_fetchl_safe_object(zarr, key, len, ce) \
-	php_array_zval_to_object(php_array_fetchl_safe(zarr, key, len), ce)
+	php_array_zval_to_object(php_array_fetchl_safe_deref(zarr, key, len), ce)
 #define php_array_fetchn_object(zarr, idx, ce) \
-	php_array_zval_to_object(php_array_fetchn(zarr, idx), ce)
+	php_array_zval_to_object(php_array_fetchn_deref(zarr, idx), ce)
 #define php_array_fetchc_object(zarr, litstr, ce) \
-	php_array_zval_to_object(php_array_fetchc(zarr, litstr), ce)
+	php_array_zval_to_object(php_array_fetchc_deref(zarr, litstr), ce)
 #define php_array_fetchz_object(zarr, key, ce) \
-        php_array_zval_to_object(php_array_fetchz(zarr, key), ce)
+	php_array_zval_to_object(php_array_fetchz_deref(zarr, key), ce)
 
 /* unset($zarr[$key]) - Erase a key from an array
  *

--- a/src/contrib/php_array_api.h
+++ b/src/contrib/php_array_api.h
@@ -172,7 +172,6 @@ static inline
 zval *php_array_fetchz(zval *zarr, zval *key) {
 	switch (Z_TYPE_P(key)) {
 		case IS_NULL:
-			return php_array_fetchn(zarr, 0);
 		case IS_FALSE:
 			return php_array_fetchn(zarr, 0);
 		case IS_TRUE:
@@ -180,7 +179,7 @@ zval *php_array_fetchz(zval *zarr, zval *key) {
 		case IS_LONG:
 			return php_array_fetchn(zarr, Z_LVAL_P(key));
 		case IS_DOUBLE:
-			return php_array_fetchn(zarr, (long)Z_DVAL_P(key));
+			return php_array_fetchn(zarr, (zend_ulong) Z_DVAL_P(key));
 		case IS_STRING:
 			return php_array_fetchl(zarr, Z_STRVAL_P(key), Z_STRLEN_P(key));
 		default:
@@ -465,8 +464,6 @@ void php_array_unsetl_safe(zval *zarr, const char *key, int key_len) {
 static inline void php_array_unsetz(zval *zarr, zval *key) {
 	switch (Z_TYPE_P(key)) {
 		case IS_NULL:
-			zend_hash_index_del(Z_ARRVAL_P(zarr), 0);
-			return;
 		case IS_FALSE:
 			zend_hash_index_del(Z_ARRVAL_P(zarr), 0);
 			return;
@@ -477,7 +474,7 @@ static inline void php_array_unsetz(zval *zarr, zval *key) {
 			zend_hash_index_del(Z_ARRVAL_P(zarr), Z_LVAL_P(key));
 			return;
 		case IS_DOUBLE:
-			zend_hash_index_del(Z_ARRVAL_P(zarr), (long)Z_DVAL_P(key));
+			zend_hash_index_del(Z_ARRVAL_P(zarr), (zend_ulong) Z_DVAL_P(key));
 			break;
 		case IS_STRING:
 			php_array_unsetl(zarr, Z_STRVAL_P(key), Z_STRLEN_P(key));

--- a/src/contrib/php_array_api.h
+++ b/src/contrib/php_array_api.h
@@ -25,12 +25,6 @@
 #include "zend_hash.h"
 #include "zend_list.h"
 
-# define PAA_LENGTH_ADJ(l) (l)
-# define PAA_SYM_EXISTS zend_symtable_str_exists
-# define PAA_SYM_DEL    zend_symtable_str_del
-# define PAA_LONG       zend_long
-# define PAA_ULONG      zend_ulong
-
 /**
  * All APIs in this file follow a general format:
  *
@@ -73,12 +67,12 @@
  */
 static inline
 zend_bool php_array_exists(zval *zarr, const char *key) {
-	return PAA_SYM_EXISTS(Z_ARRVAL_P(zarr), key, PAA_LENGTH_ADJ(strlen(key)));
+	return zend_symtable_str_exists(Z_ARRVAL_P(zarr), key, strlen(key));
 }
 #define php_array_existsc(zarr, litstr) \
-	PAA_SYM_EXISTS(Z_ARRVAL_P(zarr), litstr, PAA_LENGTH_ADJ(sizeof(litstr) - 1))
+	zend_symtable_str_exists(Z_ARRVAL_P(zarr), litstr, sizeof(litstr) - 1)
 #define php_array_existsl(zarr, key, len) \
-	PAA_SYM_EXISTS(Z_ARRVAL_P(zarr), key, PAA_LENGTH_ADJ(len))
+	zend_symtable_str_exists(Z_ARRVAL_P(zarr), key, len)
 static inline
 zend_bool php_array_existsl_safe(zval *zarr, const char *key, int key_len) {
 	zend_string *keystr = zend_string_init(key, key_len, 0);
@@ -171,7 +165,7 @@ zval *php_array_fetchl_safe(zval *zarr, const char *key, int key_len) {
 	return ret;
 }
 static inline
-zval *php_array_fetchn(zval *zarr, PAA_ULONG idx) {
+zval *php_array_fetchn(zval *zarr, zend_ulong idx) {
 	return zend_hash_index_find(Z_ARRVAL_P(zarr), idx);
 }
 static inline
@@ -201,7 +195,7 @@ static inline ctype php_array_fetchl_##ztype(zval *zarr, const char *key, int ke
 	{ return php_array_zval_to_##ztype(php_array_fetchl(zarr, key, key_len)); } \
 static inline ctype php_array_fetchl_safe_##ztype(zval *zarr, const char *key, int key_len) \
 	{ return php_array_zval_to_##ztype(php_array_fetchl_safe(zarr, key, key_len)); } \
-static inline ctype php_array_fetchn_##ztype(zval *zarr, PAA_ULONG idx) \
+static inline ctype php_array_fetchn_##ztype(zval *zarr, zend_ulong idx) \
 	{ return php_array_zval_to_##ztype(php_array_fetchn(zarr, idx)); } \
 static inline ctype php_array_fetchz_##ztype(zval *zarr, zval *key) \
 	{ return php_array_zval_to_##ztype(php_array_fetchz(zarr, key)); }
@@ -233,7 +227,7 @@ PHP_ARRAY_FETCH_TYPE_MAP(zend_bool, bool)
  * long php_array_fetchz_long(zval *zarr, zval *key)
  */
 static inline
-PAA_LONG php_array_zval_to_long(zval *z) {
+zend_long php_array_zval_to_long(zval *z) {
 try_again:
 	if (!z) { return 0; }
 	switch(Z_TYPE_P(z)) {
@@ -253,7 +247,7 @@ try_again:
 		}
 	}
 }
-PHP_ARRAY_FETCH_TYPE_MAP(PAA_LONG, long)
+PHP_ARRAY_FETCH_TYPE_MAP(zend_long, long)
 #define php_array_fetchc_long(zarr, litstr) \
 	php_array_zval_to_long(php_array_fetchc(zarr, litstr))
 
@@ -454,20 +448,20 @@ zval *php_array_zval_to_object(zval *z, zend_class_entry *ce) {
  */
 static inline
 void php_array_unset(zval *zarr, const char *key) {
-	PAA_SYM_DEL(Z_ARRVAL_P(zarr), key, PAA_LENGTH_ADJ(strlen(key)));
+	zend_symtable_str_del(Z_ARRVAL_P(zarr), key, strlen(key));
 }
 #define php_array_unsetl(zarr, key, len) \
-	PAA_SYM_DEL(Z_ARRVAL_P(zarr), key, PAA_LENGTH_ADJ(len))
+	zend_symtable_str_del(Z_ARRVAL_P(zarr), key, len)
 static inline
 void php_array_unsetl_safe(zval *zarr, const char *key, int key_len) {
 	char *k = estrndup(key, key_len);
-	PAA_SYM_DEL(Z_ARRVAL_P(zarr), k, PAA_LENGTH_ADJ(key_len));
+	zend_symtable_str_del(Z_ARRVAL_P(zarr), k, key_len);
 	efree(k);
 }
 #define php_array_unsetn(zarr, idx) \
 	zend_symtable_index_del(Z_ARRVAL_P(zarr), idx)
 #define php_array_unsetc(zarr, litstr) \
-	PAA_SYM_DEL(Z_ARRVAL_P(zarr), litstr, PAA_LENGTH_ADJ(sizeof(litstr) - 1))
+	zend_symtable_str_del(Z_ARRVAL_P(zarr), litstr, sizeof(litstr) - 1)
 static inline void php_array_unsetz(zval *zarr, zval *key) {
 	switch (Z_TYPE_P(key)) {
 		case IS_NULL:

--- a/src/contrib/php_array_api.h
+++ b/src/contrib/php_array_api.h
@@ -25,19 +25,11 @@
 #include "zend_hash.h"
 #include "zend_list.h"
 
-#ifdef ZEND_ENGINE_3
 # define PAA_LENGTH_ADJ(l) (l)
 # define PAA_SYM_EXISTS zend_symtable_str_exists
 # define PAA_SYM_DEL    zend_symtable_str_del
 # define PAA_LONG       zend_long
 # define PAA_ULONG      zend_ulong
-#else
-# define PAA_LENGTH_ADJ(l) (l+1)
-# define PAA_SYM_EXISTS zend_symtable_exists
-# define PAA_SYM_DEL    zend_symtable_del
-# define PAA_LONG       long
-# define PAA_ULONG      ulong
-#endif
 
 /**
  * All APIs in this file follow a general format:
@@ -89,15 +81,9 @@ zend_bool php_array_exists(zval *zarr, const char *key) {
 	PAA_SYM_EXISTS(Z_ARRVAL_P(zarr), key, PAA_LENGTH_ADJ(len))
 static inline
 zend_bool php_array_existsl_safe(zval *zarr, const char *key, int key_len) {
-#ifdef ZEND_ENGINE_3
 	zend_string *keystr = zend_string_init(key, key_len, 0);
 	zend_bool ret = zend_symtable_exists(Z_ARRVAL_P(zarr), keystr);
 	zend_string_release(keystr);
-#else
-	char *k = estrndup(key, key_len);
-	zend_bool ret = zend_symtable_exists(Z_ARRVAL_P(zarr), k, key_len + 1);
-	efree(k);
-#endif
 	return ret;
 }
 #define php_array_existsn(zarr, idx) \
@@ -107,14 +93,10 @@ zend_bool php_array_existsz(zval *zarr, zval *key) {
 	switch (Z_TYPE_P(key)) {
 		case IS_NULL:
 			return php_array_existsc(zarr, "");
-#ifdef ZEND_ENGINE_3
 		case IS_FALSE:
 			return zend_hash_index_exists(Z_ARRVAL_P(zarr), 0);
 		case IS_TRUE:
 			return zend_hash_index_exists(Z_ARRVAL_P(zarr), 1);
-#else
-		case IS_BOOL: /* fallthrough */
-#endif
 		case IS_LONG:
 			return zend_hash_index_exists(Z_ARRVAL_P(zarr), Z_LVAL_P(key));
 		case IS_DOUBLE:
@@ -174,17 +156,7 @@ zend_bool php_array_existsz(zval *zarr, zval *key) {
  */
 static inline
 zval *php_array_fetchl(zval *zarr, const char *key, int key_len) {
-#ifdef ZEND_ENGINE_3
 	return zend_symtable_str_find(Z_ARRVAL_P(zarr), key, key_len);
-#else
-	zval **ppzval;
-	if (FAILURE == zend_symtable_find(Z_ARRVAL_P(zarr),
-                                          key, key_len + 1,
-                                          (void**)&ppzval)) {
-		return NULL;
-	}
-	return *ppzval;
-#endif
 }
 static inline
 zval *php_array_fetch(zval *zarr, const char *key) {
@@ -193,43 +165,24 @@ zval *php_array_fetch(zval *zarr, const char *key) {
 #define php_array_fetchc(zarr, litstr) php_array_fetchl(zarr, litstr, sizeof(litstr)-1)
 static inline
 zval *php_array_fetchl_safe(zval *zarr, const char *key, int key_len) {
-#ifdef ZEND_ENGINE_3
 	zend_string *keystr = zend_string_init(key, key_len, 0);
 	zval *ret = zend_symtable_find(Z_ARRVAL_P(zarr), keystr);
 	zend_string_release(keystr);
-#else
-	char *k = estrndup(key, key_len);
-	zval *ret = php_array_fetchl(zarr, k, key_len);
-	efree(k);
-#endif
 	return ret;
 }
 static inline
 zval *php_array_fetchn(zval *zarr, PAA_ULONG idx) {
-#ifdef ZEND_ENGINE_3
 	return zend_hash_index_find(Z_ARRVAL_P(zarr), idx);
-#else
-	zval **ppzval;
-	if (FAILURE == zend_hash_index_find(Z_ARRVAL_P(zarr),
-	                                    idx, (void**)&ppzval)) {
-		return NULL;
-	}
-	return *ppzval;
-#endif
 }
 static inline
 zval *php_array_fetchz(zval *zarr, zval *key) {
 	switch (Z_TYPE_P(key)) {
 		case IS_NULL:
 			return php_array_fetchn(zarr, 0);
-#ifdef ZEND_ENGINE_3
 		case IS_FALSE:
 			return php_array_fetchn(zarr, 0);
 		case IS_TRUE:
 			return php_array_fetchn(zarr, 1);
-#else
-		case IS_BOOL: /* fallthrough */
-#endif
 		case IS_LONG:
 			return php_array_fetchn(zarr, Z_LVAL_P(key));
 		case IS_DOUBLE:
@@ -288,12 +241,8 @@ try_again:
 			ZVAL_DEREF(z);
 			goto try_again;
 		case IS_NULL: return 0;
-#ifdef ZEND_ENGINE_3
 		case IS_FALSE: return 0;
 		case IS_TRUE: return 1;
-#else
-		case IS_BOOL: return Z_BVAL_P(z);
-#endif
 		case IS_LONG: return Z_LVAL_P(z);
 		default:
 		{
@@ -326,12 +275,8 @@ try_again:
 			ZVAL_DEREF(z);
 			goto try_again;
 		case IS_NULL: return 0.0;
-#ifdef ZEND_ENGINE_3
 		case IS_FALSE: return 0.0;
 		case IS_TRUE: return 1.0;
-#else
-		case IS_BOOL: return (double)Z_BVAL_P(z);
-#endif
 		case IS_LONG: return (double)Z_LVAL_P(z);
 		case IS_DOUBLE: return Z_DVAL_P(z);
 		default:
@@ -381,11 +326,7 @@ try_again:
 			zval c = *z;
 			zval_copy_ctor(&c);
 			convert_to_string(&c);
-#ifdef ZEND_ENGINE_3
 			*pfree = ! IS_INTERNED(Z_STR(c));
-#else
-			*pfree = ! IS_INTERNED(Z_STRVAL(c));
-#endif
 			*plen = Z_STRLEN(c);
 			return Z_STRVAL(c);
 		}
@@ -454,18 +395,7 @@ PHP_ARRAY_FETCH_TYPE_MAP(zval*, array)
  */
 static inline
 void *php_array_zval_to_resource(zval *z, int le) {
-#ifdef ZEND_ENGINE_3
 	return zend_fetch_resource_ex(z, NULL, le);
-#else
-	void *ret;
-	int rtype;
- 	if (!z || Z_TYPE_P(z) != IS_RESOURCE) { return NULL; }
-	ret = zend_list_find(Z_RESVAL_P(z), &rtype);
-	if (!ret || (rtype != le)) {
-		return NULL;
-	}
-	return ret;
-#endif
 }
 #define php_array_fetch_resource(zarr, key, le) \
 	php_array_zval_to_resource(php_array_fetch(zarr, key), le)
@@ -543,16 +473,12 @@ static inline void php_array_unsetz(zval *zarr, zval *key) {
 		case IS_NULL:
 			zend_hash_index_del(Z_ARRVAL_P(zarr), 0);
 			return;
-#ifdef ZEND_ENGINE_3
 		case IS_FALSE:
 			zend_hash_index_del(Z_ARRVAL_P(zarr), 0);
 			return;
 		case IS_TRUE:
 			zend_hash_index_del(Z_ARRVAL_P(zarr), 1);
 			return;
-#else
-		case IS_BOOL: /* fallthrough */
-#endif
 		case IS_LONG:
 			zend_hash_index_del(Z_ARRVAL_P(zarr), Z_LVAL_P(key));
 			return;

--- a/src/contrib/php_array_api.h
+++ b/src/contrib/php_array_api.h
@@ -202,24 +202,24 @@ static inline zval* zval_deref_safe(zval* z) {
  * zval *php_array_fetchz_deref(zval *zarr, zval *key)
  */
 static inline
-	zval *php_array_fetchl_deref(zval *zarr, const char *key, int key_len) {
+zval *php_array_fetchl_deref(zval *zarr, const char *key, int key_len) {
 	return zval_deref_safe(php_array_fetchl(zarr, key, key_len));
 }
 static inline
-	zval *php_array_fetch_deref(zval *zarr, const char *key) {
+zval *php_array_fetch_deref(zval *zarr, const char *key) {
 	return zval_deref_safe(php_array_fetch(zarr, key));
 }
 #define php_array_fetchc_deref(zarr, litstr) zval_deref_safe(php_array_fetchl(zarr, litstr, sizeof(litstr)-1))
 static inline
-	zval *php_array_fetchl_safe_deref(zval *zarr, const char *key, int key_len) {
+zval *php_array_fetchl_safe_deref(zval *zarr, const char *key, int key_len) {
 	return zval_deref_safe(php_array_fetchl_safe(zarr, key, key_len));
 }
 static inline
-	zval *php_array_fetchn_deref(zval *zarr, zend_ulong idx) {
+zval *php_array_fetchn_deref(zval *zarr, zend_ulong idx) {
 	return zval_deref_safe(php_array_fetchn(zarr, idx));
 }
 static inline
-	zval *php_array_fetchz_deref(zval *zarr, zval *key) {
+zval *php_array_fetchz_deref(zval *zarr, zval *key) {
 	return zval_deref_safe(php_array_fetchz(zarr, key));
 }
 

--- a/src/phongo_client.c
+++ b/src/phongo_client.c
@@ -1001,7 +1001,7 @@ static bool php_phongo_extract_handshake_data(zval* driver, const char* key, cha
 		return true;
 	}
 
-	zvalue = php_array_fetch(driver, key);
+	zvalue = php_array_fetch_deref(driver, key);
 
 	if (Z_TYPE_P(zvalue) != IS_STRING) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"%s\" handshake option to be a string, %s given", key, PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zvalue));
@@ -1076,7 +1076,7 @@ static void php_phongo_set_handshake_data(zval* driverOptions)
 	size_t platform_len = 0;
 
 	if (driverOptions && php_array_existsc(driverOptions, "driver")) {
-		zval* driver = php_array_fetchc(driverOptions, "driver");
+		zval* driver = php_array_fetchc_deref(driverOptions, "driver");
 
 		if (Z_TYPE_P(driver) != IS_ARRAY) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"driver\" driver option to be an array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(driver));
@@ -1229,7 +1229,7 @@ static bool phongo_manager_set_serverapi_opts(php_phongo_manager_t* manager, zva
 		return true;
 	}
 
-	zServerApi = php_array_fetch(driverOptions, "serverApi");
+	zServerApi = php_array_fetchc_deref(driverOptions, "serverApi");
 
 	if (Z_TYPE_P(zServerApi) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(zServerApi), php_phongo_serverapi_ce)) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"serverApi\" driver option to be %s, %s given", ZSTR_VAL(php_phongo_serverapi_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zServerApi));
@@ -1258,7 +1258,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 		return true;
 	}
 
-	zAutoEncryptionOpts = php_array_fetch(driverOptions, "autoEncryption");
+	zAutoEncryptionOpts = php_array_fetchc_deref(driverOptions, "autoEncryption");
 
 	if (Z_TYPE_P(zAutoEncryptionOpts) != IS_ARRAY) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"autoEncryption\" driver option to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zAutoEncryptionOpts));
@@ -1268,15 +1268,15 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 	auto_encryption_opts = mongoc_auto_encryption_opts_new();
 
 	if (php_array_existsc(zAutoEncryptionOpts, "bypassAutoEncryption")) {
-		mongoc_auto_encryption_opts_set_bypass_auto_encryption(auto_encryption_opts, php_array_fetch_bool(zAutoEncryptionOpts, "bypassAutoEncryption"));
+		mongoc_auto_encryption_opts_set_bypass_auto_encryption(auto_encryption_opts, php_array_fetchc_bool(zAutoEncryptionOpts, "bypassAutoEncryption"));
 	}
 
 	if (php_array_existsc(zAutoEncryptionOpts, "bypassQueryAnalysis")) {
-		mongoc_auto_encryption_opts_set_bypass_query_analysis(auto_encryption_opts, php_array_fetch_bool(zAutoEncryptionOpts, "bypassQueryAnalysis"));
+		mongoc_auto_encryption_opts_set_bypass_query_analysis(auto_encryption_opts, php_array_fetchc_bool(zAutoEncryptionOpts, "bypassQueryAnalysis"));
 	}
 
 	if (php_array_existsc(zAutoEncryptionOpts, "encryptedFieldsMap")) {
-		zval*  enc_fields_map = php_array_fetch(zAutoEncryptionOpts, "encryptedFieldsMap");
+		zval*  enc_fields_map = php_array_fetchc_deref(zAutoEncryptionOpts, "encryptedFieldsMap");
 		bson_t bson_map       = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(enc_fields_map) != IS_OBJECT && Z_TYPE_P(enc_fields_map) != IS_ARRAY) {
@@ -1299,7 +1299,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 	}
 
 	if (php_array_existsc(zAutoEncryptionOpts, "keyVaultClient")) {
-		zval* key_vault_client = php_array_fetch(zAutoEncryptionOpts, "keyVaultClient");
+		zval* key_vault_client = php_array_fetchc_deref(zAutoEncryptionOpts, "keyVaultClient");
 
 		if (Z_TYPE_P(key_vault_client) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(key_vault_client), php_phongo_manager_ce)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyVaultClient\" autoEncryption option to be %s, %s given", ZSTR_VAL(php_phongo_manager_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(key_vault_client));
@@ -1329,7 +1329,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 		int       plen;
 		zend_bool pfree;
 
-		key_vault_ns = php_array_fetch_string(zAutoEncryptionOpts, "keyVaultNamespace", &plen, &pfree);
+		key_vault_ns = php_array_fetchc_string(zAutoEncryptionOpts, "keyVaultNamespace", &plen, &pfree);
 
 		if (!phongo_split_namespace(key_vault_ns, &db_name, &coll_name)) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyVaultNamespace\" autoEncryption option to contain a full collection namespace");
@@ -1352,7 +1352,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 	}
 
 	if (php_array_existsc(zAutoEncryptionOpts, "kmsProviders")) {
-		zval*  kms_providers  = php_array_fetch(zAutoEncryptionOpts, "kmsProviders");
+		zval*  kms_providers  = php_array_fetchc_deref(zAutoEncryptionOpts, "kmsProviders");
 		bson_t bson_providers = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(kms_providers) != IS_OBJECT && Z_TYPE_P(kms_providers) != IS_ARRAY) {
@@ -1371,7 +1371,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 	}
 
 	if (php_array_existsc(zAutoEncryptionOpts, "schemaMap")) {
-		zval*  schema_map = php_array_fetch(zAutoEncryptionOpts, "schemaMap");
+		zval*  schema_map = php_array_fetchc_deref(zAutoEncryptionOpts, "schemaMap");
 		bson_t bson_map   = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(schema_map) != IS_OBJECT && Z_TYPE_P(schema_map) != IS_ARRAY) {
@@ -1390,7 +1390,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 	}
 
 	if (php_array_existsc(zAutoEncryptionOpts, "tlsOptions")) {
-		zval*  tls_options  = php_array_fetch(zAutoEncryptionOpts, "tlsOptions");
+		zval*  tls_options  = php_array_fetchc_deref(zAutoEncryptionOpts, "tlsOptions");
 		bson_t bson_options = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(tls_options) != IS_OBJECT && Z_TYPE_P(tls_options) != IS_ARRAY) {
@@ -1409,7 +1409,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 	}
 
 	if (php_array_existsc(zAutoEncryptionOpts, "extraOptions")) {
-		zval*  extra_options = php_array_fetch(zAutoEncryptionOpts, "extraOptions");
+		zval*  extra_options = php_array_fetchc_deref(zAutoEncryptionOpts, "extraOptions");
 		bson_t bson_options  = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(extra_options) != IS_OBJECT && Z_TYPE_P(extra_options) != IS_ARRAY) {

--- a/src/phongo_execute.c
+++ b/src/phongo_execute.c
@@ -80,7 +80,7 @@ static bool phongo_parse_read_concern(zval* options, bson_t* mongoc_opts)
 		return false;
 	}
 
-	option = php_array_fetchc(options, "readConcern");
+	option = php_array_fetchc_deref(options, "readConcern");
 
 	if (!option) {
 		return true;
@@ -117,7 +117,7 @@ bool phongo_parse_read_preference(zval* options, zval** zreadPreference)
 		return false;
 	}
 
-	option = php_array_fetchc(options, "readPreference");
+	option = php_array_fetchc_deref(options, "readPreference");
 
 	if (!option) {
 		return true;
@@ -155,7 +155,7 @@ bool phongo_parse_session(zval* options, mongoc_client_t* client, bson_t* mongoc
 		return false;
 	}
 
-	option = php_array_fetchc(options, "session");
+	option = php_array_fetchc_deref(options, "session");
 
 	if (!option) {
 		return true;
@@ -203,7 +203,7 @@ static bool phongo_parse_write_concern(zval* options, bson_t* mongoc_opts, zval*
 		return false;
 	}
 
-	option = php_array_fetchc(options, "writeConcern");
+	option = php_array_fetchc_deref(options, "writeConcern");
 
 	if (!option) {
 		return true;

--- a/tests/query/bug2457-001.phpt
+++ b/tests/query/bug2457-001.phpt
@@ -1,12 +1,16 @@
 --TEST--
-PHPC-2457: Query modifiers can be passed reference
+PHPC-2457: Query options can be passed reference
 --FILE--
 <?php
 
-$modifiers = ['$orderby' => ['x' => 1]];
+$collation = ['locale' => 'fr_FR', 'strength' => 2];
+$let = ['x' => 1];
+$sort = ['_id' => 1];
 
 $query = new MongoDB\Driver\Query([], [
-    'modifiers' => &$modifiers,
+    'collation' => &$collation,
+    'let' => &$let,
+    'sort' => &$sort,
 ]);
 
 var_dump($query);
@@ -14,17 +18,28 @@ var_dump($query);
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
-Deprecated: MongoDB\Driver\Query::__construct(): The "modifiers" option is deprecated and will be removed in a future release in %s
+--EXPECT--
 object(MongoDB\Driver\Query)#1 (3) {
   ["filter"]=>
   object(stdClass)#2 (0) {
   }
   ["options"]=>
-  object(stdClass)#4 (1) {
-    ["sort"]=>
-    object(stdClass)#3 (1) {
+  object(stdClass)#6 (3) {
+    ["collation"]=>
+    object(stdClass)#3 (2) {
+      ["locale"]=>
+      string(5) "fr_FR"
+      ["strength"]=>
+      int(2)
+    }
+    ["let"]=>
+    object(stdClass)#4 (1) {
       ["x"]=>
+      int(1)
+    }
+    ["sort"]=>
+    object(stdClass)#5 (1) {
+      ["_id"]=>
       int(1)
     }
   }

--- a/tests/query/bug2457-001.phpt
+++ b/tests/query/bug2457-001.phpt
@@ -1,0 +1,34 @@
+--TEST--
+PHPC-2457: Query modifiers can be passed reference
+--FILE--
+<?php
+
+$modifiers = ['$orderby' => ['x' => 1]];
+
+$query = new MongoDB\Driver\Query([], [
+    'modifiers' => &$modifiers,
+]);
+
+var_dump($query);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Deprecated: MongoDB\Driver\Query::__construct(): The "modifiers" option is deprecated and will be removed in a future release in %s
+object(MongoDB\Driver\Query)#1 (3) {
+  ["filter"]=>
+  object(stdClass)#2 (0) {
+  }
+  ["options"]=>
+  object(stdClass)#4 (1) {
+    ["sort"]=>
+    object(stdClass)#3 (1) {
+      ["x"]=>
+      int(1)
+    }
+  }
+  ["readConcern"]=>
+  NULL
+}
+===DONE===

--- a/tests/query/bug2457-002.phpt
+++ b/tests/query/bug2457-002.phpt
@@ -1,0 +1,49 @@
+--TEST--
+PHPC-2457: Query options can be passed reference
+--FILE--
+<?php
+
+$collation = ['locale' => 'fr_FR', 'strength' => 2];
+$let = ['x' => 1];
+$sort = ['_id' => 1];
+
+$query = new MongoDB\Driver\Query([], [
+    'collation' => &$collation,
+    'let' => &$let,
+    'sort' => &$sort,
+]);
+
+var_dump($query);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+object(MongoDB\Driver\Query)#1 (3) {
+  ["filter"]=>
+  object(stdClass)#2 (0) {
+  }
+  ["options"]=>
+  object(stdClass)#6 (3) {
+    ["collation"]=>
+    object(stdClass)#3 (2) {
+      ["locale"]=>
+      string(5) "fr_FR"
+      ["strength"]=>
+      int(2)
+    }
+    ["let"]=>
+    object(stdClass)#4 (1) {
+      ["x"]=>
+      int(1)
+    }
+    ["sort"]=>
+    object(stdClass)#5 (1) {
+      ["_id"]=>
+      int(1)
+    }
+  }
+  ["readConcern"]=>
+  NULL
+}
+===DONE===

--- a/tests/query/bug2457-002.phpt
+++ b/tests/query/bug2457-002.phpt
@@ -1,16 +1,12 @@
 --TEST--
-PHPC-2457: Query options can be passed reference
+PHPC-2457: Query modifiers can be passed reference
 --FILE--
 <?php
 
-$collation = ['locale' => 'fr_FR', 'strength' => 2];
-$let = ['x' => 1];
-$sort = ['_id' => 1];
+$modifiers = ['$orderby' => ['x' => 1]];
 
 $query = new MongoDB\Driver\Query([], [
-    'collation' => &$collation,
-    'let' => &$let,
-    'sort' => &$sort,
+    'modifiers' => &$modifiers,
 ]);
 
 var_dump($query);
@@ -18,28 +14,17 @@ var_dump($query);
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
+Deprecated: MongoDB\Driver\Query::__construct(): The "modifiers" option is deprecated and will be removed in a future release in %s
 object(MongoDB\Driver\Query)#1 (3) {
   ["filter"]=>
   object(stdClass)#2 (0) {
   }
   ["options"]=>
-  object(stdClass)#6 (3) {
-    ["collation"]=>
-    object(stdClass)#3 (2) {
-      ["locale"]=>
-      string(5) "fr_FR"
-      ["strength"]=>
-      int(2)
-    }
-    ["let"]=>
-    object(stdClass)#4 (1) {
-      ["x"]=>
-      int(1)
-    }
+  object(stdClass)#4 (1) {
     ["sort"]=>
-    object(stdClass)#5 (1) {
-      ["_id"]=>
+    object(stdClass)#3 (1) {
+      ["x"]=>
       int(1)
     }
   }


### PR DESCRIPTION
PHPC-2457

Previous fixes for this were made in #1683 and #1223, but both attempts resulted in missed cases. #1694 fixes this for query modifiers and options, but a number of other occurrences were affected, as evidenced by the changes in this PR.

To fix this on a wider scale, I made a few adjustments to `php_array_api.h`, some of them unrelated:
* (unrelated) remove support for zend_engine 2 (PHP < 7)
* (unrelated) simplify some switch statements and fix casts
* add `php_array_fetch*_deref`
* change `php_array_fetch*_<type>` to always use `*_deref` version

After making this change, I audited all usages of `php_array_fetch*` and updated them accordingly. If references were correctly handled (such as in `phongo_zval_to_bson_value` which always calls `ZVAL_DEREF`), the call was not changed. Most cases immediately checked types after calling `php_array_fetch`, which was changed to `php_array_fetch_deref`.

In addition, I changed a number of usages of `php_array_fetch` to `php_array_fetchc` when a constant string was used.

I also included the tests added in #1694, but did not add tests for each and every usage that was changed. Let me know if you think those tests are necessary.