### PR TITLE
Use RHEL 8 to test old server versions

### DIFF
--- a/.evergreen/config/build-variants.yml
+++ b/.evergreen/config/build-variants.yml
@@ -16,18 +16,6 @@ buildvariants:
     run_on: debian11-small
     tasks:
       - name: "build-all-php"
-  - name: build-debian10
-    display_name: "Build: Debian 10"
-    tags: ["build", "debian", "x64", "pr", "tag"]
-    run_on: debian10-small
-    tasks:
-      - name: "build-all-php"
-  - name: build-debian92
-    display_name: "Build: Debian 9.2"
-    tags: ["build", "debian", "x64", "pr", "tag"]
-    run_on: debian92-small
-    tasks:
-      - name: "build-all-php"
 
   # RHEL
   - name: build-rhel90

--- a/.evergreen/config/generated/test-variant/legacy-php-full.yml
+++ b/.evergreen/config/generated/test-variant/legacy-php-full.yml
@@ -38,15 +38,15 @@ buildvariants:
           - ".ocsp .5.0"
 
   # Test versions < 5.0
-  - name: test-debian92-php-8.0
-    tags: ["test", "debian", "x64", "php8.0", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 8.0"
-    run_on: debian92-small
+  - name: test-rhel80-php-8.0
+    tags: ["test", "rhel", "x64", "php8.0", "pr", "tag"]
+    display_name: "Test: RHEL 8.0, PHP 8.0"
+    run_on: rhel80-small
     expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
+      FETCH_BUILD_VARIANT: "build-rhel8"
       FETCH_BUILD_TASK: "build-php-8.0"
     depends_on:
-      - variant: "build-debian92"
+      - variant: "build-rhel8"
         name: "build-php-8.0"
     tasks:
       # Remember to add new major versions here as they are released
@@ -97,15 +97,15 @@ buildvariants:
           - ".ocsp .5.0"
 
   # Test versions < 5.0
-  - name: test-debian92-php-7.4
-    tags: ["test", "debian", "x64", "php7.4", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 7.4"
-    run_on: debian92-small
+  - name: test-rhel80-php-7.4
+    tags: ["test", "rhel", "x64", "php7.4", "pr", "tag"]
+    display_name: "Test: RHEL 8.0, PHP 7.4"
+    run_on: rhel80-small
     expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
+      FETCH_BUILD_VARIANT: "build-rhel8"
       FETCH_BUILD_TASK: "build-php-7.4"
     depends_on:
-      - variant: "build-debian92"
+      - variant: "build-rhel8"
         name: "build-php-7.4"
     tasks:
       # Remember to add new major versions here as they are released

--- a/.evergreen/config/generated/test-variant/modern-php-full.yml
+++ b/.evergreen/config/generated/test-variant/modern-php-full.yml
@@ -59,15 +59,15 @@ buildvariants:
           - ".ocsp .5.0"
 
   # Test versions < 5.0
-  - name: test-debian92-php-8.3
-    tags: ["test", "debian", "x64", "php8.3", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 8.3"
-    run_on: debian92-small
+  - name: test-rhel80-php-8.3
+    tags: ["test", "rhel", "x64", "php8.3", "pr", "tag"]
+    display_name: "Test: RHEL 8.0, PHP 8.3"
+    run_on: rhel80-small
     expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
+      FETCH_BUILD_VARIANT: "build-rhel8"
       FETCH_BUILD_TASK: "build-php-8.3"
     depends_on:
-      - variant: "build-debian92"
+      - variant: "build-rhel8"
         name: "build-php-8.3"
     tasks:
       # Remember to add new major versions here as they are released
@@ -139,15 +139,15 @@ buildvariants:
           - ".ocsp .5.0"
 
   # Test versions < 5.0
-  - name: test-debian92-php-8.2
-    tags: ["test", "debian", "x64", "php8.2", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 8.2"
-    run_on: debian92-small
+  - name: test-rhel80-php-8.2
+    tags: ["test", "rhel", "x64", "php8.2", "pr", "tag"]
+    display_name: "Test: RHEL 8.0, PHP 8.2"
+    run_on: rhel80-small
     expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
+      FETCH_BUILD_VARIANT: "build-rhel8"
       FETCH_BUILD_TASK: "build-php-8.2"
     depends_on:
-      - variant: "build-debian92"
+      - variant: "build-rhel8"
         name: "build-php-8.2"
     tasks:
       # Remember to add new major versions here as they are released
@@ -219,15 +219,15 @@ buildvariants:
           - ".ocsp .5.0"
 
   # Test versions < 5.0
-  - name: test-debian92-php-8.1
-    tags: ["test", "debian", "x64", "php8.1", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 8.1"
-    run_on: debian92-small
+  - name: test-rhel80-php-8.1
+    tags: ["test", "rhel", "x64", "php8.1", "pr", "tag"]
+    display_name: "Test: RHEL 8.0, PHP 8.1"
+    run_on: rhel80-small
     expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
+      FETCH_BUILD_VARIANT: "build-rhel8"
       FETCH_BUILD_TASK: "build-php-8.1"
     depends_on:
-      - variant: "build-debian92"
+      - variant: "build-rhel8"
         name: "build-php-8.1"
     tasks:
       # Remember to add new major versions here as they are released

--- a/.evergreen/config/templates/test-variant/legacy-php-full.yml
+++ b/.evergreen/config/templates/test-variant/legacy-php-full.yml
@@ -36,15 +36,15 @@
           - ".ocsp .5.0"
 
   # Test versions < 5.0
-  - name: test-debian92-php-%phpVersion%
-    tags: ["test", "debian", "x64", "php%phpVersion%", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP %phpVersion%"
-    run_on: debian92-small
+  - name: test-rhel80-php-%phpVersion%
+    tags: ["test", "rhel", "x64", "php%phpVersion%", "pr", "tag"]
+    display_name: "Test: RHEL 8.0, PHP %phpVersion%"
+    run_on: rhel80-small
     expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
+      FETCH_BUILD_VARIANT: "build-rhel8"
       FETCH_BUILD_TASK: "build-php-%phpVersion%"
     depends_on:
-      - variant: "build-debian92"
+      - variant: "build-rhel8"
         name: "build-php-%phpVersion%"
     tasks:
       # Remember to add new major versions here as they are released

--- a/.evergreen/config/templates/test-variant/modern-php-full.yml
+++ b/.evergreen/config/templates/test-variant/modern-php-full.yml
@@ -57,15 +57,15 @@
           - ".ocsp .5.0"
 
   # Test versions < 5.0
-  - name: test-debian92-php-%phpVersion%
-    tags: ["test", "debian", "x64", "php%phpVersion%", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP %phpVersion%"
-    run_on: debian92-small
+  - name: test-rhel80-php-%phpVersion%
+    tags: ["test", "rhel", "x64", "php%phpVersion%", "pr", "tag"]
+    display_name: "Test: RHEL 8.0, PHP %phpVersion%"
+    run_on: rhel80-small
     expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
+      FETCH_BUILD_VARIANT: "build-rhel8"
       FETCH_BUILD_TASK: "build-php-%phpVersion%"
     depends_on:
-      - variant: "build-debian92"
+      - variant: "build-rhel8"
         name: "build-php-%phpVersion%"
     tasks:
       # Remember to add new major versions here as they are released


### PR DESCRIPTION
This PR drops Debian 10 and Debian 9.2 from our build pipeline. Debian 9.2 was used to test MongoDB < 5.0, which will be tested on RHEL 8 going forwards. Debian 10 isn't used at all, so we can safely drop it as well. This will make it easier to test with PHP 8.4 on Evergreen, which isn't available on Debian 9.2 due to an old openssl version.