### PR TITLE
PHPC-2460: Use zend_zval_type_name instead of internal macros

### DIFF
--- a/php_phongo.h
+++ b/php_phongo.h
@@ -82,9 +82,6 @@ zend_object_handlers* phongo_get_std_object_handlers(void);
 		}                                                   \
 	} while (0)
 
-#define PHONGO_ZVAL_CLASS_OR_TYPE_NAME(zv) (Z_TYPE(zv) == IS_OBJECT ? ZSTR_VAL(Z_OBJCE(zv)->name) : zend_get_type_by_const(Z_TYPE(zv)))
-#define PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zvp) PHONGO_ZVAL_CLASS_OR_TYPE_NAME(*(zvp))
-
 #define PHONGO_ZVAL_EXCEPTION_NAME(e) (ZSTR_VAL(e->ce->name))
 
 #define PHONGO_SET_CREATED_BY_PID(intern)          \

--- a/src/BSON/Document.c
+++ b/src/BSON/Document.c
@@ -328,7 +328,7 @@ static PHP_METHOD(MongoDB_BSON_Document, offsetGet)
 	intern = Z_DOCUMENT_OBJ_P(getThis());
 
 	if (Z_TYPE_P(offset) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key of type \"%s\" in BSON document", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(offset));
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key of type \"%s\" in BSON document", zend_zval_type_name(offset));
 		return;
 	}
 
@@ -598,7 +598,7 @@ zval* php_phongo_document_read_dimension(zend_object* object, zval* offset, int 
 			return rv;
 		}
 
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key of type \"%s\" in BSON document", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(offset));
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find key of type \"%s\" in BSON document", zend_zval_type_name(offset));
 		return &EG(uninitialized_zval);
 	}
 

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -103,7 +103,7 @@ static PHP_METHOD(MongoDB_BSON_Int64, __construct)
 	} else if (Z_TYPE_P(value) == IS_LONG) {
 		php_phongo_int64_init(intern, Z_LVAL_P(value));
 	} else {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected value to be integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(value));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected value to be integer or string, %s given", zend_zval_type_name(value));
 	}
 }
 

--- a/src/BSON/Iterator.c
+++ b/src/BSON/Iterator.c
@@ -54,13 +54,13 @@ static bool php_phongo_iterator_init_with_zval(php_phongo_iterator_t* iterator, 
 	bson = php_phongo_iterator_get_bson_from_zval(zbson);
 	if (!bson) {
 		/* Should never happen, but if it does: exception */
-		phongo_throw_exception(PHONGO_ERROR_LOGIC, "Could not create iterator for %s instance", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zbson));
+		phongo_throw_exception(PHONGO_ERROR_LOGIC, "Could not create iterator for %s instance", zend_zval_type_name(zbson));
 
 		return false;
 	}
 
 	if (!bson_iter_init(&iterator->iter, bson)) {
-		phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE, "Could not create iterator for %s instance", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zbson));
+		phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE, "Could not create iterator for %s instance", zend_zval_type_name(zbson));
 
 		return false;
 	}

--- a/src/BSON/PackedArray.c
+++ b/src/BSON/PackedArray.c
@@ -354,7 +354,7 @@ static PHP_METHOD(MongoDB_BSON_PackedArray, offsetGet)
 	intern = Z_PACKEDARRAY_OBJ_P(getThis());
 
 	if (Z_TYPE_P(key) != IS_LONG) {
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find index of type \"%s\" in BSON array", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(key));
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find index of type \"%s\" in BSON array", zend_zval_type_name(key));
 		return;
 	}
 
@@ -587,7 +587,7 @@ zval* php_phongo_packedarray_read_dimension(zend_object* object, zval* offset, i
 			return rv;
 		}
 
-		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find index of type \"%s\" in BSON array", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(offset));
+		phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Could not find index of type \"%s\" in BSON array", zend_zval_type_name(offset));
 		return &EG(uninitialized_zval);
 	}
 

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -144,7 +144,7 @@ static PHP_METHOD(MongoDB_BSON_Timestamp, __construct)
 	}
 
 	if (Z_TYPE_P(increment) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected increment to be an unsigned 32-bit integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(increment));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected increment to be an unsigned 32-bit integer or string, %s given", zend_zval_type_name(increment));
 		return;
 	}
 
@@ -153,7 +153,7 @@ static PHP_METHOD(MongoDB_BSON_Timestamp, __construct)
 	}
 
 	if (Z_TYPE_P(timestamp) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected timestamp to be an unsigned 32-bit integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(timestamp));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected timestamp to be an unsigned 32-bit integer or string, %s given", zend_zval_type_name(timestamp));
 		return;
 	}
 

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -230,7 +230,7 @@ static PHP_METHOD(MongoDB_BSON_UTCDateTime, __construct)
 			return;
 	}
 
-	phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(milliseconds));
+	phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected integer or string, %s given", zend_zval_type_name(milliseconds));
 }
 
 static PHP_METHOD(MongoDB_BSON_UTCDateTime, __set_state)

--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -429,7 +429,7 @@ static PHP_METHOD(MongoDB_Driver_ClientEncryption, rewrapManyDataKey)
 		zval* zmasterkey = php_array_fetchc_deref(options, "masterKey");
 
 		if (Z_TYPE_P(zmasterkey) != IS_OBJECT && Z_TYPE_P(zmasterkey) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"masterKey\" option to be array or object, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zmasterkey));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"masterKey\" option to be array or object, %s given", zend_zval_type_name(zmasterkey));
 			goto cleanup;
 		}
 
@@ -552,7 +552,7 @@ static mongoc_client_encryption_opts_t* phongo_clientencryption_opts_from_zval(z
 		zval* key_vault_client = php_array_fetchc_deref(options, "keyVaultClient");
 
 		if (Z_TYPE_P(key_vault_client) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(key_vault_client), php_phongo_manager_ce)) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyVaultClient\" option to be %s, %s given", ZSTR_VAL(php_phongo_manager_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(key_vault_client));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyVaultClient\" option to be %s, %s given", ZSTR_VAL(php_phongo_manager_ce->name), zend_zval_type_name(key_vault_client));
 			goto cleanup;
 		}
 
@@ -601,7 +601,7 @@ static mongoc_client_encryption_opts_t* phongo_clientencryption_opts_from_zval(z
 		bson_t bson_providers = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(kms_providers) != IS_ARRAY && Z_TYPE_P(kms_providers) != IS_OBJECT) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"kmsProviders\" option to be an array or object, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(kms_providers));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"kmsProviders\" option to be an array or object, %s given", zend_zval_type_name(kms_providers));
 			goto cleanup;
 		}
 
@@ -619,7 +619,7 @@ static mongoc_client_encryption_opts_t* phongo_clientencryption_opts_from_zval(z
 		bson_t bson_options = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(tls_options) != IS_ARRAY && Z_TYPE_P(tls_options) != IS_OBJECT) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"tlsOptions\" option to be an array or object, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(tls_options));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"tlsOptions\" option to be an array or object, %s given", zend_zval_type_name(tls_options));
 			goto cleanup;
 		}
 
@@ -715,7 +715,7 @@ static mongoc_client_encryption_datakey_opts_t* phongo_clientencryption_datakey_
 		bool       failed = false;
 
 		if (!zkeyaltnames || Z_TYPE_P(zkeyaltnames) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected keyAltNames to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zkeyaltnames));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected keyAltNames to be array, %s given", zend_zval_type_name(zkeyaltnames));
 			goto cleanup;
 		}
 
@@ -738,9 +738,9 @@ static mongoc_client_encryption_datakey_opts_t* phongo_clientencryption_datakey_
 
 				if (Z_TYPE_P(keyaltname) != IS_STRING) {
 					if (string_key) {
-						phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected keyAltName with index \"%s\" to be string, %s given", ZSTR_VAL(string_key), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(keyaltname));
+						phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected keyAltName with index \"%s\" to be string, %s given", ZSTR_VAL(string_key), zend_zval_type_name(keyaltname));
 					} else {
-						phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected keyAltName with index \"%lu\" to be string, %s given", num_key, PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(keyaltname));
+						phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected keyAltName with index \"%lu\" to be string, %s given", num_key, zend_zval_type_name(keyaltname));
 					}
 
 					failed = true;
@@ -771,7 +771,7 @@ static mongoc_client_encryption_datakey_opts_t* phongo_clientencryption_datakey_
 		zval* keyMaterial = php_array_fetchc_deref(options, "keyMaterial");
 
 		if (Z_TYPE_P(keyMaterial) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(keyMaterial), php_phongo_binary_ce)) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyMaterial\" option to be %s, %s given", ZSTR_VAL(php_phongo_binary_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(keyMaterial));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyMaterial\" option to be %s, %s given", ZSTR_VAL(php_phongo_binary_ce->name), zend_zval_type_name(keyMaterial));
 			goto cleanup;
 		}
 
@@ -783,7 +783,7 @@ static mongoc_client_encryption_datakey_opts_t* phongo_clientencryption_datakey_
 		bson_t masterkey  = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(zmasterkey) != IS_OBJECT && Z_TYPE_P(zmasterkey) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"masterKey\" option to be array or object, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zmasterkey));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"masterKey\" option to be array or object, %s given", zend_zval_type_name(zmasterkey));
 			goto cleanup;
 		}
 

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -741,7 +741,7 @@ static PHP_METHOD(MongoDB_Driver_Manager, startSession)
 			phongo_throw_exception(
 				PHONGO_ERROR_INVALID_ARGUMENT,
 				"Expected \"defaultTransactionOptions\" option to be an array, %s given",
-				PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(txn_options));
+				zend_zval_type_name(txn_options));
 			goto cleanup;
 		}
 

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -39,7 +39,7 @@ static bool php_phongo_query_opts_append_string(bson_t* opts, const char* opts_k
 	zval* value = php_array_fetch_deref(zarr, zarr_key);
 
 	if (Z_TYPE_P(value) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"%s\" %s to be string, %s given", zarr_key, zarr_key[0] == '$' ? "modifier" : "option", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(value));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"%s\" %s to be string, %s given", zarr_key, zarr_key[0] == '$' ? "modifier" : "option", zend_zval_type_name(value));
 		return false;
 	}
 
@@ -59,7 +59,7 @@ static bool php_phongo_query_opts_append_document(bson_t* opts, const char* opts
 	bson_t b     = BSON_INITIALIZER;
 
 	if (Z_TYPE_P(value) != IS_OBJECT && Z_TYPE_P(value) != IS_ARRAY) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"%s\" %s to be array or object, %s given", zarr_key, zarr_key[0] == '$' ? "modifier" : "option", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(value));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"%s\" %s to be array or object, %s given", zarr_key, zarr_key[0] == '$' ? "modifier" : "option", zend_zval_type_name(value));
 		return false;
 	}
 
@@ -249,7 +249,7 @@ static bool php_phongo_query_init_readconcern(php_phongo_query_t* intern, zval* 
 	read_concern = php_array_fetchc_deref(options, "readConcern");
 
 	if (Z_TYPE_P(read_concern) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(read_concern), php_phongo_readconcern_ce)) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(read_concern));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), zend_zval_type_name(read_concern));
 		return false;
 	}
 
@@ -303,7 +303,7 @@ bool phongo_query_init(zval* return_value, zval* filter, zval* options)
 	}
 
 	if (Z_TYPE_P(return_value) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(return_value), php_phongo_query_ce)) {
-		phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE, "Expected initialization object to be %s, %s given", ZSTR_VAL(php_phongo_query_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(return_value));
+		phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE, "Expected initialization object to be %s, %s given", ZSTR_VAL(php_phongo_query_ce->name), zend_zval_type_name(return_value));
 		return false;
 	}
 
@@ -336,7 +336,7 @@ bool phongo_query_init(zval* return_value, zval* filter, zval* options)
 		modifiers = php_array_fetchc_deref(options, "modifiers");
 
 		if (Z_TYPE_P(modifiers) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"modifiers\" option to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(modifiers));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"modifiers\" option to be array, %s given", zend_zval_type_name(modifiers));
 			return false;
 		}
 

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -225,7 +225,7 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, __construct)
 			return;
 		}
 	} else {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected mode to be integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(mode));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected mode to be integer or string, %s given", zend_zval_type_name(mode));
 		return;
 	}
 

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -381,7 +381,7 @@ mongoc_transaction_opt_t* php_mongodb_session_parse_transaction_options(zval* op
 		zval* read_concern = php_array_fetchc_deref(options, "readConcern");
 
 		if (Z_TYPE_P(read_concern) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(read_concern), php_phongo_readconcern_ce)) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(read_concern));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), zend_zval_type_name(read_concern));
 			if (opts) {
 				mongoc_transaction_opts_destroy(opts);
 			}
@@ -399,7 +399,7 @@ mongoc_transaction_opt_t* php_mongodb_session_parse_transaction_options(zval* op
 		zval* read_preference = php_array_fetchc_deref(options, "readPreference");
 
 		if (Z_TYPE_P(read_preference) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(read_preference), php_phongo_readpreference_ce)) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readPreference\" option to be %s, %s given", ZSTR_VAL(php_phongo_readpreference_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(read_preference));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readPreference\" option to be %s, %s given", ZSTR_VAL(php_phongo_readpreference_ce->name), zend_zval_type_name(read_preference));
 			if (opts) {
 				mongoc_transaction_opts_destroy(opts);
 			}
@@ -417,7 +417,7 @@ mongoc_transaction_opt_t* php_mongodb_session_parse_transaction_options(zval* op
 		zval* write_concern = php_array_fetchc_deref(options, "writeConcern");
 
 		if (Z_TYPE_P(write_concern) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(write_concern), php_phongo_writeconcern_ce)) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"writeConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_writeconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(write_concern));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"writeConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_writeconcern_ce->name), zend_zval_type_name(write_concern));
 			if (opts) {
 				mongoc_transaction_opts_destroy(opts);
 			}

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -138,7 +138,7 @@ static PHP_METHOD(MongoDB_Driver_WriteConcern, __construct)
 			mongoc_write_concern_set_wtag(intern->write_concern, Z_STRVAL_P(w));
 		}
 	} else {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected w to be integer or string, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(w));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected w to be integer or string, %s given", zend_zval_type_name(w));
 		return;
 	}
 

--- a/src/phongo_bson_encode.c
+++ b/src/phongo_bson_encode.c
@@ -104,7 +104,7 @@ static inline bool phongo_check_bson_serialize_return_type(zval* retval, zend_cl
 								   ZSTR_VAL(ce->name),
 								   BSON_SERIALIZE_FUNC_NAME,
 								   ZSTR_VAL(php_phongo_document_ce->name),
-								   PHONGO_ZVAL_CLASS_OR_TYPE_NAME(*retval));
+								   zend_zval_type_name(retval));
 			return false;
 		}
 
@@ -121,7 +121,7 @@ static inline bool phongo_check_bson_serialize_return_type(zval* retval, zend_cl
 								   BSON_SERIALIZE_FUNC_NAME,
 								   ZSTR_VAL(php_phongo_document_ce->name),
 								   ZSTR_VAL(php_phongo_packedarray_ce->name),
-								   PHONGO_ZVAL_CLASS_OR_TYPE_NAME(*retval));
+								   zend_zval_type_name(retval));
 			return false;
 		}
 

--- a/src/phongo_client.c
+++ b/src/phongo_client.c
@@ -1004,7 +1004,7 @@ static bool php_phongo_extract_handshake_data(zval* driver, const char* key, cha
 	zvalue = php_array_fetch_deref(driver, key);
 
 	if (Z_TYPE_P(zvalue) != IS_STRING) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"%s\" handshake option to be a string, %s given", key, PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zvalue));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"%s\" handshake option to be a string, %s given", key, zend_zval_type_name(zvalue));
 		return false;
 	}
 
@@ -1079,7 +1079,7 @@ static void php_phongo_set_handshake_data(zval* driverOptions)
 		zval* driver = php_array_fetchc_deref(driverOptions, "driver");
 
 		if (Z_TYPE_P(driver) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"driver\" driver option to be an array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(driver));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"driver\" driver option to be an array, %s given", zend_zval_type_name(driver));
 			return;
 		}
 
@@ -1232,7 +1232,7 @@ static bool phongo_manager_set_serverapi_opts(php_phongo_manager_t* manager, zva
 	zServerApi = php_array_fetchc_deref(driverOptions, "serverApi");
 
 	if (Z_TYPE_P(zServerApi) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(zServerApi), php_phongo_serverapi_ce)) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"serverApi\" driver option to be %s, %s given", ZSTR_VAL(php_phongo_serverapi_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zServerApi));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"serverApi\" driver option to be %s, %s given", ZSTR_VAL(php_phongo_serverapi_ce->name), zend_zval_type_name(zServerApi));
 		return false;
 	}
 
@@ -1261,7 +1261,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 	zAutoEncryptionOpts = php_array_fetchc_deref(driverOptions, "autoEncryption");
 
 	if (Z_TYPE_P(zAutoEncryptionOpts) != IS_ARRAY) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"autoEncryption\" driver option to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(zAutoEncryptionOpts));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"autoEncryption\" driver option to be array, %s given", zend_zval_type_name(zAutoEncryptionOpts));
 		return false;
 	}
 
@@ -1280,7 +1280,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 		bson_t bson_map       = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(enc_fields_map) != IS_OBJECT && Z_TYPE_P(enc_fields_map) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"encryptedFieldsMap\" autoEncryption option to be an array or object, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(enc_fields_map));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"encryptedFieldsMap\" autoEncryption option to be an array or object, %s given", zend_zval_type_name(enc_fields_map));
 			goto cleanup;
 		}
 
@@ -1302,7 +1302,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 		zval* key_vault_client = php_array_fetchc_deref(zAutoEncryptionOpts, "keyVaultClient");
 
 		if (Z_TYPE_P(key_vault_client) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(key_vault_client), php_phongo_manager_ce)) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyVaultClient\" autoEncryption option to be %s, %s given", ZSTR_VAL(php_phongo_manager_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(key_vault_client));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"keyVaultClient\" autoEncryption option to be %s, %s given", ZSTR_VAL(php_phongo_manager_ce->name), zend_zval_type_name(key_vault_client));
 			goto cleanup;
 		}
 
@@ -1356,7 +1356,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 		bson_t bson_providers = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(kms_providers) != IS_OBJECT && Z_TYPE_P(kms_providers) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"kmsProviders\" autoEncryption option to be an array or object, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(kms_providers));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"kmsProviders\" autoEncryption option to be an array or object, %s given", zend_zval_type_name(kms_providers));
 			goto cleanup;
 		}
 
@@ -1375,7 +1375,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 		bson_t bson_map   = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(schema_map) != IS_OBJECT && Z_TYPE_P(schema_map) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"schemaMap\" autoEncryption option to be an array or object, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(schema_map));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"schemaMap\" autoEncryption option to be an array or object, %s given", zend_zval_type_name(schema_map));
 			goto cleanup;
 		}
 
@@ -1394,7 +1394,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 		bson_t bson_options = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(tls_options) != IS_OBJECT && Z_TYPE_P(tls_options) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"tlsOptions\" autoEncryption option to be an array or object, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(tls_options));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"tlsOptions\" autoEncryption option to be an array or object, %s given", zend_zval_type_name(tls_options));
 			goto cleanup;
 		}
 
@@ -1413,7 +1413,7 @@ static bool phongo_manager_set_auto_encryption_opts(php_phongo_manager_t* manage
 		bson_t bson_options  = BSON_INITIALIZER;
 
 		if (Z_TYPE_P(extra_options) != IS_OBJECT && Z_TYPE_P(extra_options) != IS_ARRAY) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"extraOptions\" autoEncryption option to be an array or object, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(extra_options));
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"extraOptions\" autoEncryption option to be an array or object, %s given", zend_zval_type_name(extra_options));
 			goto cleanup;
 		}
 

--- a/src/phongo_execute.c
+++ b/src/phongo_execute.c
@@ -76,7 +76,7 @@ static bool phongo_parse_read_concern(zval* options, bson_t* mongoc_opts)
 	}
 
 	if (Z_TYPE_P(options) != IS_ARRAY) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected options to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(options));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected options to be array, %s given", zend_zval_type_name(options));
 		return false;
 	}
 
@@ -87,7 +87,7 @@ static bool phongo_parse_read_concern(zval* options, bson_t* mongoc_opts)
 	}
 
 	if (Z_TYPE_P(option) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(option), php_phongo_readconcern_ce)) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_readconcern_ce->name), zend_zval_type_name(option));
 		return false;
 	}
 
@@ -113,7 +113,7 @@ bool phongo_parse_read_preference(zval* options, zval** zreadPreference)
 	}
 
 	if (Z_TYPE_P(options) != IS_ARRAY) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected options to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(options));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected options to be array, %s given", zend_zval_type_name(options));
 		return false;
 	}
 
@@ -124,7 +124,7 @@ bool phongo_parse_read_preference(zval* options, zval** zreadPreference)
 	}
 
 	if (Z_TYPE_P(option) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(option), php_phongo_readpreference_ce)) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readPreference\" option to be %s, %s given", ZSTR_VAL(php_phongo_readpreference_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"readPreference\" option to be %s, %s given", ZSTR_VAL(php_phongo_readpreference_ce->name), zend_zval_type_name(option));
 		return false;
 	}
 
@@ -151,7 +151,7 @@ bool phongo_parse_session(zval* options, mongoc_client_t* client, bson_t* mongoc
 	}
 
 	if (Z_TYPE_P(options) != IS_ARRAY) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected options to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(options));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected options to be array, %s given", zend_zval_type_name(options));
 		return false;
 	}
 
@@ -162,7 +162,7 @@ bool phongo_parse_session(zval* options, mongoc_client_t* client, bson_t* mongoc
 	}
 
 	if (Z_TYPE_P(option) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(option), php_phongo_session_ce)) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"session\" option to be %s, %s given", ZSTR_VAL(php_phongo_session_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"session\" option to be %s, %s given", ZSTR_VAL(php_phongo_session_ce->name), zend_zval_type_name(option));
 		return false;
 	}
 
@@ -199,7 +199,7 @@ static bool phongo_parse_write_concern(zval* options, bson_t* mongoc_opts, zval*
 	}
 
 	if (Z_TYPE_P(options) != IS_ARRAY) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected options to be array, %s given", PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(options));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected options to be array, %s given", zend_zval_type_name(options));
 		return false;
 	}
 
@@ -210,7 +210,7 @@ static bool phongo_parse_write_concern(zval* options, bson_t* mongoc_opts, zval*
 	}
 
 	if (Z_TYPE_P(option) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(option), php_phongo_writeconcern_ce)) {
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"writeConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_writeconcern_ce->name), PHONGO_ZVAL_CLASS_OR_TYPE_NAME_P(option));
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"writeConcern\" option to be %s, %s given", ZSTR_VAL(php_phongo_writeconcern_ce->name), zend_zval_type_name(option));
 		return false;
 	}
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2460

This supersedes https://github.com/mongodb/mongo-php-driver/pull/1712, as I forgot the ticket was for 1.21.