### PR TITLE
PHPC-2433: Test PHP 8.4 on Evergreen

### DIFF
--- a/.evergreen/config/build-task-groups.yml
+++ b/.evergreen/config/build-task-groups.yml
@@ -19,6 +19,17 @@ task_groups:
     tasks:
       - ".build"
 
+  # TODO: Remove task group once PHP 8.4 is available on PPC and Zseries
+  - name: "build-all-php-except-8.4"
+    # Keep this number in sync with the number of PHP versions to allow for parallel builds
+    max_hosts: 4
+    setup_task: *build_setup
+    setup_task_can_fail_task: true
+    setup_task_timeout_secs: 1800
+    teardown_task: *build_teardown
+    tasks:
+      - ".build !.php8.4"
+
   # Builds all versions of PHP that support OpenSSL 3 (PHP 8.1+)
   - name: "build-php-openssl3"
     # Keep this number in sync with the number of PHP versions to allow for parallel builds

--- a/.evergreen/config/build-variants.yml
+++ b/.evergreen/config/build-variants.yml
@@ -29,7 +29,8 @@ buildvariants:
     tags: ["build", "rhel", "zseries", "tag"]
     run_on: rhel8-zseries-small
     tasks:
-      - name: "build-all-php"
+      # TODO: Re-enable PHP 8.4 once it's available on PPC and Zseries
+      - name: "build-all-php-except-8.4"
   - name: build-rhel8-arm64
     display_name: "Build: RHEL 8 ARM64"
     tags: ["build", "rhel", "arm64", "tag"]
@@ -41,7 +42,8 @@ buildvariants:
     tags: ["build", "rhel", "power8", "tag"]
     run_on: rhel8-power-large
     tasks:
-      - name: "build-all-php"
+      # TODO: Re-enable PHP 8.4 once it's available on PPC and Zseries
+      - name: "build-all-php-except-8.4"
   - name: build-rhel8
     display_name: "Build: RHEL 8 x64"
     tags: ["build", "rhel", "x64", "pr", "tag"]

--- a/.evergreen/config/generate-config.php
+++ b/.evergreen/config/generate-config.php
@@ -3,6 +3,7 @@
 
 // Supported PHP versions. Add new versions to the beginning of the list
 $modernPhpVersions = [
+    '8.4',
     '8.3',
     '8.2',
     '8.1',
@@ -26,7 +27,9 @@ $supportedMongoDBVersions = [
     '4.0',
 ];
 
-$latestPhpVersion = max($supportedPhpVersions);
+// TODO: Change when PHP 8.4 is stable
+// $latestPhpVersion = max($supportedPhpVersions);
+$latestPhpVersion = '8.3';
 
 // Only test the latest PHP version for libmongoc
 $libmongocBuildPhpVersions = [ $latestPhpVersion ];
@@ -112,4 +115,3 @@ HEADER;
 
     return '.evergreen/config' . $filename;
 }
-

--- a/.evergreen/config/generated/build/build-php.yml
+++ b/.evergreen/config/generated/build/build-php.yml
@@ -1,5 +1,12 @@
 # This file is generated automatically - please edit the "templates/build/build-php.yml" template file instead.
 tasks:
+  - name: "build-php-8.4"
+    tags: ["build", "php8.4", "pr", "tag"]
+    commands:
+      - func: "compile driver"
+        vars:
+          PHP_VERSION: "8.4"
+      - func: "upload build"
   - name: "build-php-8.3"
     tags: ["build", "php8.3", "pr", "tag"]
     commands:

--- a/.evergreen/config/generated/test-variant/modern-php-full.yml
+++ b/.evergreen/config/generated/test-variant/modern-php-full.yml
@@ -1,6 +1,86 @@
 # This file is generated automatically - please edit the "templates/test-variant/modern-php-full.yml" template file instead.
 buildvariants:
   # Test MongoDB >= 7.0
+  - name: test-debian12-php-8.4
+    tags: ["test", "debian", "x64", "php8.4", "pr", "tag"]
+    display_name: "Test: Debian 12, PHP 8.4"
+    run_on: debian12-small
+    expansions:
+      FETCH_BUILD_VARIANT: "build-debian12"
+      FETCH_BUILD_TASK: "build-php-8.4"
+    depends_on:
+      - variant: "build-debian12"
+        name: "build-php-8.4"
+    tasks:
+      - ".standalone .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+      - ".replicaset .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+      - ".sharded .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+      - ".loadbalanced .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+      - ".ocsp !.4.4 !.5.0 !.6.0"
+      - "test-atlas-connectivity"
+    display_tasks:
+      - name: "test-ocsp-latest"
+        execution_tasks:
+          - ".ocsp .latest"
+      - name: "test-ocsp-rapid"
+        execution_tasks:
+          - ".ocsp .rapid"
+      - name: "test-ocsp-8.0"
+        execution_tasks:
+          - ".ocsp .8.0"
+      - name: "test-ocsp-7.0"
+        execution_tasks:
+          - ".ocsp .7.0"
+
+  # Test MongoDB 5.0 and 6.0
+  - name: test-debian11-php-8.4
+    tags: ["test", "debian", "x64", "php8.4", "pr", "tag"]
+    display_name: "Test: Debian 11, PHP 8.4"
+    run_on: debian11-small
+    expansions:
+      FETCH_BUILD_VARIANT: "build-debian11"
+      FETCH_BUILD_TASK: "build-php-8.4"
+    depends_on:
+      - variant: "build-debian11"
+        name: "build-php-8.4"
+    tasks:
+      # Remember to add new major versions here as they are released
+      - ".standalone .local !.4.0 !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.4.0 !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.4.0 !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.4.0 !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+      - ".ocsp !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+    display_tasks:
+      - name: "test-ocsp-6.0"
+        execution_tasks:
+          - ".ocsp .6.0"
+      - name: "test-ocsp-5.0"
+        execution_tasks:
+          - ".ocsp .5.0"
+
+  # Test versions < 5.0
+  - name: test-rhel80-php-8.4
+    tags: ["test", "rhel", "x64", "php8.4", "pr", "tag"]
+    display_name: "Test: RHEL 8.0, PHP 8.4"
+    run_on: rhel80-small
+    expansions:
+      FETCH_BUILD_VARIANT: "build-rhel8"
+      FETCH_BUILD_TASK: "build-php-8.4"
+    depends_on:
+      - variant: "build-rhel8"
+        name: "build-php-8.4"
+    tasks:
+      # Remember to add new major versions here as they are released
+      - ".standalone .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".ocsp !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+    display_tasks:
+      - name: "test-ocsp-4.4"
+        execution_tasks:
+          - ".ocsp .4.4"
+  # Test MongoDB >= 7.0
   - name: test-debian12-php-8.3
     tags: ["test", "debian", "x64", "php8.3", "pr", "tag"]
     display_name: "Test: Debian 12, PHP 8.3"


### PR DESCRIPTION
PHPC-2433

This adds testing with PHP 8.4 on Evergreen. PPC and Zseries hosts are currently excluded, as the underlying hosts have changed and there was a bit of confusion which distros the toolchain should be updated on. I'll create a separate pull request to add PHP 8.4 on those two platforms.

Note: this is added to 1.20 as we're already testing with 8.4 on GitHub Actions, so the expectation is that 1.20 is compatible with PHP 8.4.