### PR TITLE
Update to latest setup-php-sdk version

### DIFF
--- a/.github/actions/windows/prepare-build/action.yml
+++ b/.github/actions/windows/prepare-build/action.yml
@@ -31,12 +31,13 @@ runs:
 
     - name: Setup PHP SDK
       id: setup-php
-      uses: php/setup-php-sdk@v0.9
+      uses: php/setup-php-sdk@v0.10
       with:
         version: ${{ inputs.version }}
         arch: ${{ inputs.arch }}
         ts: ${{ inputs.ts }}
         deps: openssl
+        cache: true
 
     - name: Enable Developer Command Prompt
       uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
This updates the setup-php-sdk action to version 0.10, which will allow us to cache the SDK and speed up builds. This will also serve as a PR to investigate the build failures on PHP 7.4 that I've observed in #1725.