### PR TITLE
Skip building against libmongoc master

### DIFF
--- a/.evergreen/config/build-task-groups.yml
+++ b/.evergreen/config/build-task-groups.yml
@@ -44,7 +44,7 @@ task_groups:
 
   - name: "build-php-libmongoc"
     # Keep this in sync with the actual number of libmongoc builds (typically 3) defined in _template-build-libmongoc.yml
-    max_hosts: 3
+    max_hosts: 2
     setup_task: *build_setup
     setup_task_can_fail_task: true
     setup_task_timeout_secs: 1800

--- a/.evergreen/config/generated/build/build-libmongoc.yml
+++ b/.evergreen/config/generated/build/build-libmongoc.yml
@@ -24,11 +24,13 @@ tasks:
           LIBMONGOC_VERSION: "r1.28"
       - func: "upload build"
 
-  - name: "build-php-8.3-libmongoc-latest"
-    tags: ["build-libmongoc", "php8.3"]
-    commands:
-      - func: "compile driver"
-        vars:
-          PHP_VERSION: "8.3"
-          LIBMONGOC_VERSION: "master"
-      - func: "upload build"
+# TODO: this currently fails as libmongoc master needs changes to build directories
+# We can re-enable this after switching to 1.29-dev
+#  - name: "build-php-8.3-libmongoc-latest"
+#    tags: ["build-libmongoc", "php8.3"]
+#    commands:
+#      - func: "compile driver"
+#        vars:
+#          PHP_VERSION: "8.3"
+#          LIBMONGOC_VERSION: "master"
+#      - func: "upload build"

--- a/.evergreen/config/generated/test-variant/legacy-php-full.yml
+++ b/.evergreen/config/generated/test-variant/legacy-php-full.yml
@@ -53,7 +53,6 @@ buildvariants:
       - ".standalone .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".replicaset .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".sharded .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".ocsp !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
     display_tasks:
       - name: "test-ocsp-4.4"
@@ -112,7 +111,6 @@ buildvariants:
       - ".standalone .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".replicaset .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".sharded .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".ocsp !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
     display_tasks:
       - name: "test-ocsp-4.4"

--- a/.evergreen/config/generated/test-variant/libmongoc.yml
+++ b/.evergreen/config/generated/test-variant/libmongoc.yml
@@ -63,33 +63,33 @@ buildvariants:
         execution_tasks:
           - ".ocsp .7.0"
 
-  - name: test-debian12-php-8.3-libmongoc-latest
-    tags: ["test", "libmongoc", "debian", "x64", "php8.3"]
-    display_name: "Test: Debian 12, PHP 8.3, libmongoc latest"
-    run_on: debian12-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian12"
-      FETCH_BUILD_TASK: "build-php-8.3-libmongoc-latest"
-    depends_on:
-      - variant: "build-debian12"
-        name: "build-php-8.3-libmongoc-latest"
-    tasks:
-      - ".standalone .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".replicaset .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".sharded .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".loadbalanced .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - "test-atlas-connectivity"
-      - ".ocsp !.4.4 !.5.0 !.6.0"
-    display_tasks:
-      - name: "test-ocsp-latest"
-        execution_tasks:
-          - ".ocsp .latest"
-      - name: "test-ocsp-rapid"
-        execution_tasks:
-          - ".ocsp .rapid"
-      - name: "test-ocsp-8.0"
-        execution_tasks:
-          - ".ocsp .8.0"
-      - name: "test-ocsp-7.0"
-        execution_tasks:
-          - ".ocsp .7.0"
+#  - name: test-debian12-php-8.3-libmongoc-latest
+#    tags: ["test", "libmongoc", "debian", "x64", "php8.3"]
+#    display_name: "Test: Debian 12, PHP 8.3, libmongoc latest"
+#    run_on: debian12-small
+#    expansions:
+#      FETCH_BUILD_VARIANT: "build-debian12"
+#      FETCH_BUILD_TASK: "build-php-8.3-libmongoc-latest"
+#    depends_on:
+#      - variant: "build-debian12"
+#        name: "build-php-8.3-libmongoc-latest"
+#    tasks:
+#      - ".standalone .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+#      - ".replicaset .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+#      - ".sharded .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+#      - ".loadbalanced .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+#      - "test-atlas-connectivity"
+#      - ".ocsp !.4.4 !.5.0 !.6.0"
+#    display_tasks:
+#      - name: "test-ocsp-latest"
+#        execution_tasks:
+#          - ".ocsp .latest"
+#      - name: "test-ocsp-rapid"
+#        execution_tasks:
+#          - ".ocsp .rapid"
+#      - name: "test-ocsp-8.0"
+#        execution_tasks:
+#          - ".ocsp .8.0"
+#      - name: "test-ocsp-7.0"
+#        execution_tasks:
+#          - ".ocsp .7.0"

--- a/.evergreen/config/generated/test-variant/modern-php-full.yml
+++ b/.evergreen/config/generated/test-variant/modern-php-full.yml
@@ -74,7 +74,6 @@ buildvariants:
       - ".standalone .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".replicaset .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".sharded .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".ocsp !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
     display_tasks:
       - name: "test-ocsp-4.4"
@@ -154,7 +153,6 @@ buildvariants:
       - ".standalone .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".replicaset .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".sharded .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".ocsp !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
     display_tasks:
       - name: "test-ocsp-4.4"
@@ -234,7 +232,6 @@ buildvariants:
       - ".standalone .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".replicaset .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".sharded .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".ocsp !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
     display_tasks:
       - name: "test-ocsp-4.4"
@@ -314,7 +311,6 @@ buildvariants:
       - ".standalone .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".replicaset .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".sharded .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".ocsp !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
     display_tasks:
       - name: "test-ocsp-4.4"

--- a/.evergreen/config/templates/build/build-libmongoc.yml
+++ b/.evergreen/config/templates/build/build-libmongoc.yml
@@ -22,11 +22,13 @@
           LIBMONGOC_VERSION: "r1.28"
       - func: "upload build"
 
-  - name: "build-php-%phpVersion%-libmongoc-latest"
-    tags: ["build-libmongoc", "php%phpVersion%"]
-    commands:
-      - func: "compile driver"
-        vars:
-          PHP_VERSION: "%phpVersion%"
-          LIBMONGOC_VERSION: "master"
-      - func: "upload build"
+# TODO: this currently fails as libmongoc master needs changes to build directories
+# We can re-enable this after switching to 1.29-dev
+#  - name: "build-php-%phpVersion%-libmongoc-latest"
+#    tags: ["build-libmongoc", "php%phpVersion%"]
+#    commands:
+#      - func: "compile driver"
+#        vars:
+#          PHP_VERSION: "%phpVersion%"
+#          LIBMONGOC_VERSION: "master"
+#      - func: "upload build"

--- a/.evergreen/config/templates/test-variant/legacy-php-full.yml
+++ b/.evergreen/config/templates/test-variant/legacy-php-full.yml
@@ -51,7 +51,6 @@
       - ".standalone .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".replicaset .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".sharded .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".ocsp !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
     display_tasks:
       - name: "test-ocsp-4.4"

--- a/.evergreen/config/templates/test-variant/libmongoc.yml
+++ b/.evergreen/config/templates/test-variant/libmongoc.yml
@@ -61,33 +61,33 @@
         execution_tasks:
           - ".ocsp .7.0"
 
-  - name: test-debian12-php-%phpVersion%-libmongoc-latest
-    tags: ["test", "libmongoc", "debian", "x64", "php%phpVersion%"]
-    display_name: "Test: Debian 12, PHP %phpVersion%, libmongoc latest"
-    run_on: debian12-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian12"
-      FETCH_BUILD_TASK: "build-php-%phpVersion%-libmongoc-latest"
-    depends_on:
-      - variant: "build-debian12"
-        name: "build-php-%phpVersion%-libmongoc-latest"
-    tasks:
-      - ".standalone .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".replicaset .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".sharded .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".loadbalanced .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - "test-atlas-connectivity"
-      - ".ocsp !.4.4 !.5.0 !.6.0"
-    display_tasks:
-      - name: "test-ocsp-latest"
-        execution_tasks:
-          - ".ocsp .latest"
-      - name: "test-ocsp-rapid"
-        execution_tasks:
-          - ".ocsp .rapid"
-      - name: "test-ocsp-8.0"
-        execution_tasks:
-          - ".ocsp .8.0"
-      - name: "test-ocsp-7.0"
-        execution_tasks:
-          - ".ocsp .7.0"
+#  - name: test-debian12-php-%phpVersion%-libmongoc-latest
+#    tags: ["test", "libmongoc", "debian", "x64", "php%phpVersion%"]
+#    display_name: "Test: Debian 12, PHP %phpVersion%, libmongoc latest"
+#    run_on: debian12-small
+#    expansions:
+#      FETCH_BUILD_VARIANT: "build-debian12"
+#      FETCH_BUILD_TASK: "build-php-%phpVersion%-libmongoc-latest"
+#    depends_on:
+#      - variant: "build-debian12"
+#        name: "build-php-%phpVersion%-libmongoc-latest"
+#    tasks:
+#      - ".standalone .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+#      - ".replicaset .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+#      - ".sharded .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+#      - ".loadbalanced .local !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
+#      - "test-atlas-connectivity"
+#      - ".ocsp !.4.4 !.5.0 !.6.0"
+#    display_tasks:
+#      - name: "test-ocsp-latest"
+#        execution_tasks:
+#          - ".ocsp .latest"
+#      - name: "test-ocsp-rapid"
+#        execution_tasks:
+#          - ".ocsp .rapid"
+#      - name: "test-ocsp-8.0"
+#        execution_tasks:
+#          - ".ocsp .8.0"
+#      - name: "test-ocsp-7.0"
+#        execution_tasks:
+#          - ".ocsp .7.0"

--- a/.evergreen/config/templates/test-variant/modern-php-full.yml
+++ b/.evergreen/config/templates/test-variant/modern-php-full.yml
@@ -72,7 +72,6 @@
       - ".standalone .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".replicaset .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".sharded .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - ".ocsp !.5.0 !.6.0 !.7.0 !.8.0 !.rapid !.latest"
     display_tasks:
       - name: "test-ocsp-4.4"


### PR DESCRIPTION
The upcoming libmongoc version will require changes to build directories, as the sources in libmongoc/src/common moved to a different subdirectory. As the build is currently failing due to a deprecation and will continue failing unless we make the build directory changes (which are uncompatible with r1.28 and thus not applicable in this branch), disabling the build makes most sense for the time being.

In addition, this PR removes an unmatched task selector that was creating warnings in Evergreen.