### PR TITLE
PHPC-2649: Use output from setup-php-sdk in packaging step

### DIFF
--- a/.github/actions/windows/build/action.yml
+++ b/.github/actions/windows/build/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: "Thread-safety (nts or ts)"
     required: true
 outputs:
+  vs:
+    description: "The Visual Studio version"
+    value: ${{ steps.prepare-build-env.outputs.vs }}
   build-dir:
     description: "The build directory to be used"
     value: ${{ steps.prepare-build-env.outputs.build-dir }}

--- a/.github/actions/windows/prepare-build/action.yml
+++ b/.github/actions/windows/prepare-build/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: "Thread-safety (nts or ts)"
     required: true
 outputs:
+  vs:
+    description: "The Visual Studio version"
+    value: ${{steps.setup-php.outputs.vs}}
   build-dir:
     description: "The build directory to be used"
     value: ${{steps.get-build-dir.outputs.build_dir}}

--- a/.github/workflows/build-windows-package.yml
+++ b/.github/workflows/build-windows-package.yml
@@ -38,6 +38,8 @@ jobs:
     defaults:
       run:
         shell: cmd
+    outputs:
+      vs: ${{ steps.build-driver.outputs.vs }}
 
     steps:
       - uses: actions/checkout@v4
@@ -114,27 +116,9 @@ jobs:
       - name: "Copy signature file"
         run: cp ${RELEASE_ASSETS}/php_mongodb.dll.sig .
 
-      - name: "Set compiler environment variable"
-        run: |
-          case "$PHP_VERSION" in
-            "7.4")
-              COMPILER="vc15"
-              ;;
-            "8.0" | "8.1" | "8.2" | "8.3")
-              COMPILER="vs16"
-              ;;
-            "8.4")
-              COMPILER="vs17"
-              ;;
-          esac
-          echo "COMPILER=${COMPILER}" >> "$GITHUB_ENV"
-        shell: bash
-        env:
-          PHP_VERSION: ${{ inputs.php }}
-
       - name: "Create and upload release asset"
         if: ${{ inputs.upload_release_asset }}
         run: |
-          ARCHIVE=php_mongodb-${{ inputs.version }}-${{ inputs.php }}-${{ inputs.ts }}-${{ env.COMPILER }}-${{ inputs.arch }}.zip
+          ARCHIVE=php_mongodb-${{ inputs.version }}-${{ inputs.php }}-${{ inputs.ts }}-${{ needs.build.outputs.vs }}-${{ inputs.arch }}.zip
           zip ${ARCHIVE} php_mongodb.dll php_mongodb.dll.sig php_mongodb.pdb CREDITS CONTRIBUTING.md LICENSE README.md THIRD_PARTY_NOTICES
           gh release upload ${{ inputs.version }} ${ARCHIVE}

--- a/.github/workflows/build-windows-package.yml
+++ b/.github/workflows/build-windows-package.yml
@@ -119,6 +119,6 @@ jobs:
       - name: "Create and upload release asset"
         if: ${{ inputs.upload_release_asset }}
         run: |
-          ARCHIVE=php_mongodb-${{ inputs.version }}-${{ inputs.php }}-${{ inputs.ts }}-${{ needs.build.outputs.vs }}-${{ inputs.arch }}.zip
+          ARCHIVE=php_mongodb-${{ inputs.version }}-${{ inputs.php }}-${{ inputs.ts }}-${{ needs.build.outputs.vs }}-${{ inputs.arch == 'x64' && 'x64_86' || inputs.arch }}.zip
           zip ${ARCHIVE} php_mongodb.dll php_mongodb.dll.sig php_mongodb.pdb CREDITS CONTRIBUTING.md LICENSE README.md THIRD_PARTY_NOTICES
           gh release upload ${{ inputs.version }} ${ARCHIVE}

--- a/.github/workflows/build-windows-package.yml
+++ b/.github/workflows/build-windows-package.yml
@@ -112,13 +112,22 @@ jobs:
         with:
           filenames: php_mongodb.dll
 
-      # Copy the signature file from the release asset directory to avoid directory issues in the ZIP file
-      - name: "Copy signature file"
-        run: cp ${RELEASE_ASSETS}/php_mongodb.dll.sig .
+      - name: "Generate file name for DLL and archive"
+        run:
+          echo FILENAME="php_mongodb-${{ inputs.version }}-${{ inputs.php }}-${{ inputs.ts }}-${{ needs.build.outputs.vs }}-${{ inputs.arch == 'x64' && 'x64_86' || inputs.arch }}" >> "$GITHUB_ENV"
+
+      # In this step, we:
+      # - update the extension DLL file name to match the expectation of pie
+      # - copy the signature file from the release asset directory to avoid directory issues in the archive
+      # - rename the signature file to match the extension DLL file
+      - name: "Copy signature file and use correct file names"
+        run: |
+          mv php_mongodb.dll ${{ env.FILENAME }}.dll
+          cp ${RELEASE_ASSETS}/php_mongodb.dll.sig ${{ env.FILENAME }}.dll.sig
 
       - name: "Create and upload release asset"
         if: ${{ inputs.upload_release_asset }}
         run: |
-          ARCHIVE=php_mongodb-${{ inputs.version }}-${{ inputs.php }}-${{ inputs.ts }}-${{ needs.build.outputs.vs }}-${{ inputs.arch == 'x64' && 'x64_86' || inputs.arch }}.zip
-          zip ${ARCHIVE} php_mongodb.dll php_mongodb.dll.sig php_mongodb.pdb CREDITS CONTRIBUTING.md LICENSE README.md THIRD_PARTY_NOTICES
+          ARCHIVE=${{ env.FILENAME }}.zip
+          zip ${ARCHIVE} ${{ env.FILENAME }}.dll ${{ env.FILENAME }}.dll.sig php_mongodb.pdb CREDITS CONTRIBUTING.md LICENSE README.md THIRD_PARTY_NOTICES
           gh release upload ${{ inputs.version }} ${ARCHIVE}


### PR DESCRIPTION
PHPC-2649

This PR adds the `vs` output variable from the `setup-php-sdk` action to all actions involved in building Windows packages so that it can be used when determining the filename for the archive. This removes the need for maintaining a list of PHP versions with their compilers.

In addition to this, the PR makes two more adjustments for compatibility with PIE:
* The archive name should contain `x86_64` for 64-bit platforms, not `x64`
* The built DLL should be named like the archive instead of the default `php_mongodb.dll`. PIE will rename the file in its install step.

cc @mickverm - this should get rid of the issues you encountered, but we won't know until we release 1.20.1. Please bear with us while we sort out the initial difficulties with PIE. We do appreciate your testing efforts for PIE compatibility 💪 