### PR TITLE
PHPC-1247: Update links to PHP.net docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ env:
 
     **Documentation**
 
-    Documentation is available on [PHP.net](https://php.net/mongodb).
+    Documentation is available on [PHP.net](https://www.php.net/mongodb).
 
     **Installation**
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ env:
 
     **Documentation**
 
-    Documentation is available on [PHP.net](https://php.net/set.mongodb).
+    Documentation is available on [PHP.net](https://php.net/mongodb).
 
     **Installation**
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ languages.
 
 ## Documentation
 
- - https://php.net/mongodb
+ - https://www.php.net/mongodb
  - https://www.mongodb.com/docs/drivers/php-drivers/
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ languages.
 
 ## Documentation
 
- - https://php.net/manual/en/set.mongodb.php
- - https://www.mongodb.com/docs/drivers/php/
+ - https://php.net/mongodb
+ - https://www.mongodb.com/docs/drivers/php-drivers/
 
 ## Installation
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1247

Also updates canonical URL for internal PHP driver docs