### PR TITLE
Enable PHP 8.4 testing on PPC and Zseries

### DIFF
--- a/.evergreen/config/build-task-groups.yml
+++ b/.evergreen/config/build-task-groups.yml
@@ -19,17 +19,6 @@ task_groups:
     tasks:
       - ".build"
 
-  # TODO: Remove task group once PHP 8.4 is available on PPC and Zseries
-  - name: "build-all-php-except-8.4"
-    # Keep this number in sync with the number of PHP versions to allow for parallel builds
-    max_hosts: 4
-    setup_task: *build_setup
-    setup_task_can_fail_task: true
-    setup_task_timeout_secs: 1800
-    teardown_task: *build_teardown
-    tasks:
-      - ".build !.php8.4"
-
   # Builds all versions of PHP that support OpenSSL 3 (PHP 8.1+)
   - name: "build-php-openssl3"
     # Keep this number in sync with the number of PHP versions to allow for parallel builds

--- a/.evergreen/config/build-variants.yml
+++ b/.evergreen/config/build-variants.yml
@@ -29,8 +29,7 @@ buildvariants:
     tags: ["build", "rhel", "zseries", "tag"]
     run_on: rhel8-zseries-small
     tasks:
-      # TODO: Re-enable PHP 8.4 once it's available on PPC and Zseries
-      - name: "build-all-php-except-8.4"
+      - name: "build-all-php"
   - name: build-rhel8-arm64
     display_name: "Build: RHEL 8 ARM64"
     tags: ["build", "rhel", "arm64", "tag"]
@@ -42,8 +41,7 @@ buildvariants:
     tags: ["build", "rhel", "power8", "tag"]
     run_on: rhel8-power-large
     tasks:
-      # TODO: Re-enable PHP 8.4 once it's available on PPC and Zseries
-      - name: "build-all-php-except-8.4"
+      - name: "build-all-php"
   - name: build-rhel8
     display_name: "Build: RHEL 8 x64"
     tags: ["build", "rhel", "x64", "pr", "tag"]


### PR DESCRIPTION
This enables the last of the PHP 8.4 builds that were missing, as PHP 8.4 is now available on PPC and Z hosts.