### PR TITLE
Test PPC and Zseries on RHEL 9

### DIFF
--- a/.evergreen/config/build-variants.yml
+++ b/.evergreen/config/build-variants.yml
@@ -24,22 +24,22 @@ buildvariants:
     run_on: rhel90-small
     tasks:
       - name: "build-all-php"
-  - name: build-rhel8-zseries
-    display_name: "Build: RHEL 8 Zseries"
+  - name: build-rhel9-zseries
+    display_name: "Build: RHEL 9 Zseries"
     tags: ["build", "rhel", "zseries", "tag"]
-    run_on: rhel8-zseries-small
+    run_on: rhel9-zseries-small
+    tasks:
+      - name: "build-all-php"
+  - name: build-rhel9-power
+    display_name: "Build: RHEL 9 PPC"
+    tags: ["build", "rhel", "power", "tag"]
+    run_on: rhel9-power-small
     tasks:
       - name: "build-all-php"
   - name: build-rhel8-arm64
     display_name: "Build: RHEL 8 ARM64"
     tags: ["build", "rhel", "arm64", "tag"]
     run_on: rhel82-arm64
-    tasks:
-      - name: "build-all-php"
-  - name: build-rhel8-power8
-    display_name: "Build: RHEL 8 Power8"
-    tags: ["build", "rhel", "power8", "tag"]
-    run_on: rhel8-power-large
     tasks:
       - name: "build-all-php"
   - name: build-rhel8


### PR DESCRIPTION
With Power8 being phased out, we need to switch over to Power9 for PPC testing. PPC and Zseries variants have been scheduled in the patch build.