### PR TITLE
Remove prefix ext- from extension name.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "ext-json": "*"
   },
   "php-ext": {
-    "extension-name": "ext-mongodb",
+    "extension-name": "mongodb",
     "configure-options": [
       {
         "name": "enable-mongodb-developer-flags",


### PR DESCRIPTION
Replace  #1751 

See https://github.com/mongodb/mongo-php-driver/issues/1750.

Remove the wrong extension name prefix into composer.json configuration used by php/pie.