### PR TITLE
Configure release notes to exclude merge-up bot

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - mongodb-php-bot


### PR DESCRIPTION
GitHub [allows configuring automated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes), and the file added here should exclude all of the merge commits from the merge-up bot for less noise in the release notes. At the same time, this should preserve the original commit that is being merged up, so that release notes include commits merged up from previous releases.