### PR TITLE
PHPC-2489: Deprecate passing WriteConcern and ReadPreference objects to execute methods

### DIFF
--- a/src/phongo_util.c
+++ b/src/phongo_util.c
@@ -92,6 +92,8 @@ zval* php_phongo_prep_legacy_option(zval* options, const char* key, bool* alloca
 		Z_ADDREF_P(options);
 		*allocated = true;
 
+		php_error_docref(NULL, E_DEPRECATED, "Passing the \"%s\" option directly is deprecated and will be removed in ext-mongodb 2.0", key);
+
 		return new_options;
 	}
 

--- a/tests/bulk/write-0002.phpt
+++ b/tests/bulk/write-0002.phpt
@@ -21,7 +21,7 @@ $w = 1;
 $wtimeout = 1000;
 $writeConcern = new \MongoDB\Driver\WriteConcern($w, $wtimeout);
 var_dump($insertBulk);
-$result = $manager->executeBulkWrite(NS, $insertBulk, $writeConcern);
+$result = $manager->executeBulkWrite(NS, $insertBulk, ['writeConcern' => $writeConcern]);
 var_dump($insertBulk);
 
 assert($result instanceof \MongoDB\Driver\WriteResult);

--- a/tests/manager/manager-executeBulkWrite-015.phpt
+++ b/tests/manager/manager-executeBulkWrite-015.phpt
@@ -1,0 +1,23 @@
+--TEST--
+MongoDB\Driver\Manager::executeBulkWrite() explicit WriteConcern argument is deprecated
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_not_clean(); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager();
+
+$bulk = new MongoDB\Driver\BulkWrite();
+$bulk->insert(['_id' => 1]);
+$manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Deprecated: MongoDB\Driver\Manager::executeBulkWrite(): Passing the "writeConcern" option directly is deprecated and will be removed in ext-mongodb 2.0%s
+===DONE===

--- a/tests/manager/manager-executeBulkWrite_error-003.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-003.phpt
@@ -14,7 +14,7 @@ $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(array('_id' => 1, 'x' => 1));
 
 try {
-    $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(30));
+    $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(30)]);
 } catch (MongoDB\Driver\Exception\BulkWriteException $e) {
     printf("BulkWriteException: %s\n", $e->getMessage());
 

--- a/tests/manager/manager-executeCommand-003.phpt
+++ b/tests/manager/manager-executeCommand-003.phpt
@@ -32,10 +32,14 @@ echo "is_secondary: ", $cursor->getServer()->isSecondary() ? 'true' : 'false', "
 <?php exit(0); ?>
 --EXPECTF--
 Testing primary:
+
+Deprecated: MongoDB\Driver\Manager::executeCommand(): Passing the "readPreference" option directly is deprecated and will be removed in ext-mongodb 2.0%s
 is_primary: true
 is_secondary: false
 
 Testing secondary:
+
+Deprecated: MongoDB\Driver\Manager::executeCommand(): Passing the "readPreference" option directly is deprecated and will be removed in ext-mongodb 2.0%s
 is_primary: false
 is_secondary: true
 

--- a/tests/manager/manager-executeQuery-004.phpt
+++ b/tests/manager/manager-executeQuery-004.phpt
@@ -37,10 +37,14 @@ echo "is_secondary: ", $cursor->getServer()->isSecondary() ? 'true' : 'false', "
 <?php exit(0); ?>
 --EXPECTF--
 Testing primary:
+
+Deprecated: MongoDB\Driver\Manager::executeQuery(): Passing the "readPreference" option directly is deprecated and will be removed in ext-mongodb 2.0%s
 is_primary: true
 is_secondary: false
 
 Testing secondary:
+
+Deprecated: MongoDB\Driver\Manager::executeQuery(): Passing the "readPreference" option directly is deprecated and will be removed in ext-mongodb 2.0%s
 is_primary: false
 is_secondary: true
 

--- a/tests/readPreference/bug0146-001.phpt
+++ b/tests/readPreference/bug0146-001.phpt
@@ -26,7 +26,7 @@ $rps = [
 
 foreach($rps as $r) {
     $rp = new MongoDB\Driver\ReadPreference($r);
-    $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query(array("my" => "query")), $rp);
+    $cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query(['my' => 'query']), ['readPreference' => $rp]);
     var_dump($cursor);
 }
 

--- a/tests/replicaset/bug0155.phpt
+++ b/tests/replicaset/bug0155.phpt
@@ -15,7 +15,7 @@ $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(array('example' => 'document'));
 
 try {
-    $manager->executeBulkWrite(NS, $bulk, $wc);
+    $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => $wc]);
 } catch(MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteConcernError());
 }

--- a/tests/replicaset/readconcern-001.phpt
+++ b/tests/replicaset/readconcern-001.phpt
@@ -15,7 +15,7 @@ $wc = new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY);
 $bulk = new MongoDB\Driver\BulkWrite();
 $bulk->insert(['_id' => 1, 'x' => 1]);
 $bulk->insert(['_id' => 2, 'x' => 2]);
-$manager->executeBulkWrite(NS, $bulk, $wc);
+$manager->executeBulkWrite(NS, $bulk, ['writeConcern' => $wc]);
 
 $rc = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL);
 $query = new MongoDB\Driver\Query(['x' => 2], ['readConcern' => $rc]);

--- a/tests/replicaset/writeconcernerror-001.phpt
+++ b/tests/replicaset/writeconcernerror-001.phpt
@@ -15,7 +15,7 @@ $bulk->insert(array("my" => "value"));
 
 $w = new MongoDB\Driver\WriteConcern(30, 100);
 try {
-    $retval = $manager->executeBulkWrite(NS, $bulk, $w);
+    $retval = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => $w]);
 } catch(MongoDB\Driver\Exception\BulkWriteException $e) {
     $server = $e->getWriteResult()->getServer();
     $server->getPort();

--- a/tests/replicaset/writeconcernerror-002.phpt
+++ b/tests/replicaset/writeconcernerror-002.phpt
@@ -21,7 +21,7 @@ $bulk->update(array("foo" => "bar"), array('$set' => array("foo" => "baz")), arr
 
 $w = new MongoDB\Driver\WriteConcern(30);
 try {
-    $retval = $manager->executeBulkWrite(NS, $bulk, $w);
+    $retval = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => $w]);
 } catch(MongoDB\Driver\Exception\BulkWriteException $e) {
     printWriteResult($e->getWriteResult(), false);
 }

--- a/tests/replicaset/writeresult-getserver-001.phpt
+++ b/tests/replicaset/writeresult-getserver-001.phpt
@@ -30,7 +30,7 @@ var_dump($server == $server2);
 
 $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 /* Fetch a secondary */
-$server3 = $manager->executeQuery(NS, new MongoDB\Driver\Query(array()), $rp)->getServer();
+$server3 = $manager->executeQuery(NS, new MongoDB\Driver\Query([]), ['readPreference' => $rp])->getServer();
 
 var_dump($server == $server3);
 var_dump($server->getPort(), $server3->getPort());

--- a/tests/replicaset/writeresult-getserver-002.phpt
+++ b/tests/replicaset/writeresult-getserver-002.phpt
@@ -33,7 +33,7 @@ var_dump($server == $server2);
 
 $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 /* Fetch a secondary */
-$server3 = $manager->executeQuery(NS, new MongoDB\Driver\Query(array()), $rp)->getServer();
+$server3 = $manager->executeQuery(NS, new MongoDB\Driver\Query([]), ['readPreference' => $rp])->getServer();
 
 var_dump($server == $server3);
 var_dump($server->getPort(), $server3->getPort());

--- a/tests/server/server-executeBulkWrite-002.phpt
+++ b/tests/server/server-executeBulkWrite-002.phpt
@@ -17,7 +17,7 @@ foreach ($writeConcerns as $writeConcern) {
     $bulk = new MongoDB\Driver\BulkWrite();
     $bulk->insert(array('wc' => $writeConcern));
 
-    $result = $primary->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern($writeConcern));
+    $result = $primary->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern($writeConcern)]);
     var_dump($result->isAcknowledged());
     var_dump($result->getInsertedCount());
 }

--- a/tests/server/server-executeBulkWrite-003.phpt
+++ b/tests/server/server-executeBulkWrite-003.phpt
@@ -18,7 +18,7 @@ foreach ($writeConcerns as $wc) {
     $bulk = new MongoDB\Driver\BulkWrite();
     $bulk->insert(array('wc' => $wc));
 
-    $result = $server->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern($wc));
+    $result = $server->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern($wc)]);
     var_dump($result->isAcknowledged());
     var_dump($result->getInsertedCount());
 }

--- a/tests/server/server-executeBulkWrite-004.phpt
+++ b/tests/server/server-executeBulkWrite-004.phpt
@@ -21,7 +21,7 @@ foreach ($writeConcerns as $wc) {
     $bulk->insert(array('wc' => $wc));
 
     echo throws(function() use ($server, $bulk, $wc) {
-        $server->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern($wc));
+        $server->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern($wc)]);
     }, "MongoDB\Driver\Exception\RuntimeException"), "\n";
 }
 

--- a/tests/server/server-executeBulkWrite-005.phpt
+++ b/tests/server/server-executeBulkWrite-005.phpt
@@ -23,7 +23,7 @@ foreach ($writeConcerns as $wc) {
     $bulk = new MongoDB\Driver\BulkWrite();
     $bulk->insert(array('wc' => $wc));
 
-    $result = $server->executeBulkWrite('local.' . COLLECTION_NAME, $bulk, new MongoDB\Driver\WriteConcern($wc));
+    $result = $server->executeBulkWrite('local.' . COLLECTION_NAME, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern($wc)]);
     var_dump($result->isAcknowledged());
     var_dump($result->getInsertedCount());
 }

--- a/tests/server/server-executeBulkWrite-010.phpt
+++ b/tests/server/server-executeBulkWrite-010.phpt
@@ -1,0 +1,24 @@
+--TEST--
+MongoDB\Driver\Server::executeBulkWrite() explicit WriteConcern argument is deprecated
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_not_clean(); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager();
+$server = $manager->selectServer();
+
+$bulk = new MongoDB\Driver\BulkWrite();
+$bulk->insert(['_id' => 1]);
+$server->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Deprecated: MongoDB\Driver\Server::executeBulkWrite(): Passing the "writeConcern" option directly is deprecated and will be removed in ext-mongodb 2.0%s
+===DONE===

--- a/tests/server/server-executeCommand-002.phpt
+++ b/tests/server/server-executeCommand-002.phpt
@@ -25,7 +25,7 @@ $command = new MongoDB\Driver\Command([
     'pipeline' => [ [ '$match' => [ 'x' => 1 ] ] ],
     'cursor' => (object) [],
 ]);
-$secondary->executeCommand(DATABASE_NAME, $command, $rp);
+$secondary->executeCommand(DATABASE_NAME, $command, ['readPreference' => $rp]);
 
 $query = new MongoDB\Driver\Query(
     array(
@@ -37,7 +37,7 @@ $query = new MongoDB\Driver\Query(
         'limit' => 1,
     )
 );
-$cursor = $secondary->executeQuery(DATABASE_NAME . '.system.profile', $query, $rp);
+$cursor = $secondary->executeQuery(DATABASE_NAME . '.system.profile', $query, ['readPreference' => $rp]);
 $profileEntry = current($cursor->toArray());
 
 var_dump($profileEntry->command);

--- a/tests/server/server-executeCommand-003.phpt
+++ b/tests/server/server-executeCommand-003.phpt
@@ -17,7 +17,7 @@ $secondary = $manager->selectServer($secondaryRp);
  * no effect when directly querying a server, since the secondaryOk flag is always
  * set for hinted commands. */
 $primaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY);
-$cursor = $secondary->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(array('ping' => 1)), $primaryRp);
+$cursor = $secondary->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(array('ping' => 1)), ['readPreference' => $primaryRp]);
 
 var_dump($cursor->toArray());
 

--- a/tests/server/server-executeCommand-005.phpt
+++ b/tests/server/server-executeCommand-005.phpt
@@ -35,10 +35,14 @@ echo "is_secondary: ", $cursor->getServer()->isSecondary() ? 'true' : 'false', "
 <?php exit(0); ?>
 --EXPECTF--
 Testing primary:
+
+Deprecated: MongoDB\Driver\Server::executeCommand(): Passing the "readPreference" option directly is deprecated and will be removed in ext-mongodb 2.0%s
 is_primary: true
 is_secondary: false
 
 Testing secondary:
+
+Deprecated: MongoDB\Driver\Server::executeCommand(): Passing the "readPreference" option directly is deprecated and will be removed in ext-mongodb 2.0%s
 is_primary: false
 is_secondary: true
 

--- a/tests/server/server-executeQuery-006.phpt
+++ b/tests/server/server-executeQuery-006.phpt
@@ -24,7 +24,7 @@ if (empty($result->ok)) {
     exit("Could not set profile level\n");
 }
 
-$secondary->executeQuery(NS, new MongoDB\Driver\Query(array("x" => 1)), $rp);
+$secondary->executeQuery(NS, new MongoDB\Driver\Query(['x' => 1]), ['readPreference' => $rp]);
 
 $query = new MongoDB\Driver\Query(
     array(
@@ -36,7 +36,7 @@ $query = new MongoDB\Driver\Query(
         'limit' => 1,
     )
 );
-$cursor = $secondary->executeQuery(DATABASE_NAME . '.system.profile', $query, $rp);
+$cursor = $secondary->executeQuery(DATABASE_NAME . '.system.profile', $query, ['readPreference' => $rp]);
 $profileEntry = current($cursor->toArray());
 
 if (! isset( $profileEntry->command )) {

--- a/tests/server/server-executeQuery-008.phpt
+++ b/tests/server/server-executeQuery-008.phpt
@@ -21,7 +21,7 @@ $dataBearingNodes = count(array_filter($manager->getServers(), function (MongoDB
 
 $bulk = new \MongoDB\Driver\BulkWrite;
 $bulk->insert(['_id' => 1, 'x' => 1]);
-$primary->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern($dataBearingNodes));
+$primary->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern($dataBearingNodes)]);
 
 $secondaryRp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY);
 $secondary = $manager->selectServer($secondaryRp);
@@ -29,7 +29,7 @@ $secondary = $manager->selectServer($secondaryRp);
 /* Note: this is testing that the read preference (even a conflicting one) has
  * no effect when directly querying a server, since the secondaryOk flag is always
  * set for hinted queries. */
-$cursor = $secondary->executeQuery(NS, new MongoDB\Driver\Query(['x' => 1]), $primaryRp);
+$cursor = $secondary->executeQuery(NS, new MongoDB\Driver\Query(['x' => 1]), ['readPreference' => $primaryRp]);
 
 var_dump($cursor->toArray());
 

--- a/tests/server/server-executeQuery-010.phpt
+++ b/tests/server/server-executeQuery-010.phpt
@@ -40,10 +40,14 @@ echo "is_secondary: ", $cursor->getServer()->isSecondary() ? 'true' : 'false', "
 <?php exit(0); ?>
 --EXPECTF--
 Testing primary:
+
+Deprecated: MongoDB\Driver\Server::executeQuery(): Passing the "readPreference" option directly is deprecated and will be removed in ext-mongodb 2.0%s
 is_primary: true
 is_secondary: false
 
 Testing secondary:
+
+Deprecated: MongoDB\Driver\Server::executeQuery(): Passing the "readPreference" option directly is deprecated and will be removed in ext-mongodb 2.0%s
 is_primary: false
 is_secondary: true
 

--- a/tests/server/server-executeQuery-010.phpt
+++ b/tests/server/server-executeQuery-010.phpt
@@ -24,14 +24,14 @@ $secondary = $manager->selectServer($secondaryRp);
 
 echo "Testing primary:\n";
 $query = new MongoDB\Driver\Query(['x' => 3], ['projection' => ['y' => 1]]);
-$cursor = $manager->executeQuery(NS, $query, $primaryRp);
+$cursor = $primary->executeQuery(NS, $query, $primaryRp);
 
 echo "is_primary: ", $cursor->getServer()->isPrimary() ? 'true' : 'false', "\n";
 echo "is_secondary: ", $cursor->getServer()->isSecondary() ? 'true' : 'false', "\n\n";
 
 echo "Testing secondary:\n";
 $query = new MongoDB\Driver\Query(['x' => 3], ['projection' => ['y' => 1]]);
-$cursor = $manager->executeQuery(NS, $query, $secondaryRp);
+$cursor = $secondary->executeQuery(NS, $query, $secondaryRp);
 
 echo "is_primary: ", $cursor->getServer()->isPrimary() ? 'true' : 'false', "\n";
 echo "is_secondary: ", $cursor->getServer()->isSecondary() ? 'true' : 'false', "\n\n";

--- a/tests/standalone/bug0545.phpt
+++ b/tests/standalone/bug0545.phpt
@@ -57,7 +57,7 @@ $page1->content = 'Lorem ipsum';
 $book->pages[] = $page1;
 $bulk = new MongoDB\Driver\BulkWrite;
 $bulk->insert($book);
-$result = $manager->executeBulkWrite(NS, $bulk, $wc);
+$result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => $wc]);
 printf("Inserted %d document(s)\n", $result->getInsertedCount());
 
 // Read
@@ -72,7 +72,7 @@ $page2->content = 'Dolor sit amet';
 $bookAfterInsert->pages[] = $page2;
 $bulk = new MongoDB\Driver\BulkWrite;
 $bulk->update(['title' => $bookAfterInsert->title], $bookAfterInsert);
-$result = $manager->executeBulkWrite(NS, $bulk, $wc);
+$result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => $wc]);
 printf("Modified %d document(s)\n", $result->getModifiedCount());
 
 // Read (again)

--- a/tests/standalone/manager-as-singleton.phpt
+++ b/tests/standalone/manager-as-singleton.phpt
@@ -30,7 +30,7 @@ class Database {
     }
  
     public function query($scheme, $query) {
-        return $this->Database->executeQuery($scheme, $query, new ReadPreference(ReadPreference::PRIMARY));
+        return $this->Database->executeQuery($scheme, $query, ['readPreference' => new ReadPreference(ReadPreference::PRIMARY)]);
     }
 }
  

--- a/tests/standalone/write-error-001.phpt
+++ b/tests/standalone/write-error-001.phpt
@@ -20,7 +20,7 @@ $w = 2;
 $wtimeout = 1000;
 $writeConcern = new \MongoDB\Driver\WriteConcern($w, $wtimeout);
 echo throws(function() use($bulk, $writeConcern, $manager) {
-    $result = $manager->executeBulkWrite(NS, $bulk, $writeConcern);
+    $result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => $writeConcern]);
 }, "MongoDB\Driver\Exception\BulkWriteException"),  "\n";
 
 ?>

--- a/tests/standalone/writeresult-isacknowledged-003.phpt
+++ b/tests/standalone/writeresult-isacknowledged-003.phpt
@@ -12,7 +12,7 @@ $manager = create_test_manager();
 
 $bulk = new \MongoDB\Driver\BulkWrite;
 $bulk->insert(array('x' => 2));
-$result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
+$result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(0)]);
 
 printf("WriteResult::isAcknowledged(): %s\n", $result->isAcknowledged() ? 'true' : 'false');
 var_dump($result);

--- a/tests/writeConcernError/writeconcernerror-debug-001.phpt
+++ b/tests/writeConcernError/writeconcernerror-debug-001.phpt
@@ -15,7 +15,7 @@ $bulk->insert(['x' => 1]);
 
 try {
     /* We assume that the replica set does not have 12 nodes */
-    $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(12));
+    $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(12)]);
 } catch(MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteConcernError());
 }

--- a/tests/writeConcernError/writeconcernerror-getcode-001.phpt
+++ b/tests/writeConcernError/writeconcernerror-getcode-001.phpt
@@ -15,7 +15,7 @@ $bulk->insert(['x' => 1]);
 
 try {
     /* We assume that the replica set does not have 12 nodes */
-    $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(12));
+    $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(12)]);
 } catch(MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteConcernError()->getCode());
 }

--- a/tests/writeConcernError/writeconcernerror-getmessage-001.phpt
+++ b/tests/writeConcernError/writeconcernerror-getmessage-001.phpt
@@ -15,7 +15,7 @@ $bulk->insert(['x' => 1]);
 
 try {
     /* We assume that the replica set does not have 12 nodes */
-    $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(12));
+    $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(12)]);
 } catch(MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteConcernError()->getMessage());
 }

--- a/tests/writeResult/writeresult-debug-002.phpt
+++ b/tests/writeResult/writeresult-debug-002.phpt
@@ -22,7 +22,7 @@ $bulk->insert(['_id' => 3]);
 
 try {
     /* We assume that the replica set does not have 30 nodes */
-    $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(30));
+    $result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(30)]);
 } catch (MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult());
 }

--- a/tests/writeResult/writeresult-getdeletedcount-002.phpt
+++ b/tests/writeResult/writeresult-getdeletedcount-002.phpt
@@ -17,7 +17,7 @@ $bulk->update(['x' => 2], ['$set' => ['y' => 1]], ['upsert' => true]);
 $bulk->update(['x' => 3], ['$set' => ['y' => 2]], ['upsert' => true]);
 $bulk->delete(['x' => 1]);
 
-$result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
+$result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(0)]);
 
 var_dump($result->getDeletedCount());
 

--- a/tests/writeResult/writeresult-getinsertedcount-002.phpt
+++ b/tests/writeResult/writeresult-getinsertedcount-002.phpt
@@ -17,7 +17,7 @@ $bulk->update(['x' => 2], ['$set' => ['y' => 1]], ['upsert' => true]);
 $bulk->update(['x' => 3], ['$set' => ['y' => 2]], ['upsert' => true]);
 $bulk->delete(['x' => 1]);
 
-$result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
+$result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(0)]);
 
 var_dump($result->getInsertedCount());
 

--- a/tests/writeResult/writeresult-getmatchedcount-002.phpt
+++ b/tests/writeResult/writeresult-getmatchedcount-002.phpt
@@ -17,7 +17,7 @@ $bulk->update(['x' => 2], ['$set' => ['y' => 1]], ['upsert' => true]);
 $bulk->update(['x' => 3], ['$set' => ['y' => 2]], ['upsert' => true]);
 $bulk->delete(['x' => 1]);
 
-$result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
+$result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(0)]);
 
 var_dump($result->getMatchedCount());
 

--- a/tests/writeResult/writeresult-getmodifiedcount-002.phpt
+++ b/tests/writeResult/writeresult-getmodifiedcount-002.phpt
@@ -17,7 +17,7 @@ $bulk->update(['x' => 2], ['$set' => ['y' => 1]], ['upsert' => true]);
 $bulk->update(['x' => 3], ['$set' => ['y' => 2]], ['upsert' => true]);
 $bulk->delete(['x' => 1]);
 
-$result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
+$result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(0)]);
 
 var_dump($result->getModifiedCount());
 

--- a/tests/writeResult/writeresult-getupsertedcount-002.phpt
+++ b/tests/writeResult/writeresult-getupsertedcount-002.phpt
@@ -17,7 +17,7 @@ $bulk->update(['x' => 2], ['$set' => ['y' => 1]], ['upsert' => true]);
 $bulk->update(['x' => 3], ['$set' => ['y' => 2]], ['upsert' => true]);
 $bulk->delete(['x' => 1]);
 
-$result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(0));
+$result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(0)]);
 
 var_dump($result->getUpsertedCount());
 

--- a/tests/writeResult/writeresult-getwriteconcernerror-001.phpt
+++ b/tests/writeResult/writeresult-getwriteconcernerror-001.phpt
@@ -15,7 +15,7 @@ $bulk->insert(['x' => 1]);
 
 try {
     /* We assume that the replica set does not have 12 nodes */
-    $result = $manager->executeBulkWrite(NS, $bulk, new MongoDB\Driver\WriteConcern(12));
+    $result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(12)]);
 } catch (MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteConcernError());
 }

--- a/tests/writeResult/writeresult-isacknowledged-001.phpt
+++ b/tests/writeResult/writeresult-isacknowledged-001.phpt
@@ -19,7 +19,7 @@ foreach ($wcs as $wc) {
     $bulk = new MongoDB\Driver\BulkWrite;
     $bulk->insert(['x' => 1]);
 
-    $result = $manager->executeBulkWrite(NS, $bulk, $wc);
+    $result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => $wc]);
 
     var_dump($result->isAcknowledged());
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2489