### PR TITLE
PHPC-2502: Remove XFAIL in server-executeQuery-012.phpt

### DIFF
--- a/tests/server/server-executeQuery-012.phpt
+++ b/tests/server/server-executeQuery-012.phpt
@@ -1,7 +1,5 @@
 --TEST--
 MongoDB\Driver\Server::executeQuery() pins transaction to server
---XFAIL--
-_mongoc_cursor_fetch_stream segfault (CDRIVER-4290)
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_mongos(); ?>


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2502

The corresponding CDRIVER ticket was fixed a while back, and included in the submodule bump for PHPC 1.13.