### PR TITLE
PHPC-2501: Conditionally define MONGOC_CYRUS_PLUGIN_PATH_PREFIX on Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -239,6 +239,10 @@ if (PHP_MONGODB != "no") {
       CHECK_HEADER_ADD_INCLUDE("sasl/sasl.h", "CFLAGS_MONGODB")) {
     mongoc_opts.MONGOC_ENABLE_SASL = 1;
     mongoc_opts.MONGOC_ENABLE_SASL_CYRUS = 1;
+
+    // Referenced by _mongoc_cyrus_verifyfile_cb in mongoc-cyrus.c on Windows
+    ADD_FLAG("CFLAGS_MONGODB", "/D MONGOC_CYRUS_PLUGIN_PATH_PREFIX=NULL");
+
     if (CHECK_FUNC_IN_HEADER("sasl/sasl.h", "sasl_client_done")) {
       mongoc_opts.MONGOC_HAVE_SASL_CLIENT_DONE = 1;
     }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2501

This was missed in 6a2e15ae1fea545b750dff2977924f7e3eaf4af7 when bumping to libmongoc 1.26.2.

Define the constant as null to satisfy compilation. It will not actually be used for path prefix checking.