### PR TITLE
PHPC-2503: Conditionally allow more concise output for libbson 1.30

### DIFF
--- a/tests/bson/bson-encode-001.phpt
+++ b/tests/bson/bson-encode-001.phpt
@@ -39,7 +39,7 @@ foreach($tests as $n => $test) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 Test#0 { "hello" : "world" }
      0 : 16 00 00 00 02 68 65 6c 6c 6f 00 06 00 00 00 77  [.....hello.....w]
     10 : 6f 72 6c 64 00 00                                [orld..]
@@ -98,7 +98,7 @@ Test#16 { "foo" : "test", "0" : "foo", "1" : "bar" }
      0 : 29 00 00 00 02 66 6f 6f 00 05 00 00 00 74 65 73  [)....foo.....tes]
     10 : 74 00 02 30 00 04 00 00 00 66 6f 6f 00 02 31 00  [t..0.....foo..1.]
     20 : 04 00 00 00 62 61 72 00 00                       [....bar..]
-Test#17 { "int" : { "$numberInt" : "3" }, "boolean" : true, "array" : [ "foo", "bar" ], "object" : {  }, "string" : "test", "3" : "test" }
+Test#17 { "int" : { "$numberInt" : "3" }, "boolean" : true, "array" : [ "foo", "bar" ], "object" : { %w}, "string" : "test", "3" : "test" }
      0 : 64 00 00 00 10 69 6e 74 00 03 00 00 00 08 62 6f  [d....int......bo]
     10 : 6f 6c 65 61 6e 00 01 04 61 72 72 61 79 00 1b 00  [olean...array...]
     20 : 00 00 02 30 00 04 00 00 00 66 6f 6f 00 02 31 00  [...0.....foo..1.]
@@ -123,7 +123,7 @@ Test#21 { "0" : { "foo" : "test", "0" : "foo", "1" : "bar" } }
     10 : 05 00 00 00 74 65 73 74 00 02 30 00 04 00 00 00  [....test..0.....]
     20 : 66 6f 6f 00 02 31 00 04 00 00 00 62 61 72 00 00  [foo..1.....bar..]
     30 : 00                                               [.]
-Test#22 { "0" : { "int" : { "$numberInt" : "3" }, "boolean" : true, "array" : [ "foo", "bar" ], "object" : {  }, "string" : "test", "3" : "test" } }
+Test#22 { "0" : { "int" : { "$numberInt" : "3" }, "boolean" : true, "array" : [ "foo", "bar" ], "object" : { %w}, "string" : "test", "3" : "test" } }
      0 : 6c 00 00 00 03 30 00 64 00 00 00 10 69 6e 74 00  [l....0.d....int.]
     10 : 03 00 00 00 08 62 6f 6f 6c 65 61 6e 00 01 04 61  [.....boolean...a]
     20 : 72 72 61 79 00 1b 00 00 00 02 30 00 04 00 00 00  [rray......0.....]

--- a/tests/bson/bson-encode-004.phpt
+++ b/tests/bson/bson-encode-004.phpt
@@ -71,7 +71,7 @@ object(Person)#%d (5) {
   ["secret":protected]=>
   string(24) "Hannes confidential info"
 }
-Test { "0" : { "__pclass" : { "$binary" : { "base64" : "UGVyc29u", "subType" : "80" } }, "name" : "Hannes", "age" : { "$numberInt" : "42" }, "addresses" : [ { "__pclass" : { "$binary" : { "base64" : "QWRkcmVzcw==", "subType" : "80" } }, "zip" : { "$numberInt" : "94086" }, "country" : "USA" }, { "__pclass" : { "$binary" : { "base64" : "QWRkcmVzcw==", "subType" : "80" } }, "zip" : { "$numberInt" : "200" }, "country" : "Iceland" } ], "friends" : [ { "__pclass" : { "$binary" : { "base64" : "UGVyc29u", "subType" : "80" } }, "name" : "Jeremy", "age" : { "$numberInt" : "21" }, "addresses" : [  ], "friends" : [  ] } ] } }
+Test { "0" : { "__pclass" : { "$binary" : { "base64" : "UGVyc29u", "subType" : "80" } }, "name" : "Hannes", "age" : { "$numberInt" : "42" }, "addresses" : [ { "__pclass" : { "$binary" : { "base64" : "QWRkcmVzcw==", "subType" : "80" } }, "zip" : { "$numberInt" : "94086" }, "country" : "USA" }, { "__pclass" : { "$binary" : { "base64" : "QWRkcmVzcw==", "subType" : "80" } }, "zip" : { "$numberInt" : "200" }, "country" : "Iceland" } ], "friends" : [ { "__pclass" : { "$binary" : { "base64" : "UGVyc29u", "subType" : "80" } }, "name" : "Jeremy", "age" : { "$numberInt" : "21" }, "addresses" : [ %w], "friends" : [ %w] } ] } }
      0 : 23 01 00 00 03 30 00 1b 01 00 00 05 5f 5f 70 63  [#....0......__pc]
     10 : 6c 61 73 73 00 06 00 00 00 80 50 65 72 73 6f 6e  [lass......Person]
     20 : 02 6e 61 6d 65 00 07 00 00 00 48 61 6e 6e 65 73  [.name.....Hannes]

--- a/tests/bson/bson-encode-005.phpt
+++ b/tests/bson/bson-encode-005.phpt
@@ -19,7 +19,7 @@ var_dump($ret);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-Test { "emptyarray" : [  ], "emptyclass" : {  } }
+Test { "emptyarray" : [ %w], "emptyclass" : { %w} }
      0 : 27 00 00 00 04 65 6d 70 74 79 61 72 72 61 79 00  ['....emptyarray.]
     10 : 05 00 00 00 00 03 65 6d 70 74 79 63 6c 61 73 73  [......emptyclass]
     20 : 00 05 00 00 00 00 00                             [.......]

--- a/tests/readPreference/readpreference-bsonserialize-001.phpt
+++ b/tests/readPreference/readpreference-bsonserialize-001.phpt
@@ -24,7 +24,7 @@ foreach ($tests as $test) {
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 { "mode" : "primary" }
 { "mode" : "primaryPreferred" }
 { "mode" : "secondary" }
@@ -32,6 +32,6 @@ foreach ($tests as $test) {
 { "mode" : "nearest" }
 { "mode" : "primary" }
 { "mode" : "secondary", "tags" : [ { "dc" : "ny" } ] }
-{ "mode" : "secondary", "tags" : [ { "dc" : "ny" }, { "dc" : "sf", "use" : "reporting" }, {  } ] }
+{ "mode" : "secondary", "tags" : [ { "dc" : "ny" }, { "dc" : "sf", "use" : "reporting" }, { %w} ] }
 { "mode" : "secondary", "maxStalenessSeconds" : { "$numberInt" : "1000" } }
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2503

mongodb/mongo-c-driver@f2c1bb7989177fa2ddba1a915e8423e46ee1defe reduced the whitespace for empty arrays and documents. The EXPECTF pattern is necessary for compatibility with earlier versions of libbson, but it can be removed once libbson 1.30+ is formally required.