### PR TITLE
Use pre-packaged-source for pie downloads

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
   },
   "php-ext": {
     "extension-name": "mongodb",
+    "download-url-method": "pre-packaged-source",
+    "build-path": "mongodb-{version}",
     "configure-options": [
       {
         "name": "enable-mongodb-developer-flags",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
   "php-ext": {
     "extension-name": "mongodb",
     "download-url-method": "pre-packaged-source",
-    "build-path": "mongodb-{version}",
     "configure-options": [
       {
         "name": "enable-mongodb-developer-flags",


### PR DESCRIPTION
We worked on php/pie#39 to allow the `mongodb` extension to be built from pre-packaged source URLs instead of relying on the git-generated ZIP archive that GitHub etc. uses (and thus Composer/PIE).

Note: `build-path` is also needed, and I added a template for it, since the TGZ produced has a subdirectory in it based on the version; so in the case of `mongodb` at least, we'll need both `download-url-method` and `build-path` to be specified.

Note 2: needs php/pie#187 to be merged first