### PR TITLE
Fix openssl detection on Silicon Macs

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -536,6 +536,7 @@ Build configuration:
   libmongoc                                        : $PHP_MONGODB_BSON_VERSION_STRING
   libbson                                          : $PHP_MONGODB_MONGOC_VERSION_STRING
   libmongocrypt                                    : $PHP_MONGODB_MONGOCRYPT_VERSION_STRING
+  SSL                                              : $PHP_MONGODB_SSL
   LDFLAGS                                          : $LDFLAGS
   EXTRA_LDFLAGS                                    : $EXTRA_LDFLAGS
   MONGODB_SHARED_LIBADD                            : $MONGODB_SHARED_LIBADD

--- a/scripts/autotools/libmongoc/CheckSSL.m4
+++ b/scripts/autotools/libmongoc/CheckSSL.m4
@@ -57,7 +57,7 @@ AS_IF([test "$PHP_MONGODB_SSL" = "openssl" -o "$PHP_MONGODB_SSL" = "auto"],[
     dnl Use a list of directories from PHP_SETUP_OPENSSL by default.
     dnl Support documented "auto" and older, undocumented "yes" options
     if test "$PHP_OPENSSL_DIR" = "auto" -o "$PHP_OPENSSL_DIR" = "yes"; then
-      PHP_OPENSSL_DIR="/usr/local/ssl /usr/local /usr /usr/local/openssl"
+      PHP_OPENSSL_DIR="/usr/local/ssl /usr/local /usr /usr/local/openssl /opt/homebrew/opt/openssl"
     fi
 
     for i in $PHP_OPENSSL_DIR; do


### PR DESCRIPTION
Targeting 1.21 for this change, as it could lead to a different SSL library being picked, which I wouldn't expect in a patch release. This is consistent with #1463 which was the original attempt to prefer openssl over Secure Transport and also targeted a minor version to avoid unexpected issues on a patch update.

On Silicon Macs, the paths for homebrew have changed, so if the `PKG_CHECK_MODULES` macro does not find openssl on MacOS and no `OPENSSL_DIR` option has been provided, it usually won't be found. As a result, Secure Transport will be picked in those circumstances.

On Silicon platforms, homebrew installs openssl into `/opt/homebrew/opt/openssl`, so adding that path to `PHP_OPENSSL_DIR` fixes the issue.

To make debugging easier, I also added the selected SSL library to the configure output.

NB: I checked whether pkg-config is available on my system, and it isn't by default. A quick search through homebrew also didn't reveal it, so my assumption is that pkg-config won't be available on the typical developer machine, hence this workaround.