### PR TITLE
PHPC-2518: Support sort option for updateOne and replaceOne

### DIFF
--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -280,6 +280,7 @@ static bool php_phongo_bulkwrite_update_apply_options(bson_t* boptions, zval* zo
 	PHONGO_BULKWRITE_APPEND_BOOL("upsert", upsert);
 	PHONGO_BULKWRITE_OPT_ARRAY("arrayFilters");
 	PHONGO_BULKWRITE_OPT_DOCUMENT("collation");
+	PHONGO_BULKWRITE_OPT_DOCUMENT("sort");
 
 	if (!php_phongo_bulkwrite_opt_hint(boptions, zoptions)) {
 		return false;

--- a/tests/bulk/bulkwrite-update-008.phpt
+++ b/tests/bulk/bulkwrite-update-008.phpt
@@ -1,0 +1,81 @@
+--TEST--
+MongoDB\Driver\BulkWrite::update() with sort option
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_server_version('<', '8.0'); ?>
+<?php skip_if_not_clean(); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+class CommandLogger implements MongoDB\Driver\Monitoring\CommandSubscriber
+{
+    public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event): void
+    {
+        if ($event->getCommandName() !== 'update') {
+            return;
+        }
+
+        printf("update included sort: %s\n", json_encode($event->getCommand()->updates[0]->sort));
+    }
+
+    public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event): void
+    {
+    }
+
+    public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event): void
+    {
+    }
+}
+
+$manager = create_test_manager();
+
+$bulk = new MongoDB\Driver\BulkWrite();
+$bulk->insert(['_id' => 1]);
+$bulk->insert(['_id' => 2]);
+$bulk->insert(['_id' => 3]);
+$manager->executeBulkWrite(NS, $bulk);
+
+MongoDB\Driver\Monitoring\addSubscriber(new CommandLogger);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->update(['_id' => ['$gt' => 1]], ['$set' => ['x' => 11]], ['sort' => ['_id' => 1]]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->update(['_id' => ['$gt' => 1]], ['x' => 22], ['sort' => ['_id' => -1]]);
+$manager->executeBulkWrite(NS, $bulk);
+
+$cursor = $manager->executeQuery(NS, new MongoDB\Driver\Query([]));
+
+var_dump($cursor->toArray());
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+update included sort: {"_id":1}
+update included sort: {"_id":-1}
+array(3) {
+  [0]=>
+  object(stdClass)#%d (%d) {
+    ["_id"]=>
+    int(1)
+  }
+  [1]=>
+  object(stdClass)#%d (%d) {
+    ["_id"]=>
+    int(2)
+    ["x"]=>
+    int(11)
+  }
+  [2]=>
+  object(stdClass)#%d (%d) {
+    ["_id"]=>
+    int(3)
+    ["x"]=>
+    int(22)
+  }
+}
+===DONE===

--- a/tests/bulk/bulkwrite-update_error-009.phpt
+++ b/tests/bulk/bulkwrite-update_error-009.phpt
@@ -1,0 +1,22 @@
+--TEST--
+MongoDB\Driver\BulkWrite::update() with multi:true prohibits sort option
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager();
+$bulk = new MongoDB\Driver\BulkWrite;
+
+echo throws(function() use ($manager, $bulk) {
+    $bulk->update(['x' => ['$gt' => 1]], ['$set' => ['y' => 11]], ['multi' => true, 'sort' => ['x' => 1]]);
+}, MongoDB\Driver\Exception\InvalidArgumentException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\InvalidArgumentException
+Invalid option 'sort'
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2518

updateMany does not support sort. That validation is handled by mongoc_bulk_operation_update_many_with_opts().