### PR TITLE
Add CODEOWNERS for 1.21+

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mongodb/dbx-php


### PR DESCRIPTION
With the new code ownership initiative, we're required to have ownership for all files in the repository. This adds the corresponding code ownership file from PHPLIB