### PR TITLE
Add details to the generic `BulkWriteCommandException` message

### DIFF
--- a/src/phongo_execute.c
+++ b/src/phongo_execute.c
@@ -440,6 +440,8 @@ bool phongo_execute_bulkwritecommand(zval* manager, php_phongo_bulkwritecommand_
 			(void) spprintf(&message, 0, "Bulk write failed due to previous %s: %s", PHONGO_ZVAL_EXCEPTION_NAME(EG(exception)), error.message);
 			zend_throw_exception(php_phongo_bulkwritecommandexception_ce, message, 0);
 			efree(message);
+		} else if (!has_top_level_error && bw_ret.res) {
+			zend_throw_exception(php_phongo_bulkwritecommandexception_ce, "Bulk write failed with %d write concern errors and %d write errors", error.code, bw_ret.res->n_write_concern_errors, bw_ret.res->n_write_errors);
 		} else {
 			zend_throw_exception(php_phongo_bulkwritecommandexception_ce, has_top_level_error ? error.message : "Bulk write failed", error.code);
 		}

--- a/tests/bulkwritecommand/bulkwritecommandexception-001.phpt
+++ b/tests/bulkwritecommand/bulkwritecommandexception-001.phpt
@@ -1,0 +1,30 @@
+--TEST--
+MongoDB\Driver\BulkWriteCommandResult::isAcknowledged() with unacknowledged write concern
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_server_version('<', '8.0'); ?>
+<?php skip_if_not_clean(); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager(URI);
+
+$bulk = new MongoDB\Driver\BulkWriteCommand(['ordered' => false]);
+$bulk->insertOne(NS, ['_id' => 1]);
+$bulk->insertOne(NS, ['_id' => 1]);
+
+echo throws(function() use ($result) {
+    $manager->executeBulkWriteCommand($bulk);
+}, MongoDB\Driver\Exception\BulkWriteCommandException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+bool(false)
+OK: Got MongoDB\Driver\Exception\BulkWriteCommandException
+Bulk write failed with 0 write concern errors and 1 write errors
+===DONE===


### PR DESCRIPTION
I'm trying to add more context to the exception. When a `BulkWriteCommandException` is thrown for individual operation error, the message is not helpful. By mentioning "write concern errors" and "write errors", we give a hint for debugging.