### PR TITLE
PHPC-2367: Add SSPI SASL, drop Cyrus on Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -232,27 +232,33 @@ if (PHP_MONGODB != "no") {
     WARNING("mongodb libopenssl support not enabled, libs not found");
   }
 
-  if (PHP_MONGODB_SASL != "no" &&
-      CHECK_LIB("libsasl.lib", "mongodb", PHP_MONGODB) &&
-      CHECK_HEADER_ADD_INCLUDE("sasl/sasl.h", "CFLAGS_MONGODB")) {
+  has_sasl_libs = CHECK_LIB("libsasl.lib", "mongodb", PHP_MONGODB) &&
+    CHECK_HEADER_ADD_INCLUDE("sasl/sasl.h", "CFLAGS_MONGODB");
+  if (PHP_MONGODB_SASL != "no") {
+    if (has_sasl_libs) {
+      // TODO 3.0: Remove warning on "yes" as it implies "sspi"
+      if (PHP_MONGODB_SASL == "yes") {
+        WARNING("Cyrus SASL support for Windows was removed. Falling back to SSPI; use '--with-mongodb-sasl=sspi' to avoid this warning.");
+        PHP_MONGODB_SASL = "sspi";
+      }
 
-    // TODO 3.0: Remove warning on "yes" as it implies "sspi"
-    if (PHP_MONGODB_SASL == "yes") {
-      WARNING("Cyrus SASL support for Windows was removed. Falling back to SSPI; use '--with-mongodb-sasl=sspi' to avoid this warning.");
-    }
+      if (PHP_MONGODB_SASL == "sspi") {
+        mongoc_opts.MONGOC_ENABLE_SASL = 1;
+        mongoc_opts.MONGOC_ENABLE_SASL_SSPI = 1;
+      } else {
+        ERROR("MongoDB SASL support not enabled, unknown value for --with-mongodb-sasl: " + PHP_MONGODB_SASL);
+      }
 
-    if (PHP_MONGODB_SASL == "yes" || PHP_MONGODB_SASL == "sspi") {
-      mongoc_opts.MONGOC_ENABLE_SASL = 1;
-      mongoc_opts.MONGOC_ENABLE_SASL_SSPI = 1;
+      if (CHECK_FUNC_IN_HEADER("sasl/sasl.h", "sasl_client_done")) {
+        mongoc_opts.MONGOC_HAVE_SASL_CLIENT_DONE = 1;
+      }
+    } else if (PHP_MONGODB_SASL != "yes") {
+      // If the user explicitly requested SASL support, we error out if the
+      // necessary libraries are not found.
+      ERROR("MongoDB SASL support not enabled, libs not found");
     } else {
-      ERROR("MongoDB SASL support not enabled, unknown value for --with-mongodb-sasl: " + PHP_MONGODB_SASL);
+      WARNING("MongoDB SASL support not enabled, libs not found");
     }
-
-    if (CHECK_FUNC_IN_HEADER("sasl/sasl.h", "sasl_client_done")) {
-      mongoc_opts.MONGOC_HAVE_SASL_CLIENT_DONE = 1;
-    }
-  } else if (PHP_MONGODB_SASL != "no") {
-    ERROR("MongoDB SASL support not enabled, libs not found");
   }
 
   if (PHP_MONGODB_CLIENT_SIDE_ENCRYPTION != "no" && mongoc_ssl_found) {

--- a/config.w32
+++ b/config.w32
@@ -70,7 +70,7 @@ function MONGODB_ADD_SOURCES(dir, file_list)
 }
 
 ARG_ENABLE("mongodb", "MongoDB support", "no");
-ARG_WITH("mongodb-sasl", "MongoDB: Build with SASL (cyrus, sspi)", "yes");
+ARG_WITH("mongodb-sasl", "MongoDB: Build with SSPI SASL", "yes");
 ARG_WITH("mongodb-client-side-encryption", "MongoDB: Enable client-side encryption", "yes");
 
 if (PHP_MONGODB != "no") {
@@ -237,12 +237,12 @@ if (PHP_MONGODB != "no") {
       CHECK_HEADER_ADD_INCLUDE("sasl/sasl.h", "CFLAGS_MONGODB")) {
     mongoc_opts.MONGOC_ENABLE_SASL = 1;
 
-    if (PHP_MONGODB_SASL == "yes" || PHP_MONGODB_SASL == "cyrus") {
-      mongoc_opts.MONGOC_ENABLE_SASL_CYRUS = 1;
+    // TODO 3.0: Remove warning on "yes" as it implies "sspi"
+    if (PHP_MONGODB_SASL == "yes") {
+      WARNING("Cyrus SASL support for Windows was removed. Falling back to SSPI.");
+    }
 
-      // Referenced by _mongoc_cyrus_verifyfile_cb in mongoc-cyrus.c on Windows
-      ADD_FLAG("CFLAGS_MONGODB", "/D MONGOC_CYRUS_PLUGIN_PATH_PREFIX=NULL");
-    } else if (PHP_MONGODB_SASL == "sspi") {
+    if (PHP_MONGODB_SASL == "yes" || PHP_MONGODB_SASL == "sspi") {
       mongoc_opts.MONGOC_ENABLE_SASL_SSPI = 1;
     } else {
       WARNING("mongodb sasl support not enabled, unknown value for PHP_MONGODB_SASL: " + PHP_MONGODB_SASL);

--- a/config.w32
+++ b/config.w32
@@ -70,7 +70,7 @@ function MONGODB_ADD_SOURCES(dir, file_list)
 }
 
 ARG_ENABLE("mongodb", "MongoDB support", "no");
-ARG_WITH("mongodb-sasl", "MongoDB: Build against Cyrus-SASL", "yes");
+ARG_WITH("mongodb-sasl", "MongoDB: Build with SASL (cyrus, sspi)", "yes");
 ARG_WITH("mongodb-client-side-encryption", "MongoDB: Enable client-side encryption", "yes");
 
 if (PHP_MONGODB != "no") {
@@ -232,15 +232,21 @@ if (PHP_MONGODB != "no") {
     WARNING("mongodb libopenssl support not enabled, libs not found");
   }
 
-  // TODO: Support building with native GSSAPI (SSPI) on Windows
   if (PHP_MONGODB_SASL != "no" &&
       CHECK_LIB("libsasl.lib", "mongodb", PHP_MONGODB) &&
       CHECK_HEADER_ADD_INCLUDE("sasl/sasl.h", "CFLAGS_MONGODB")) {
     mongoc_opts.MONGOC_ENABLE_SASL = 1;
-    mongoc_opts.MONGOC_ENABLE_SASL_CYRUS = 1;
 
-    // Referenced by _mongoc_cyrus_verifyfile_cb in mongoc-cyrus.c on Windows
-    ADD_FLAG("CFLAGS_MONGODB", "/D MONGOC_CYRUS_PLUGIN_PATH_PREFIX=NULL");
+    if (PHP_MONGODB_SASL == "yes" || PHP_MONGODB_SASL == "cyrus") {
+      mongoc_opts.MONGOC_ENABLE_SASL_CYRUS = 1;
+
+      // Referenced by _mongoc_cyrus_verifyfile_cb in mongoc-cyrus.c on Windows
+      ADD_FLAG("CFLAGS_MONGODB", "/D MONGOC_CYRUS_PLUGIN_PATH_PREFIX=NULL");
+    } else if (PHP_MONGODB_SASL == "sspi") {
+      mongoc_opts.MONGOC_ENABLE_SASL_SSPI = 1;
+    } else {
+      WARNING("mongodb sasl support not enabled, unknown value for PHP_MONGODB_SASL: " + PHP_MONGODB_SASL);
+    }
 
     if (CHECK_FUNC_IN_HEADER("sasl/sasl.h", "sasl_client_done")) {
       mongoc_opts.MONGOC_HAVE_SASL_CLIENT_DONE = 1;

--- a/config.w32
+++ b/config.w32
@@ -70,7 +70,7 @@ function MONGODB_ADD_SOURCES(dir, file_list)
 }
 
 ARG_ENABLE("mongodb", "MongoDB support", "no");
-ARG_WITH("mongodb-sasl", "MongoDB: Build with SSPI SASL", "yes");
+ARG_WITH("mongodb-sasl", "MongoDB: Build with SSPI SASL (valid values: 'yes' (fallback to SSPI), 'sspi', 'no')", "yes");
 ARG_WITH("mongodb-client-side-encryption", "MongoDB: Enable client-side encryption", "yes");
 
 if (PHP_MONGODB != "no") {
@@ -235,17 +235,17 @@ if (PHP_MONGODB != "no") {
   if (PHP_MONGODB_SASL != "no" &&
       CHECK_LIB("libsasl.lib", "mongodb", PHP_MONGODB) &&
       CHECK_HEADER_ADD_INCLUDE("sasl/sasl.h", "CFLAGS_MONGODB")) {
-    mongoc_opts.MONGOC_ENABLE_SASL = 1;
 
     // TODO 3.0: Remove warning on "yes" as it implies "sspi"
     if (PHP_MONGODB_SASL == "yes") {
-      WARNING("Cyrus SASL support for Windows was removed. Falling back to SSPI.");
+      WARNING("Cyrus SASL support for Windows was removed. Falling back to SSPI; use '--with-mongodb-sasl=sspi' to avoid this warning.");
     }
 
     if (PHP_MONGODB_SASL == "yes" || PHP_MONGODB_SASL == "sspi") {
+      mongoc_opts.MONGOC_ENABLE_SASL = 1;
       mongoc_opts.MONGOC_ENABLE_SASL_SSPI = 1;
     } else {
-      WARNING("mongodb sasl support not enabled, unknown value for PHP_MONGODB_SASL: " + PHP_MONGODB_SASL);
+      WARNING("MongoDB SASL support not enabled, unknown value for PHP_MONGODB_SASL: " + PHP_MONGODB_SASL);
     }
 
     if (CHECK_FUNC_IN_HEADER("sasl/sasl.h", "sasl_client_done")) {

--- a/config.w32
+++ b/config.w32
@@ -245,14 +245,14 @@ if (PHP_MONGODB != "no") {
       mongoc_opts.MONGOC_ENABLE_SASL = 1;
       mongoc_opts.MONGOC_ENABLE_SASL_SSPI = 1;
     } else {
-      WARNING("MongoDB SASL support not enabled, unknown value for PHP_MONGODB_SASL: " + PHP_MONGODB_SASL);
+      ERROR("MongoDB SASL support not enabled, unknown value for --with-mongodb-sasl: " + PHP_MONGODB_SASL);
     }
 
     if (CHECK_FUNC_IN_HEADER("sasl/sasl.h", "sasl_client_done")) {
       mongoc_opts.MONGOC_HAVE_SASL_CLIENT_DONE = 1;
     }
   } else if (PHP_MONGODB_SASL != "no") {
-    WARNING("mongodb libsasl support not enabled, libs not found");
+    ERROR("MongoDB SASL support not enabled, libs not found");
   }
 
   if (PHP_MONGODB_CLIENT_SIDE_ENCRYPTION != "no" && mongoc_ssl_found) {


### PR DESCRIPTION
PHPC-2367

This build adds support for building with SSPI SASL on Windows, in turn dropping Cyrus as it's no longer supported by libmongoc. Since people would be using the default value (`yes`) to enable Cyrus support, we add a warning that we're falling back to SSPI. The setting also supports an explicit sspi setting (`--with-mongodb-sasl=sspi`) that does not emit a warning.

Note that our GitHub Windows builds test with SASL support enabled, so this change is properly tested.