### PR TITLE
Ignore branches that are no longer maintained when merging up

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -24,9 +24,10 @@ jobs:
 
       - name: Create pull request
         id: create-pull-request
-        uses: alcaeus/automatic-merge-up-action@main
+        uses: alcaeus/automatic-merge-up-action@1.0.0
         with:
           ref: ${{ github.ref_name }}
           branchNamePattern: 'v<major>.<minor>'
           devBranchNamePattern: 'v<major>.x'
+          ignoredBranches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
           enableAutoMerge: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,11 +112,12 @@ jobs:
 
       - name: "Determine branch to merge up to"
         id: get-next-branch
-        uses: alcaeus/automatic-merge-up-action/get-next-branch@main
+        uses: alcaeus/automatic-merge-up-action/get-next-branch@1.0.0
         with:
           ref: ${{ github.ref_name }}
           branchNamePattern: 'v<major>.<minor>'
           devBranchNamePattern: 'v<major>.x'
+          ignoredBranches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
 
       - name: "Manually merge up changes"
         if: ${{ steps.get-next-branch.outputs.hasNextBranch }}


### PR DESCRIPTION
The new `IGNORED_MERGE_UP_BRANCHES` action variable is already configured to exclude the `v1.x` and `v2.0` branches which we no longer support.