### PR TITLE
Update installation instruction to use `pie`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ on:
 
 env:
   default-release-message: |
-    The PHP team is happy to announce that version {0} of the [mongodb](https://pecl.php.net/package/mongodb) PHP extension is now available on PECL.
+    The PHP team is happy to announce that version {0} of the MongoDB PHP extension is now available.
+    - [mongodb/mongodb-extension](https://packagist.org/packages/mongodb/mongodb-extension#{0}) on Packagist.
+    - [mongodb](https://pecl.php.net/package/mongodb) on PECL
 
     **Release Highlights**
 
@@ -32,16 +34,10 @@ env:
     You can either download and install the source manually, or you can install the extension with:
 
     ```
-    pecl install mongodb-{0}
+    pie install mongodb/mongodb-extension:{0}
     ```
 
-    or update with:
-
-    ```
-    pecl upgrade mongodb-{0}
-    ```
-
-    Windows binaries are attached to the GitHub release notes.
+    Sources and Windows binaries are attached to the GitHub release notes.
 
 jobs:
   prepare-release:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ languages.
  - https://www.php.net/mongodb
  - https://www.mongodb.com/docs/drivers/php-drivers/
 
-## Installation with pie
+## Installation
+
+### With pie
 
 To install this extension, you need [pie](https://github.com/php/pie) installed on your system. `pie` is a modern tool for managing PHP extensions.
 
@@ -34,13 +36,23 @@ pie install mongodb/mongodb-extension
 
 This will automatically download, build, and enable the MongoDB extension for your PHP installation.
 
+Add a version constraint after the extension name to restrict can be installed:
+
+```shell
+pie install mongodb/mongodb-extension:^2.1.0
+```
+
+The constraint `^2.1.0` will install the latest version `>= 2.1.0 < 3.0.0-dev`.
+
+
 For more details on using `pie`, see the [pie documentation](https://github.com/php/pie).
 
-## Installation with pecl
+### with pecl
 
-Using pecl to install extensions is deprecated, 
+> [!NOTE]
+> Using pecl to install extensions is deprecated.
 
-To build and install the driver:
+To build and install the extension:
 
 ```shell
 pecl install mongodb
@@ -58,7 +70,7 @@ distributed as the
 [`mongodb/mongodb`](https://packagist.org/packages/mongodb/mongodb) package for
 [Composer](https://getcomposer.org).
 
-### Release Integrity
+## Release Integrity
 
 Releases are created automatically and signed using the 
 [PHP team's GPG key](https://pgp.mongodb.com/php-driver.asc). This applies to

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ distributed as the
 
 ## Release Integrity
 
+> [!NOTE]
+> Integrity validation is not yet supported when installing with `pie`. If you require signature verification, use the manual or PECL installation methods described below.
+
 Releases are created automatically and signed using the 
 [PHP team's GPG key](https://pgp.mongodb.com/php-driver.asc). This applies to
 the git tag as well as all release packages provided as part of a

--- a/README.md
+++ b/README.md
@@ -22,12 +22,30 @@ languages.
  - https://www.php.net/mongodb
  - https://www.mongodb.com/docs/drivers/php-drivers/
 
-## Installation
+## Installation with pie
+
+To install this extension, you need [pie](https://github.com/php/pie) installed on your system. `pie` is a modern tool for managing PHP extensions.
+
+Install the [`mongodb/mongodb-extension`](https://packagist.org/packages/mongodb/mongodb-extension) package from Packagist using the following command:
+
+```shell
+pie install mongodb/mongodb-extension
+```
+
+This will automatically download, build, and enable the MongoDB extension for your PHP installation.
+
+For more details on using `pie`, see the [pie documentation](https://github.com/php/pie).
+
+## Installation with pecl
+
+Using pecl to install extensions is deprecated, 
 
 To build and install the driver:
 
-    $ pecl install mongodb
-    $ echo "extension=mongodb.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+```shell
+pecl install mongodb
+echo "extension=mongodb.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+```
 
 The MongoDB PHP Driver follows [semantic versioning](https://semver.org/) for its releases.
 
@@ -40,7 +58,7 @@ distributed as the
 [`mongodb/mongodb`](https://packagist.org/packages/mongodb/mongodb) package for
 [Composer](https://getcomposer.org).
 
-## Release Integrity
+### Release Integrity
 
 Releases are created automatically and signed using the 
 [PHP team's GPG key](https://pgp.mongodb.com/php-driver.asc). This applies to


### PR DESCRIPTION
pie 1.0.0 has been released, it's the new recommended way of installing PHP extension as it works with Windows, Linux and Mac. It provides more security as the extension metadata are extracted from GitHub releases and published on Packagist [`mongodb/mongodb-extension`](https://packagist.org/packages/mongodb/mongodb-extension), and the source are downloaded from GitHub releases.