### PR TITLE
PHPC-2601: Add crypt_shared version to a manager's debug output

### DIFF
--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -828,7 +828,7 @@ static HashTable* php_phongo_manager_get_debug_info(zend_object* object, int* is
 	*is_temp = 1;
 	intern   = Z_OBJ_MANAGER(object);
 
-	array_init_size(&retval, 2);
+	array_init_size(&retval, 3);
 
 	ADD_ASSOC_STRING(&retval, "uri", mongoc_uri_get_string(mongoc_client_get_uri(intern->client)));
 
@@ -850,6 +850,16 @@ static HashTable* php_phongo_manager_get_debug_info(zend_object* object, int* is
 	}
 
 	ADD_ASSOC_ZVAL_EX(&retval, "cluster", &cluster);
+
+	{
+		const char* crypt_shared_version = mongoc_client_get_crypt_shared_version(intern->client);
+
+		if (crypt_shared_version) {
+			ADD_ASSOC_STRING(&retval, "cryptSharedVersion", crypt_shared_version);
+		} else {
+			ADD_ASSOC_NULL_EX(&retval, "cryptSharedVersion");
+		}
+	}
 
 done:
 	mongoc_server_descriptions_destroy_all(sds, n);

--- a/tests/manager/bug0940-001.phpt
+++ b/tests/manager/bug0940-001.phpt
@@ -20,5 +20,7 @@ object(MongoDB\Driver\Manager)#%d (%d) {
   ["cluster"]=>
   array(0) {
   }
+  ["cryptSharedVersion"]=>
+  NULL
 }
 ===DONE===

--- a/tests/manager/manager-ctor-auto_encryption-002.phpt
+++ b/tests/manager/manager-ctor-auto_encryption-002.phpt
@@ -4,8 +4,6 @@ MongoDB\Driver\Manager::__construct(): crypt_shared is required
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_libmongocrypt(); ?>
 <?php skip_if_no_crypt_shared(); ?>
---XFAIL--
-crypt_shared log output breaks build (PHPC-2156)
 --FILE--
 <?php
 

--- a/tests/manager/manager-ctor-ssl-001.phpt
+++ b/tests/manager/manager-ctor-ssl-001.phpt
@@ -21,6 +21,8 @@ object(MongoDB\Driver\Manager)#%d (%d) {
   ["cluster"]=>
   array(0) {
   }
+  ["cryptSharedVersion"]=>
+  NULL
 }
 object(MongoDB\Driver\Manager)#%d (%d) {
   ["uri"]=>
@@ -28,5 +30,7 @@ object(MongoDB\Driver\Manager)#%d (%d) {
   ["cluster"]=>
   array(0) {
   }
+  ["cryptSharedVersion"]=>
+  NULL
 }
 ===DONE===

--- a/tests/manager/manager-debug-004.phpt
+++ b/tests/manager/manager-debug-004.phpt
@@ -1,0 +1,53 @@
+--TEST--
+MongoDB\Driver\Manager debug output with crypt_shared
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_libmongocrypt(); ?>
+<?php skip_if_no_crypt_shared(); ?>
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+// First, create a test manager without auto-encryption
+$manager = create_test_manager();
+
+var_dump($manager);
+var_dump(get_module_info('crypt_shared library version'));
+
+$autoEncryptionOptions = [
+    'keyVaultNamespace' => CSFLE_KEY_VAULT_NS,
+    'kmsProviders' => ['local' => ['key' => new MongoDB\BSON\Binary(CSFLE_LOCAL_KEY, 0)]],
+    'extraOptions' => ['cryptSharedLibRequired' => true],
+];
+
+$manager = create_test_manager(null, [], ['autoEncryption' => $autoEncryptionOptions]);
+
+var_dump($manager);
+var_dump(get_module_info('crypt_shared library version'));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\Driver\Manager)#%d (%d) {
+  ["uri"]=>
+  string(%d) "%s"
+  ["cluster"]=>
+  array(0) {
+  }
+  ["cryptSharedVersion"]=>
+  NULL
+}
+string(7) "unknown"
+object(MongoDB\Driver\Manager)#%d (%d) {
+  ["uri"]=>
+  string(%d) "%s"
+  ["cluster"]=>
+  array(0) {
+  }
+  ["cryptSharedVersion"]=>
+  string(%d) "mongo_crypt%a"
+}
+string(7) "unknown"
+===DONE===

--- a/tests/manager/manager-var-dump-001.phpt
+++ b/tests/manager/manager-var-dump-001.phpt
@@ -28,6 +28,8 @@ object(MongoDB\Driver\Manager)#%d (%d) {
   ["cluster"]=>
   array(0) {
   }
+  ["cryptSharedVersion"]=>
+  NULL
 }
 object(MongoDB\Driver\Manager)#%d (%d) {
   ["uri"]=>
@@ -60,5 +62,7 @@ object(MongoDB\Driver\Manager)#%d (%d) {
       int(%d)
     }
   }
+  ["cryptSharedVersion"]=>
+  NULL
 }
 ===DONE===

--- a/tests/utils/skipif.php
+++ b/tests/utils/skipif.php
@@ -459,6 +459,10 @@ function skip_if_crypt_shared()
 
 function skip_if_no_crypt_shared()
 {
+    if (PHP_INT_SIZE !== 8) {
+        exit('skip crypt_shared is only available on 64-bit systems');
+    }
+
     // Intentionally consider empty values for CRYPT_SHARED_LIB_PATH
     if ( ! getenv('CRYPT_SHARED_LIB_PATH')) {
         exit('skip crypt_shared is not available');


### PR DESCRIPTION
PHPC-2601

As shown in the new test, the crypt_shared version in phpinfo can be inaccurate if the first client created in a process was created without auto-encryption. To work around this, we also expose the crypt_shared version in each client's debug info for more reliable output.

Note: includes a change for PHPC-2156 to unskip a test that no longer breaks.