### PR TITLE
Minor follow-up work for libmongoc 2 support

### DIFF
--- a/.github/actions/linux/build-libmongoc/action.yml
+++ b/.github/actions/linux/build-libmongoc/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "Prefix to install libmongoc to"
     default: "/usr/local"
   version:
-    description: "Libmongoc version to build"
+    description: "Libmongoc version to build (major.minor)"
     required: true
 runs:
   using: composite

--- a/bin/prep-release.php
+++ b/bin/prep-release.php
@@ -65,7 +65,6 @@ function get_files() {
         "src/libmongocrypt-compat/mongocrypt/*.{c,h}",
         "src/libmongocrypt/src/*.{c,h,h.in}",
         "src/libmongocrypt/src/crypto/*.{c,h}",
-        "src/libmongocrypt/src/mlib/*.h",
         // Note: src/libmongocrypt/src/mlib/ does not contain source files (as of libmongocrypt 1.14.0)
         "src/libmongocrypt/src/mlib/*.h",
         "src/libmongocrypt/src/os_posix/*.{c,h}",


### PR DESCRIPTION
This PR fixes two minor issues related to libmongoc 2 support:
- clarified the version structrure in the build-libmongoc GitHub action
- removed a duplicate path in prep_release.php