### PR TITLE
Fix dependabot configuration to only update single submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "gitsubmodule"
-    directory: "/tests/drivers-evergreen-tools"
+    directory: "/"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-name: "tests/drivers-evergreen-tools"


### PR DESCRIPTION
The previous dependabot configuration used the path of the git submodule to limit updates to drivers-evergreen-tools, as we don't want to update libmongoc and libmongocrypt to latest commits. However, this does not work for submodules as dependabot looks for the `.gitmodules` file in the indicated directory. Instead, we can use `allow` to limit the dependencies to update (or alternatively, exclude some using `ignore`). The dependency name in the config file is the name of the submodule from `.gitmodules`.