### PR TITLE
PHPC-2613: Test x509 authentication on Atlas

### DIFF
--- a/tests/atlas.phpt
+++ b/tests/atlas.phpt
@@ -12,7 +12,7 @@ function extractUri(string $env): ?string
 	return getenv($env) ?: null;
 }
 
-function extractUriWithCertificate(string $env): ?string
+function extractUriWithCertificate(string $env): ?array
 {
 	$uri = getenv($env);
 	if (! is_string($uri)) {
@@ -24,10 +24,19 @@ function extractUriWithCertificate(string $env): ?string
 		return null;
 	}
 
-	$certPath = '/tmp/cert.pem';
-	file_put_contents($certPath, base64_decode($cert));
+	$certPath = tempnam(sys_get_temp_dir(), 'cert_');
+	$certContents = base64_decode($cert);
+	if (! $certPath || ! $certContents) {
+		return null;
+	}
 
-	return $uri . '&tlsCertificateKeyFile=' . $certPath;
+	file_put_contents($certPath, $certContents);
+	chmod($certPath, 0600);
+
+	return [
+		'uri' => $uri . '&tlsCertificateKeyFile=' . $certPath,
+		'certPath' => $certPath,
+	];
 }
 
 function testConnection(string $uri): void
@@ -81,14 +90,20 @@ foreach ($envs as $env) {
 
 foreach ($x509Envs as $env) {
 	echo $env, ': ';
-	$uri = extractUriWithCertificate($env);
+	$uriWithCertificate = extractUriWithCertificate($env);
 
-	if (! is_string($uri)) {
+	if (! is_array($uriWithCertificate)) {
 		echo "FAIL: env var is undefined\n";
 		continue;
 	}
 
-	testConnection($uri);
+	['uri' => $uri, 'certPath' => $certPath] = $uriWithCertificate;
+
+	try {
+		testConnection($uri);
+	} finally {
+		@unlink($certPath);
+	}
 }
 
 ?>

--- a/tests/atlas.phpt
+++ b/tests/atlas.phpt
@@ -26,7 +26,6 @@ function extractUriWithCertificate(string $env): ?array
 	}
 
 	file_put_contents($certPath, $certContents);
-	chmod($certPath, 0600);
 
 	return [
 		'uri' => $uri . '&tlsCertificateKeyFile=' . $certPath,

--- a/tests/atlas.phpt
+++ b/tests/atlas.phpt
@@ -7,6 +7,47 @@ Atlas Connectivity Tests
 <?php
 require_once __DIR__ . "/utils/basic.inc";
 
+function extractUri(string $env): ?string
+{
+	return getenv($env) ?: null;
+}
+
+function extractUriWithCertificate(string $env): ?string
+{
+	$uri = getenv($env);
+	if (! is_string($uri)) {
+		return null;
+	}
+
+	$cert = getenv($env . '_CERT_BASE64');
+	if (! is_string($cert)) {
+		return null;
+	}
+
+	$certPath = '/tmp/cert.pem';
+	file_put_contents($certPath, base64_decode($cert));
+
+	return $uri . '&tlsCertificateKeyFile=' . $certPath;
+}
+
+function testConnection(string $uri): void
+{
+	try {
+		$m = new \MongoDB\Driver\Manager($uri);
+		$m->executeCommand(
+			'admin',
+			new \MongoDB\Driver\Command(['ping' => 1]),
+		);
+		iterator_to_array($m->executeQuery(
+			'test.test',
+			new \MongoDB\Driver\Query([]),
+		));
+		echo "PASS\n";
+	} catch(Exception $e) {
+		echo "FAIL: ", $e->getMessage(), "\n";
+	}
+}
+
 $envs = [
 	'ATLAS_SERVERLESS',
 	'ATLAS_SRV_SERVERLESS',
@@ -22,57 +63,32 @@ $envs = [
 	'ATLAS_SRV_TLS12',
 ];
 $x509Envs = [
-    'ATLAS_X509',
-    'ATLAS_X509_DEV',
+	'ATLAS_X509',
+	'ATLAS_X509_DEV',
 ];
-
-$command = new \MongoDB\Driver\Command(['ping' => 1]);
-$query = new \MongoDB\Driver\Query([]);
 
 foreach ($envs as $env) {
 	echo $env, ': ';
-	$uri = getenv($env);
+	$uri = extractUri($env);
 
 	if (! is_string($uri)) {
 		echo "FAIL: env var is undefined\n";
 		continue;
 	}
 
-	try {
-		$m = new \MongoDB\Driver\Manager($uri);
-		$m->executeCommand('admin', $command);
-		iterator_to_array($m->executeQuery('test.test', $query));
-		echo "PASS\n";
-	} catch(Exception $e) {
-		echo "FAIL: ", $e->getMessage(), "\n";
-	}
+	testConnection($uri);
 }
 
 foreach ($x509Envs as $env) {
 	echo $env, ': ';
-	$uri = getenv($env);
-	$cert = getenv($env . '_CERT_BASE64');
+	$uri = extractUriWithCertificate($env);
 
 	if (! is_string($uri)) {
 		echo "FAIL: env var is undefined\n";
 		continue;
 	}
 
-	if (! is_string($cert)) {
-		echo "FAIL: cert env var is undefined\n";
-		continue;
-	}
-
-	file_put_contents('/tmp/cert.pem', base64_decode($cert));
-
-	try {
-		$m = new \MongoDB\Driver\Manager($uri . '&tlsCertificateKeyFile=/tmp/cert.pem');
-		$m->executeCommand('admin', $command);
-		iterator_to_array($m->executeQuery('test.test', $query));
-		echo "PASS\n";
-	} catch(Exception $e) {
-		echo "FAIL: ", $e->getMessage(), "\n";
-	}
+	testConnection($uri);
 }
 
 ?>

--- a/tests/atlas.phpt
+++ b/tests/atlas.phpt
@@ -21,6 +21,10 @@ $envs = [
 	'ATLAS_TLS12',
 	'ATLAS_SRV_TLS12',
 ];
+$x509Envs = [
+    'ATLAS_X509',
+    'ATLAS_X509_DEV',
+];
 
 $command = new \MongoDB\Driver\Command(['ping' => 1]);
 $query = new \MongoDB\Driver\Query([]);
@@ -43,6 +47,34 @@ foreach ($envs as $env) {
 		echo "FAIL: ", $e->getMessage(), "\n";
 	}
 }
+
+foreach ($x509Envs as $env) {
+	echo $env, ': ';
+	$uri = getenv($env);
+	$cert = getenv($env . '_CERT_BASE64');
+
+	if (! is_string($uri)) {
+		echo "FAIL: env var is undefined\n";
+		continue;
+	}
+
+	if (! is_string($cert)) {
+		echo "FAIL: cert env var is undefined\n";
+		continue;
+	}
+
+	file_put_contents('/tmp/cert.pem', base64_decode($cert));
+
+	try {
+		$m = new \MongoDB\Driver\Manager($uri . '&tlsCertificateKeyFile=/tmp/cert.pem');
+		$m->executeCommand('admin', $command);
+		iterator_to_array($m->executeQuery('test.test', $query));
+		echo "PASS\n";
+	} catch(Exception $e) {
+		echo "FAIL: ", $e->getMessage(), "\n";
+	}
+}
+
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -59,4 +91,6 @@ ATLAS_TLS11: PASS
 ATLAS_SRV_TLS11: PASS
 ATLAS_TLS12: PASS
 ATLAS_SRV_TLS12: PASS
+ATLAS_X509: PASS
+ATLAS_X509_DEV: PASS
 ===DONE===

--- a/tests/atlas.phpt
+++ b/tests/atlas.phpt
@@ -7,11 +7,6 @@ Atlas Connectivity Tests
 <?php
 require_once __DIR__ . "/utils/basic.inc";
 
-function extractUri(string $env): ?string
-{
-	return getenv($env) ?: null;
-}
-
 function extractUriWithCertificate(string $env): ?array
 {
 	$uri = getenv($env);
@@ -78,7 +73,7 @@ $x509Envs = [
 
 foreach ($envs as $env) {
 	echo $env, ': ';
-	$uri = extractUri($env);
+	$uri = getenv($env);
 
 	if (! is_string($uri)) {
 		echo "FAIL: env var is undefined\n";


### PR DESCRIPTION
PHPC-2613

This adds two new Atlas environments to the connectivity tests. These test X509 authentication and rely on extracting a certificate string to a file and modifying the connection string accordingly.