### PR TITLE
PHPC-2617: Support PHP 8.5

### DIFF
--- a/.github/actions/windows/prepare-build/action.yml
+++ b/.github/actions/windows/prepare-build/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Setup PHP SDK
       id: setup-php
-      uses: php/setup-php-sdk@v0.10
+      uses: php/setup-php-sdk@v0.11
       with:
         version: ${{ inputs.version }}
         arch: ${{ inputs.arch }}

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -98,6 +98,6 @@ jobs:
       fail-fast: false
       matrix:
         # Note: keep this in sync with the Windows matrix in tests.yml
-        php: [ "8.1", "8.2", "8.3", "8.4" ]
+        php: [ "8.1", "8.2", "8.3", "8.4", "8.5" ]
         arch: [ x64, x86 ]
         ts: [ ts, nts ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         mongodb-version:
           - "6.0"
         topology:
@@ -125,6 +126,6 @@ jobs:
       fail-fast: false
       matrix:
         # Note: keep this in sync with the Windows matrix in package-release.yml
-        php: [ "8.1", "8.2", "8.3", "8.4" ]
+        php: [ "8.1", "8.2", "8.3", "8.4", "8.5" ]
         arch: [ x64, x86 ]
         ts: [ ts, nts ]

--- a/src/contrib/php_array_api.h
+++ b/src/contrib/php_array_api.h
@@ -350,7 +350,7 @@ char *php_array_zval_to_string(zval *z, int *plen, zend_bool *pfree) {
 			zval c = *z;
 			zval_copy_ctor(&c);
 			convert_to_string(&c);
-			*pfree = ! IS_INTERNED(Z_STR(c));
+			*pfree = ! ZSTR_IS_INTERNED(Z_STR(c));
 			*plen = Z_STRLEN(c);
 			return Z_STRVAL(c);
 		}

--- a/tests/bson/bson-decimal128-002.phpt
+++ b/tests/bson/bson-decimal128-002.phpt
@@ -4,8 +4,6 @@ MongoDB\BSON\Decimal128 NaN values
 <?php
 
 $tests = [
-    acos(8),
-    NAN,
     'nan',
     'Nan',
     'NaN',
@@ -20,8 +18,6 @@ foreach ($tests as $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
-NaN
-NaN
 NaN
 NaN
 NaN

--- a/tests/bson/bson-decimal128-004.phpt
+++ b/tests/bson/bson-decimal128-004.phpt
@@ -4,9 +4,9 @@ MongoDB\BSON\Decimal128 debug handler
 <?php
 
 $tests = [
-    1234.5678,
-    NAN,
-    INF,
+    '1234.5678',
+    'NAN',
+    'INF',
 ];
 
 foreach ($tests as $test) {

--- a/tests/bson/bson-decimal128-serialization-002.phpt
+++ b/tests/bson/bson-decimal128-serialization-002.phpt
@@ -6,9 +6,9 @@ MongoDB\BSON\Decimal128 serialization (__serialize and __unserialize)
 $tests = [
     '1234.5678',
     '-1234.5678',
-    1234.56e-78,
-    INF,
-    NAN,
+    '1234.56e-78',
+    'INF',
+    'NAN',
 ];
 
 foreach ($tests as $value) {

--- a/tests/exception/bulkwriteexception-haserrorlabel-001.phpt
+++ b/tests/exception/bulkwriteexception-haserrorlabel-001.phpt
@@ -9,7 +9,6 @@ $labels = ['test', 'foo'];
 $reflection = new ReflectionClass($exception);
 
 $resultDocumentProperty = $reflection->getProperty('errorLabels');
-$resultDocumentProperty->setAccessible(true);
 $resultDocumentProperty->setValue($exception, $labels);
 
 var_dump($exception->hasErrorLabel('foo'));

--- a/tests/exception/bulkwriteexception-haserrorlabel_error-001.phpt
+++ b/tests/exception/bulkwriteexception-haserrorlabel_error-001.phpt
@@ -9,7 +9,6 @@ $labels = 'shouldBeAnArray';
 $reflection = new ReflectionClass($exception);
 
 $resultDocumentProperty = $reflection->getProperty('errorLabels');
-$resultDocumentProperty->setAccessible(true);
 $resultDocumentProperty->setValue($exception, $labels);
 
 var_dump($exception->hasErrorLabel('bar'));

--- a/tests/exception/commandexception-getresultdocument-001.phpt
+++ b/tests/exception/commandexception-getresultdocument-001.phpt
@@ -9,7 +9,6 @@ $resultDocument = (object) ['x' => 1];
 $reflection = new ReflectionClass($exception);
 
 $resultDocumentProperty = $reflection->getProperty('resultDocument');
-$resultDocumentProperty->setAccessible(true);
 $resultDocumentProperty->setValue($exception, $resultDocument);
 
 var_dump($resultDocument === $exception->getResultDocument());

--- a/tests/exception/commandexception-haserrorlabel-001.phpt
+++ b/tests/exception/commandexception-haserrorlabel-001.phpt
@@ -9,7 +9,6 @@ $labels = ['test', 'foo'];
 $reflection = new ReflectionClass($exception);
 
 $resultDocumentProperty = $reflection->getProperty('errorLabels');
-$resultDocumentProperty->setAccessible(true);
 $resultDocumentProperty->setValue($exception, $labels);
 
 var_dump($exception->hasErrorLabel('foo'));

--- a/tests/exception/commandexception-haserrorlabel_error-001.phpt
+++ b/tests/exception/commandexception-haserrorlabel_error-001.phpt
@@ -9,7 +9,6 @@ $labels = 'shouldBeAnArray';
 $reflection = new ReflectionClass($exception);
 
 $resultDocumentProperty = $reflection->getProperty('errorLabels');
-$resultDocumentProperty->setAccessible(true);
 $resultDocumentProperty->setValue($exception, $labels);
 
 var_dump($exception->hasErrorLabel('bar'));

--- a/tests/exception/runtimeexception-haserrorlabel-001.phpt
+++ b/tests/exception/runtimeexception-haserrorlabel-001.phpt
@@ -9,7 +9,6 @@ $labels = ['test', 'foo'];
 $reflection = new ReflectionClass($exception);
 
 $resultDocumentProperty = $reflection->getProperty('errorLabels');
-$resultDocumentProperty->setAccessible(true);
 $resultDocumentProperty->setValue($exception, $labels);
 
 var_dump($exception->hasErrorLabel('foo'));

--- a/tests/exception/runtimeexception-haserrorlabel_error-001.phpt
+++ b/tests/exception/runtimeexception-haserrorlabel_error-001.phpt
@@ -9,7 +9,6 @@ $labels = 'shouldBeAnArray';
 $reflection = new ReflectionClass($exception);
 
 $resultDocumentProperty = $reflection->getProperty('errorLabels');
-$resultDocumentProperty->setAccessible(true);
 $resultDocumentProperty->setValue($exception, $labels);
 
 var_dump($exception->hasErrorLabel('bar'));

--- a/tests/server/server-construct-001.phpt
+++ b/tests/server/server-construct-001.phpt
@@ -20,7 +20,7 @@ $bulk->insert(array('foo' => 'bar'));
 $server = $manager->executeBulkWrite(NS, $bulk)->getServer();
 
 $expectedHost = $parsed['host'];
-$expectedPort = (integer) (isset($parsed['port']) ? $parsed['port'] : 27017);
+$expectedPort = (int) (isset($parsed['port']) ? $parsed['port'] : 27017);
 
 var_dump($server->getHost() == $expectedHost);
 var_dump($server->getPort() == $expectedPort);


### PR DESCRIPTION
PHPC-2617

Adds testing and support for PHP 8.5, backporting the fix for `IS_INTERNED` from #1849.