### PR TITLE
Fix wrong PHP version constraint for pie

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     { "name": "Jérôme Tamarelle", "email": "jerome.tamarelle@mongodb.com" }
   ],
   "require": {
-    "php": ">=7.4,<9",
+    "php": ">=8.1,<9",
     "ext-date": "*",
     "ext-json": "*"
   },


### PR DESCRIPTION
When we bumped the minimum PHP version to 8.1 in #1631, we forgot to update the constraint in composer.json. This can lead to pie picking the wrong version of the extension, followed by a failure to build it. This PR fixes the wrong constraint so future versions don't have the same problem.