### PR TITLE
PHPC-2627: Use appropriate return type for zend_object_iterator_funcs.valid

### DIFF
--- a/src/BSON/Iterator.c
+++ b/src/BSON/Iterator.c
@@ -303,7 +303,7 @@ static void php_phongo_iterator_it_dtor(zend_object_iterator* iter)
 	zval_ptr_dtor(&iter->data);
 }
 
-static int php_phongo_iterator_it_valid(zend_object_iterator* iter)
+static PHONGO_ITERATOR_VALID_RESULT php_phongo_iterator_it_valid(zend_object_iterator* iter)
 {
 	php_phongo_iterator_t* intern = Z_ITERATOR_OBJ_P(&iter->data);
 

--- a/src/phongo_compat.h
+++ b/src/phongo_compat.h
@@ -218,4 +218,11 @@ const char* zend_get_object_type_case(const zend_class_entry* ce, zend_bool uppe
 #define zend_get_object_type_uc(ce) zend_get_object_type_case((ce), true)
 #endif /* PHP_VERSION_ID < 80200 */
 
+/* zend_object_iterator_funcs.valid return type changed to zend_result in PHP 8.4 */
+#if PHP_VERSION_ID < 80400
+#define PHONGO_ITERATOR_VALID_RESULT int
+#else
+#define PHONGO_ITERATOR_VALID_RESULT zend_result
+#endif
+
 #endif /* PHONGO_COMPAT_H */


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2627

See: https://github.com/php/php-src/blob/571bded46ece6922f0bef0d135986786e9b49029/UPGRADING.INTERNALS#L29-L31