### PR TITLE
[PHPC-2647] Out-of-source build: Don't necessarily generate flies in the source tree

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -370,6 +370,10 @@ if test "$PHP_MONGODB" != "no"; then
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libbson/src/jsonsl/], $PHP_MONGODB_JSONSL_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libmongoc/src/mongoc/], $PHP_MONGODB_MONGOC_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
 
+    # Add the build directories as include paths to some generated files
+    PHP_ADD_INCLUDE([$PWD/src/libmongoc/src/libbson/src])
+    PHP_ADD_INCLUDE([$PWD/src/libmongoc/src/libmongoc/src])
+
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/common/src/])
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/uthash/])
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/libbson/src/])
@@ -394,12 +398,12 @@ if test "$PHP_MONGODB" != "no"; then
     ac_config_dir=PHP_EXT_SRCDIR(mongodb)
 
     AC_CONFIG_FILES([
-      ${ac_config_dir}/src/libmongoc/src/common/src/common-config.h
-      ${ac_config_dir}/src/libmongoc/src/libbson/src/bson/config.h
-      ${ac_config_dir}/src/libmongoc/src/libbson/src/bson/version.h
-      ${ac_config_dir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config.h
-      ${ac_config_dir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config-private.h
-      ${ac_config_dir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-version.h
+      src/libmongoc/src/common/src/common-config.h
+      src/libmongoc/src/libbson/src/bson/config.h
+      src/libmongoc/src/libbson/src/bson/version.h
+      src/libmongoc/src/libmongoc/src/mongoc/mongoc-config.h
+      src/libmongoc/src/libmongoc/src/mongoc/mongoc-config-private.h
+      src/libmongoc/src/libmongoc/src/mongoc/mongoc-version.h
     ])
 
     if test "x$bundled_utf8proc" = "xyes"; then

--- a/config.m4
+++ b/config.m4
@@ -370,7 +370,8 @@ if test "$PHP_MONGODB" != "no"; then
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libbson/src/jsonsl/], $PHP_MONGODB_JSONSL_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libmongoc/src/mongoc/], $PHP_MONGODB_MONGOC_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
 
-    # Add the build directories as include paths to some generated files
+    dnl Add the build directories as include paths to some generated files
+    PHP_ADD_INCLUDE([$PWD/src/libmongoc/src/common/src])
     PHP_ADD_INCLUDE([$PWD/src/libmongoc/src/libbson/src])
     PHP_ADD_INCLUDE([$PWD/src/libmongoc/src/libmongoc/src])
 


### PR DESCRIPTION
This changeset modifies an AC_CONFIG_FILES directive to configure some of mongoc's files using relative paths. IIUC, using relative paths (instead of absolute ones) will make it read the file relative to the `configure` script, but write the file with the same name relative to the `$PWD` of the `configure` execution. This allows the `configure` script to leave the source tree more pristine.

To support this, the directories that are (possibly) generated by AC_CONFIG_FILES needs to be added as `#include` search paths. (The search directories are added based on `$PWD`, which feels somewhat brittle (is there a better autotools/autoconf variable to be used here? I couldn't seem to make it work otherwise.).)

(I'm not sure if there is an existing relevant Jira ticket for out-of-source build support tasks, so I created PHPC-2647 for this.)