### PR TITLE
PHPC-2664: Drop Windows x86 builds

### DIFF
--- a/.github/actions/windows/build/action.yml
+++ b/.github/actions/windows/build/action.yml
@@ -7,9 +7,6 @@ inputs:
   php-version:
     description: "PHP version to build for"
     required: true
-  arch:
-    description: "The architecture to build for (x64 or x86)"
-    required: true
   ts:
     description: "Thread-safety (nts or ts)"
     required: true
@@ -25,7 +22,7 @@ runs:
       with:
         extension-ref: ${{ inputs.ref }}
         php-version: ${{ inputs.php-version }}
-        arch: ${{ inputs.arch }}
+        arch: x64
         ts: ${{ inputs.ts }}
         run-tests: ${{ inputs.run-tests == 'true' && true || false }}
         test-runner-args: "--show-diff"

--- a/.github/workflows/build-windows-packages.yml
+++ b/.github/workflows/build-windows-packages.yml
@@ -36,7 +36,6 @@ jobs:
           - "8.3"
           - "8.4"
           - "8.5"
-        arch: [ x64, x86 ]
         ts: [ ts, nts ]
 
     steps:
@@ -51,7 +50,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           php-version: ${{ matrix.php-version }}
-          arch: ${{ matrix.arch }}
           ts: ${{ matrix.ts }}
           run-tests: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,6 @@ jobs:
           - "8.3"
           - "8.4"
           - "8.5"
-        arch: [ x64, x86 ]
         ts: [ ts, nts ]
 
     steps:
@@ -161,7 +160,6 @@ jobs:
         uses: ./.github/actions/windows/build
         with:
           php-version: ${{ matrix.php-version }}
-          arch: ${{ matrix.arch }}
           ts: ${{ matrix.ts }}
           run-tests: true
         env:


### PR DESCRIPTION
PHPC-2664

Before php-windows-builder, we could use the x64 toolset for x86 builds, working around the heap space error we're receiving. With php-windows-builder, this no longer works. Since x86 is pretty much dead at this point, we will stop providing prebuilt x86 binaries for Windows.