### PR TITLE
Fix broken release workflow

### DIFF
--- a/.github/actions/windows/build/action.yml
+++ b/.github/actions/windows/build/action.yml
@@ -1,9 +1,6 @@
 name: "Build DLL files for Windows"
 description: "Prepares the PHP build environment for the MongoDB driver"
 inputs:
-  ref:
-    description: Git reference to build
-    required: false
   php-version:
     description: "PHP version to build for"
     required: true
@@ -23,7 +20,6 @@ runs:
     - name: Build extension
       uses: php/php-windows-builder/extension@1.6.0
       with:
-        extension-ref: ${{ inputs.ref }}
         php-version: ${{ inputs.php-version }}
         arch: ${{ inputs.arch }}
         ts: ${{ inputs.ts }}

--- a/.github/workflows/build-windows-packages.yml
+++ b/.github/workflows/build-windows-packages.yml
@@ -48,7 +48,6 @@ jobs:
         id: build-driver
         uses: ./.github/actions/windows/build
         with:
-          ref: ${{ inputs.ref }}
           php-version: ${{ matrix.php-version }}
           arch: ${{ matrix.arch }}
           ts: ${{ matrix.ts }}

--- a/.github/workflows/create-release-artifacts.yml
+++ b/.github/workflows/create-release-artifacts.yml
@@ -1,4 +1,5 @@
-name: create-release-artifacts.yml
+name: Create Release Artifacts
+run-name: Create Release artifacts for ${{ github.ref_name }}
 on:
   push:
     tags:


### PR DESCRIPTION
While the previous PR https://github.com/mongodb/mongo-php-driver/pull/1916 solved one issue, the build of Windows extensions still fails. While we're no longer getting the wrong source checked out, we did not pass the expected `extension-ref` to `php-windows-builder`. However, since the GitHub environment variables are now accurate, we can rely on `php-windows-builder` to autodetect the correct ref from those variables and correctly use the tag name as ref for release builds.

This PR also fixes the workflow name to something a little more descriptive.