### PR TITLE
Fix artifact signing

### DIFF
--- a/.github/workflows/build-windows-packages.yml
+++ b/.github/workflows/build-windows-packages.yml
@@ -86,7 +86,7 @@ jobs:
       - name: "Create detached signatures for packages"
         uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
         with:
-          filenames: php_mongodb*.zip
+          filenames: artifacts/php_mongodb*.zip
 
       - name: "Move signatures from release assets folder"
         run: |


### PR DESCRIPTION
This PR fixes a wrong path when signing artifacts. I was able to finish the previous test release using a temporary workflow and confirmed that it now works as expected.