### PR TITLE
Add Jérôme and Pauline as maintainers

### DIFF
--- a/bin/package.xml.in
+++ b/bin/package.xml.in
@@ -15,6 +15,18 @@ necessary to build a fully-functional MongoDB driver.
   <active>yes</active>
  </lead>
  <lead>
+  <name>Jérôme Tamarelle</name>
+  <user>gromnan</user>
+  <email>jerome.tamarelle@mongodb.com</email>
+  <active>yes</active>
+ </lead>
+ <lead>
+  <name>Pauline Vos</name>
+  <user>synon</user>
+  <email>info@pauline-vos.nl</email>
+  <active>yes</active>
+ </lead>
+ <lead>
   <name>Jeremy Mikola</name>
   <user>jmikola</user>
   <email>jmikola@php.net</email>


### PR DESCRIPTION
PHPC-2690

@paulinevos @GromNaN I used your MongoDB email addresses, despite them likely not being the same you used for your PECL accounts. IIRC PECL links maintainers by usernames, so the email address shouldn't matter. However, let me know if you'd prefer a different email address to be listed.