### PR TITLE
PHPC-1971: Use debug builds of PHP for testing

### DIFF
--- a/.github/actions/linux/build/action.yml
+++ b/.github/actions/linux/build/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: "Install PHP"
       uses: "shivammathur/setup-php@v2"
       with:
-        php-version: "${{ inputs.version }}"
+        php-version: "${{ inputs.version }}-debug"
         # Only install required extensions
         extensions: "none,date,json,spl,standard,xml"
 

--- a/.github/workflows/arginfo-files.yml
+++ b/.github/workflows/arginfo-files.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "${{ env.PHP_VERSION }}"
+          php-version: "${{ env.PHP_VERSION }}-debug"
 
       - name: "Run phpize"
         run: phpize

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "${{ env.PHP_VERSION }}"
+          php-version: "${{ env.PHP_VERSION }}-debug"
 
       - name: "Configure driver"
         run: .github/workflows/configure.sh


### PR DESCRIPTION
PHPC-1971

Using debug builds ensures we catch errors due to wrong return types, as PHP only validates return types for built-in methods in debug builds, but not other builds.