### PR TITLE
Avoid string length calculations for bson_append calls

### DIFF
--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -251,7 +251,7 @@ static bool phongo_bulkwrite_opt_hint(bson_t* boptions, zval* zoptions)
 		if (type == IS_STRING) {
 			zval* value = php_array_fetchc_deref(zoptions, "hint");
 
-			if (!bson_append_utf8(boptions, "hint", 4, Z_STRVAL_P(value), Z_STRLEN_P(value))) {
+			if (!bson_append_utf8(boptions, ZEND_STRL("hint"), Z_STRVAL_P(value), Z_STRLEN_P(value))) {
 				phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Error appending \"hint\" option");
 				return false;
 			}

--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -939,7 +939,7 @@ bool phongo_bson_value_to_zval_legacy(const bson_value_t* value, zval* zv)
 		PHONGO_BSON_INIT_STATE(state);
 		state.map.root.type = PHONGO_TYPEMAP_NATIVE_ARRAY;
 
-		bson_append_value(&bson, "data", 4, value);
+		bson_append_value(&bson, ZEND_STRL("data"), value);
 		if (!phongo_bson_to_zval_ex(&bson, &state)) {
 			/* Exception already thrown */
 			goto cleanup;

--- a/src/phongo_bson_encode.c
+++ b/src/phongo_bson_encode.c
@@ -527,7 +527,7 @@ done:
 		bson_oid_t oid;
 
 		bson_oid_init(&oid, NULL);
-		bson_append_oid(bson, "_id", strlen("_id"), &oid);
+		bson_append_oid(bson, ZEND_STRL("_id"), &oid);
 	}
 
 	if (flags & PHONGO_BSON_RETURN_ID && bson_out) {

--- a/src/phongo_client.c
+++ b/src/phongo_client.c
@@ -294,7 +294,7 @@ static bool phongo_apply_options_to_uri(mongoc_uri_t* uri, bson_t* options)
 				return false;
 			}
 
-			bson_append_utf8(&properties, "SERVICE_NAME", -1, bson_iter_utf8(&iter, NULL), -1);
+			bson_append_utf8(&properties, ZEND_STRL("SERVICE_NAME"), bson_iter_utf8(&iter, NULL), -1);
 
 			if (!mongoc_uri_set_mechanism_properties(uri, &properties)) {
 				phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Failed to parse \"%s\" URI option", key);

--- a/src/phongo_execute.c
+++ b/src/phongo_execute.c
@@ -581,20 +581,20 @@ bool phongo_execute_command(zval* manager, phongo_command_type_t type, const cha
 
 		bson_copy_to(&reply, &initial_reply);
 
-		bson_append_int32(&cursor_opts, "serverId", -1, server_id);
+		bson_append_int32(&cursor_opts, ZEND_STRL("serverId"), server_id);
 
 		if (command->max_await_time_ms) {
-			bson_append_bool(&cursor_opts, "awaitData", -1, 1);
-			bson_append_int64(&cursor_opts, "maxAwaitTimeMS", -1, command->max_await_time_ms);
-			bson_append_bool(&cursor_opts, "tailable", -1, 1);
+			bson_append_bool(&cursor_opts, ZEND_STRL("awaitData"), 1);
+			bson_append_int64(&cursor_opts, ZEND_STRL("maxAwaitTimeMS"), command->max_await_time_ms);
+			bson_append_bool(&cursor_opts, ZEND_STRL("tailable"), 1);
 		}
 
 		if (command->batch_size) {
-			bson_append_int64(&cursor_opts, "batchSize", -1, command->batch_size);
+			bson_append_int64(&cursor_opts, ZEND_STRL("batchSize"), command->batch_size);
 		}
 
 		if (bson_iter_init(&iter, command->bson) && bson_iter_find(&iter, "comment")) {
-			bson_append_value(&cursor_opts, "comment", -1, bson_iter_value(&iter));
+			bson_append_value(&cursor_opts, ZEND_STRL("comment"), bson_iter_value(&iter));
 		}
 
 		if (zsession && !mongoc_client_session_append(Z_SESSION_OBJ_P(zsession)->client_session, &cursor_opts, &error)) {
@@ -611,7 +611,7 @@ bool phongo_execute_command(zval* manager, phongo_command_type_t type, const cha
 		bson_t  cursor_opts   = BSON_INITIALIZER;
 		bson_t* wrapped_reply = create_wrapped_command_envelope(db, &reply);
 
-		bson_append_int32(&cursor_opts, "serverId", -1, server_id);
+		bson_append_int32(&cursor_opts, ZEND_STRL("serverId"), server_id);
 		cmd_cursor = mongoc_cursor_new_from_command_reply_with_opts(client, wrapped_reply, &cursor_opts);
 		bson_destroy(&cursor_opts);
 	}


### PR DESCRIPTION
Fixes PHPC-2095 
We don't need to calculate string length at runtime in case we're dealing with string literals