### PR TITLE
PHPC-1622: Use get_properties_for handler (prototype: ObjectId only)

### DIFF
--- a/src/BSON/ObjectId.c
+++ b/src/BSON/ObjectId.c
@@ -252,9 +252,8 @@ static int phongo_objectid_compare_objects(zval* o1, zval* o2)
 	return strcmp(intern1->oid, intern2->oid);
 }
 
-static HashTable* phongo_objectid_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_objectid_get_properties_for(zend_object* object, ARG_UNUSED zend_prop_purpose purpose)
 {
-	*is_temp = 1;
 	return phongo_objectid_get_properties_hash(object, true);
 }
 
@@ -269,12 +268,12 @@ void phongo_objectid_init_ce(INIT_FUNC_ARGS)
 	phongo_objectid_ce->create_object = phongo_objectid_create_object;
 
 	memcpy(&phongo_handler_objectid, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_objectid.compare        = phongo_objectid_compare_objects;
-	phongo_handler_objectid.clone_obj      = phongo_objectid_clone_object;
-	phongo_handler_objectid.get_debug_info = phongo_objectid_get_debug_info;
-	phongo_handler_objectid.get_properties = phongo_objectid_get_properties;
-	phongo_handler_objectid.free_obj       = phongo_objectid_free_object;
-	phongo_handler_objectid.offset         = XtOffsetOf(phongo_objectid_t, std);
+	phongo_handler_objectid.compare            = phongo_objectid_compare_objects;
+	phongo_handler_objectid.clone_obj          = phongo_objectid_clone_object;
+	phongo_handler_objectid.get_properties_for = phongo_objectid_get_properties_for;
+	phongo_handler_objectid.get_properties     = phongo_objectid_get_properties;
+	phongo_handler_objectid.free_obj           = phongo_objectid_free_object;
+	phongo_handler_objectid.offset             = XtOffsetOf(phongo_objectid_t, std);
 }
 
 bool phongo_objectid_new(zval* return_value, const bson_oid_t* oid)

--- a/tests/bson/bson-objectid-array_cast-001.phpt
+++ b/tests/bson/bson-objectid-array_cast-001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+MongoDB\BSON\ObjectId array cast (ZEND_PROP_PURPOSE_ARRAY_CAST)
+--FILE--
+<?php
+
+$oid = new MongoDB\BSON\ObjectId('53e2a1c40640fd72175d4603');
+
+var_dump((array) $oid);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+array(1) {
+  ["oid"]=>
+  string(24) "53e2a1c40640fd72175d4603"
+}
+===DONE===

--- a/tests/bson/bson-objectid-var_export-001.phpt
+++ b/tests/bson/bson-objectid-var_export-001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+MongoDB\BSON\ObjectId var_export() (ZEND_PROP_PURPOSE_VAR_EXPORT)
+--FILE--
+<?php
+
+$oid = new MongoDB\BSON\ObjectId('53e2a1c40640fd72175d4603');
+
+var_export($oid);
+echo "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+%r\\?%rMongoDB\BSON\ObjectId::__set_state(array(
+   'oid' => '53e2a1c40640fd72175d4603',
+))
+===DONE===


### PR DESCRIPTION
Fix PHPC-1622

## Summary

This is a **prototype** applying the `get_properties_for` object handler to `MongoDB\BSON\ObjectId` only, as a proof-of-concept before rolling the pattern out to all classes.

### Background

PHP 8.0 introduced a new optional object handler:

```c
HashTable *get_properties_for(zend_object *obj, zend_prop_purpose purpose)
```

with purposes `ZEND_PROP_PURPOSE_DEBUG`, `ARRAY_CAST`, `SERIALIZE`, `VAR_EXPORT`, `JSON`, and (since PHP 8.4) `GET_OBJECT_VARS`. It supersedes `get_debug_info` and allows explicit per-purpose control, avoiding the issue in PHPC-1598 where relying on `get_properties` for debugging caused GC problems.

### Changes

- **Remove `get_debug_info`** — superseded by `get_properties_for`.
- **Add `get_properties_for`** — always returns a fresh temporary `HashTable` regardless of purpose:
  ```c
  static HashTable* phongo_objectid_get_properties_for(zend_object* object, ARG_UNUSED zend_prop_purpose purpose)
  {
      return phongo_objectid_get_properties_hash(object, true);
  }
  ```
- **Retain `get_properties`** — `foreach` on non-`Traversable` objects calls it directly on all PHP versions, bypassing `get_properties_for`.

### Key findings

- **`SERIALIZE` and `JSON` purposes are never reached**: `__serialize`/`__unserialize` takes precedence over `ZEND_PROP_PURPOSE_SERIALIZE`, and `JsonSerializable::jsonSerialize()` takes precedence over `ZEND_PROP_PURPOSE_JSON`. Since `ObjectId` implements both, `get_properties_for` is never invoked for those purposes — making the `purpose` parameter irrelevant. The handler unconditionally returns the hash with no switch statement and no version guards needed.
- **Returning `NULL` from a custom `get_properties_for` does not fall back to `get_properties`** — it means "no properties for this purpose". The fallback only happens inside `zend_std_get_properties_for`, which is only invoked when no custom handler is set at all.
- **`foreach` on non-`Traversable` objects** calls `get_properties` directly and is unaffected by `get_properties_for` on all PHP versions tested.
- **`ZEND_PROP_PURPOSE_GET_OBJECT_VARS`** is a distinct purpose from `ARRAY_CAST`, added in PHP 8.4 (Property Hooks RFC). However, since it's handled identically to all other purposes here, no version guard is needed.

### New tests

| Test file | Purpose covered |
|---|---|
| `bson-objectid-array_cast-001.phpt` | `ZEND_PROP_PURPOSE_ARRAY_CAST` — `(array) $obj` |
| `bson-objectid-var_export-001.phpt` | `ZEND_PROP_PURPOSE_VAR_EXPORT` — `var_export()` |

Existing tests already cover `DEBUG` (var_dump), `GET_OBJECT_VARS` (get_object_vars), `get_properties` (foreach), `SERIALIZE` (__serialize/__unserialize), and `JSON` (json_encode).