### PR TITLE
Use DBX PR app to create merge-up pull requests

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -5,22 +5,24 @@ on:
     branches:
       - "v[0-9]+.[0-9x]+"
 
-env:
-  GH_TOKEN: ${{ secrets.MERGE_UP_TOKEN }}
-
 jobs:
   merge-up:
     name: Create merge up pull request
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v6
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
         with:
-          # fetch-depth 0 is required to fetch all branches, not just the branch being built
+          app_id: ${{ vars.PR_APP_ID }}
+          private_key: ${{ secrets.PR_APP_PRIVATE_KEY }}
+          submodules: true
           fetch-depth: 0
-          token: ${{ secrets.MERGE_UP_TOKEN }}
 
       - name: Create pull request
         id: create-pull-request


### PR DESCRIPTION
This change modifies the merge-up workflow to no longer rely on a token, but rather uses the DBX PR app to create pull requests. This change should work out of the box -- the app has been added to the repositories a while back and I've now added the necessary actions variables and secrets.