### PR TITLE
[PoC] PHPC-2379: Add properties to ReadPreference class

### DIFF
--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -31,6 +31,71 @@
 
 zend_class_entry* phongo_readpreference_ce;
 
+static const char* phongo_readpreference_get_mode_string(const mongoc_read_prefs_t* read_prefs)
+{
+	switch (mongoc_read_prefs_get_mode(read_prefs)) {
+		case MONGOC_READ_PRIMARY:
+			return PHONGO_READ_PRIMARY;
+		case MONGOC_READ_PRIMARY_PREFERRED:
+			return PHONGO_READ_PRIMARY_PREFERRED;
+		case MONGOC_READ_SECONDARY:
+			return PHONGO_READ_SECONDARY;
+		case MONGOC_READ_SECONDARY_PREFERRED:
+			return PHONGO_READ_SECONDARY_PREFERRED;
+		case MONGOC_READ_NEAREST:
+			return PHONGO_READ_NEAREST;
+		default:
+			return "";
+	}
+}
+
+static void phongo_readpreference_update_properties(phongo_readpreference_t* intern)
+{
+	const bson_t* bson;
+
+	zend_update_property_string(phongo_readpreference_ce, &intern->std, ZEND_STRL("mode"), phongo_readpreference_get_mode_string(intern->read_preference));
+	zend_update_property_long(phongo_readpreference_ce, &intern->std, ZEND_STRL("maxStalenessSeconds"), mongoc_read_prefs_get_max_staleness_seconds(intern->read_preference));
+
+	bson = mongoc_read_prefs_get_tags(intern->read_preference);
+
+	if (!bson_empty0(bson)) {
+		phongo_bson_state state;
+
+		PHONGO_BSON_INIT_STATE(state);
+		state.map.root.type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+
+		if (!phongo_bson_to_zval_ex(bson, &state)) {
+			// Exception already thrown
+			zval_ptr_dtor(&state.zchild);
+			return;
+		}
+
+		zend_update_property(phongo_readpreference_ce, &intern->std, ZEND_STRL("tags"), &state.zchild);
+		zval_ptr_dtor(&state.zchild);
+	} else {
+		zend_update_property_null(phongo_readpreference_ce, &intern->std, ZEND_STRL("tags"));
+	}
+
+	bson = mongoc_read_prefs_get_hedge(intern->read_preference);
+
+	if (!bson_empty0(bson)) {
+		phongo_bson_state state;
+
+		PHONGO_BSON_INIT_STATE(state);
+
+		if (!phongo_bson_to_zval_ex(bson, &state)) {
+			// Exception already thrown
+			zval_ptr_dtor(&state.zchild);
+			return;
+		}
+
+		zend_update_property(phongo_readpreference_ce, &intern->std, ZEND_STRL("hedge"), &state.zchild);
+		zval_ptr_dtor(&state.zchild);
+	} else {
+		zend_update_property_null(phongo_readpreference_ce, &intern->std, ZEND_STRL("hedge"));
+	}
+}
+
 /* Initialize the object from a HashTable and return whether it was successful.
  * An exception will be thrown on error. */
 static bool phongo_readpreference_init_from_hash(phongo_readpreference_t* intern, HashTable* props)
@@ -83,7 +148,7 @@ static bool phongo_readpreference_init_from_hash(phongo_readpreference_t* intern
 
 			mongoc_read_prefs_set_tags(intern->read_preference, tags);
 			bson_destroy(tags);
-		} else {
+		} else if (Z_TYPE_P(tagSets) != IS_NULL) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s initialization requires \"tags\" field to be array", ZSTR_VAL(phongo_readpreference_ce->name));
 			goto failure;
 		}
@@ -134,7 +199,7 @@ static bool phongo_readpreference_init_from_hash(phongo_readpreference_t* intern
 
 			mongoc_read_prefs_set_hedge(intern->read_preference, hedge_doc);
 			bson_destroy(hedge_doc);
-		} else {
+		} else if (Z_TYPE_P(hedge) != IS_NULL) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s initialization requires \"hedge\" field to be an array or object", ZSTR_VAL(phongo_readpreference_ce->name));
 			goto failure;
 		}
@@ -145,30 +210,14 @@ static bool phongo_readpreference_init_from_hash(phongo_readpreference_t* intern
 		goto failure;
 	}
 
+	phongo_readpreference_update_properties(intern);
+
 	return true;
 
 failure:
 	mongoc_read_prefs_destroy(intern->read_preference);
 	intern->read_preference = NULL;
 	return false;
-}
-
-static const char* phongo_readpreference_get_mode_string(const mongoc_read_prefs_t* read_prefs)
-{
-	switch (mongoc_read_prefs_get_mode(read_prefs)) {
-		case MONGOC_READ_PRIMARY:
-			return PHONGO_READ_PRIMARY;
-		case MONGOC_READ_PRIMARY_PREFERRED:
-			return PHONGO_READ_PRIMARY_PREFERRED;
-		case MONGOC_READ_SECONDARY:
-			return PHONGO_READ_SECONDARY;
-		case MONGOC_READ_SECONDARY_PREFERRED:
-			return PHONGO_READ_SECONDARY_PREFERRED;
-		case MONGOC_READ_NEAREST:
-			return PHONGO_READ_NEAREST;
-		default:
-			return "";
-	}
 }
 
 /* Constructs a new ReadPreference */
@@ -281,6 +330,8 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, __construct)
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Read preference is not valid");
 		return;
 	}
+
+	phongo_readpreference_update_properties(intern);
 }
 
 static PHP_METHOD(MongoDB_Driver_ReadPreference, __set_state)
@@ -384,87 +435,32 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, getTagSets)
 	}
 }
 
-static HashTable* phongo_readpreference_get_properties_hash(zend_object* object, bool is_temp)
-{
-	phongo_readpreference_t* intern;
-	HashTable*               props;
-	const bson_t*            tags;
-	const bson_t*            hedge;
-
-	intern = Z_OBJ_READPREFERENCE(object);
-
-	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_temp, intern, props, 4);
-
-	if (!intern->read_preference) {
-		return props;
-	}
-
-	tags  = mongoc_read_prefs_get_tags(intern->read_preference);
-	hedge = mongoc_read_prefs_get_hedge(intern->read_preference);
-
-	{
-		zval z_mode;
-
-		ZVAL_STRING(&z_mode, phongo_readpreference_get_mode_string(intern->read_preference));
-		zend_hash_str_update(props, "mode", sizeof("mode") - 1, &z_mode);
-	}
-
-	if (!bson_empty0(tags)) {
-		phongo_bson_state state;
-
-		/* Use PHONGO_TYPEMAP_NATIVE_ARRAY for the root type since tags is an
-		 * array; however, inner documents and arrays can use the default. */
-		PHONGO_BSON_INIT_STATE(state);
-		state.map.root.type = PHONGO_TYPEMAP_NATIVE_ARRAY;
-
-		if (!phongo_bson_to_zval_ex(tags, &state)) {
-			zval_ptr_dtor(&state.zchild);
-			goto done;
-		}
-
-		zend_hash_str_update(props, "tags", sizeof("tags") - 1, &state.zchild);
-	}
-
-	if (mongoc_read_prefs_get_max_staleness_seconds(intern->read_preference) != MONGOC_NO_MAX_STALENESS) {
-		/* Note: valid values for maxStalesnessSeconds will not exceed the range
-		 * of 32-bit signed integers, so conditional encoding is not necessary. */
-		long maxStalenessSeconds = mongoc_read_prefs_get_max_staleness_seconds(intern->read_preference);
-		zval z_max_ss;
-
-		ZVAL_LONG(&z_max_ss, maxStalenessSeconds);
-		zend_hash_str_update(props, "maxStalenessSeconds", sizeof("maxStalenessSeconds") - 1, &z_max_ss);
-	}
-
-	if (!bson_empty0(hedge)) {
-		phongo_bson_state state;
-
-		PHONGO_BSON_INIT_STATE(state);
-
-		if (!phongo_bson_to_zval_ex(hedge, &state)) {
-			zval_ptr_dtor(&state.zchild);
-			goto done;
-		}
-
-		zend_hash_str_update(props, "hedge", sizeof("hedge") - 1, &state.zchild);
-	}
-
-done:
-	return props;
-}
-
 static PHP_METHOD(MongoDB_Driver_ReadPreference, bsonSerialize)
 {
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	ZVAL_ARR(return_value, phongo_readpreference_get_properties_hash(Z_OBJ_P(getThis()), true));
+	array_init_size(return_value, 4);
+
+	{
+		zend_string* string_key;
+		zval*        val;
+
+		ZEND_HASH_FOREACH_STR_KEY_VAL_IND(HASH_OF(getThis()), string_key, val)
+		{
+			if (
+				(Z_TYPE_P(val) == IS_NULL) || (!strcmp(ZSTR_VAL(string_key), "maxStalenessSeconds") && Z_TYPE_P(val) == IS_LONG && Z_LVAL_P(val) == MONGOC_NO_MAX_STALENESS)) {
+				continue;
+			}
+
+			// Increase the refcount of our zval, as add_assoc_zval takes ownership, leading to the property value being
+			// freed once the return value goes out of scope
+			Z_TRY_ADDREF_P(val);
+			add_assoc_zval(return_value, ZSTR_VAL(string_key), val);
+		}
+		ZEND_HASH_FOREACH_END();
+	}
+
 	convert_to_object(return_value);
-}
-
-static PHP_METHOD(MongoDB_Driver_ReadPreference, __serialize)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	RETURN_ARR(phongo_readpreference_get_properties_hash(Z_OBJ_P(getThis()), true));
 }
 
 static PHP_METHOD(MongoDB_Driver_ReadPreference, __unserialize)
@@ -487,11 +483,6 @@ static void phongo_readpreference_free_object(zend_object* object)
 
 	zend_object_std_dtor(&intern->std);
 
-	if (intern->properties) {
-		zend_hash_destroy(intern->properties);
-		FREE_HASHTABLE(intern->properties);
-	}
-
 	if (intern->read_preference) {
 		mongoc_read_prefs_destroy(intern->read_preference);
 	}
@@ -509,15 +500,13 @@ static zend_object* phongo_readpreference_create_object(zend_class_entry* class_
 	return &intern->std;
 }
 
-static HashTable* phongo_readpreference_get_debug_info(zend_object* object, int* is_temp)
+static zval* phongo_readpreference_read_property(zend_object* zobj, zend_string* name, int type, void** cache_slot, zval* rv)
 {
-	*is_temp = 1;
-	return phongo_readpreference_get_properties_hash(object, true);
-}
+	if (!strcmp(ZSTR_VAL(name), "hedge")) {
+		php_error_docref(NULL, E_DEPRECATED, "Property MongoDB\\Driver\\ReadPreference::hedge is deprecated");
+	}
 
-static HashTable* phongo_readpreference_get_properties(zend_object* object)
-{
-	return phongo_readpreference_get_properties_hash(object, false);
+	return zend_std_read_property(zobj, name, type, cache_slot, rv);
 }
 
 void phongo_readpreference_init_ce(INIT_FUNC_ARGS)
@@ -526,10 +515,9 @@ void phongo_readpreference_init_ce(INIT_FUNC_ARGS)
 	phongo_readpreference_ce->create_object = phongo_readpreference_create_object;
 
 	memcpy(&phongo_handler_readpreference, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_readpreference.get_debug_info = phongo_readpreference_get_debug_info;
-	phongo_handler_readpreference.get_properties = phongo_readpreference_get_properties;
-	phongo_handler_readpreference.free_obj       = phongo_readpreference_free_object;
-	phongo_handler_readpreference.offset         = XtOffsetOf(phongo_readpreference_t, std);
+	phongo_handler_readpreference.read_property = phongo_readpreference_read_property;
+	phongo_handler_readpreference.free_obj      = phongo_readpreference_free_object;
+	phongo_handler_readpreference.offset        = XtOffsetOf(phongo_readpreference_t, std);
 }
 
 void phongo_readpreference_init(zval* return_value, const mongoc_read_prefs_t* read_prefs)
@@ -540,6 +528,8 @@ void phongo_readpreference_init(zval* return_value, const mongoc_read_prefs_t* r
 
 	intern                  = Z_READPREFERENCE_OBJ_P(return_value);
 	intern->read_preference = mongoc_read_prefs_copy(read_prefs);
+
+	phongo_readpreference_update_properties(intern);
 }
 
 const mongoc_read_prefs_t* phongo_read_preference_from_zval(zval* zread_preference)

--- a/src/MongoDB/ReadPreference.stub.php
+++ b/src/MongoDB/ReadPreference.stub.php
@@ -51,6 +51,13 @@ final class ReadPreference implements \MongoDB\BSON\Serializable
      */
     public const SMALLEST_MAX_STALENESS_SECONDS = UNKNOWN;
 
+    public readonly string $mode;
+    public readonly array|null $tags;
+    public readonly int $maxStalenessSeconds;
+
+    /** @deprecated */
+    public readonly object|null $hedge;
+
     final public function __construct(string $mode, ?array $tagSets = null, ?array $options = null) {}
 
     /** @deprecated Hedged reads are deprecated in MongoDB 8.0 and will be removed in a future release */
@@ -67,6 +74,4 @@ final class ReadPreference implements \MongoDB\BSON\Serializable
     final public function bsonSerialize(): \stdClass {}
 
     final public function __unserialize(array $data): void {}
-
-    final public function __serialize(): array {}
 }

--- a/src/MongoDB/ReadPreference_arginfo.h
+++ b/src/MongoDB/ReadPreference_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ecf94da5562a2befc25e9770cc9970101823dcf2 */
+ * Stub hash: e7204ca51d594bcc92f399d4c2d5fe728114c1e4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_STRING, 0)
@@ -30,8 +30,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadPrefere
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_MongoDB_Driver_ReadPreference___serialize arginfo_class_MongoDB_Driver_ReadPreference_getTagSets
-
 
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __construct);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, getHedge);
@@ -41,7 +39,6 @@ static ZEND_METHOD(MongoDB_Driver_ReadPreference, getTagSets);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __set_state);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __unserialize);
-static ZEND_METHOD(MongoDB_Driver_ReadPreference, __serialize);
 
 
 static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] = {
@@ -53,7 +50,6 @@ static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] =
 	ZEND_ME(MongoDB_Driver_ReadPreference, __set_state, arginfo_class_MongoDB_Driver_ReadPreference___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, bsonSerialize, arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, __unserialize, arginfo_class_MongoDB_Driver_ReadPreference___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	ZEND_ME(MongoDB_Driver_ReadPreference, __serialize, arginfo_class_MongoDB_Driver_ReadPreference___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -112,6 +108,30 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadPreference(zend_class
 	zend_string *const_SMALLEST_MAX_STALENESS_SECONDS_name = zend_string_init_interned("SMALLEST_MAX_STALENESS_SECONDS", sizeof("SMALLEST_MAX_STALENESS_SECONDS") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SMALLEST_MAX_STALENESS_SECONDS_name, &const_SMALLEST_MAX_STALENESS_SECONDS_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_SMALLEST_MAX_STALENESS_SECONDS_name);
+
+	zval property_mode_default_value;
+	ZVAL_UNDEF(&property_mode_default_value);
+	zend_string *property_mode_name = zend_string_init("mode", sizeof("mode") - 1, 1);
+	zend_declare_typed_property(class_entry, property_mode_name, &property_mode_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_mode_name);
+
+	zval property_tags_default_value;
+	ZVAL_UNDEF(&property_tags_default_value);
+	zend_string *property_tags_name = zend_string_init("tags", sizeof("tags") - 1, 1);
+	zend_declare_typed_property(class_entry, property_tags_name, &property_tags_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
+	zend_string_release(property_tags_name);
+
+	zval property_maxStalenessSeconds_default_value;
+	ZVAL_UNDEF(&property_maxStalenessSeconds_default_value);
+	zend_string *property_maxStalenessSeconds_name = zend_string_init("maxStalenessSeconds", sizeof("maxStalenessSeconds") - 1, 1);
+	zend_declare_typed_property(class_entry, property_maxStalenessSeconds_name, &property_maxStalenessSeconds_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_maxStalenessSeconds_name);
+
+	zval property_hedge_default_value;
+	ZVAL_UNDEF(&property_hedge_default_value);
+	zend_string *property_hedge_name = zend_string_init("hedge", sizeof("hedge") - 1, 1);
+	zend_declare_typed_property(class_entry, property_hedge_name, &property_hedge_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT|MAY_BE_NULL));
+	zend_string_release(property_hedge_name);
 
 	return class_entry;
 }

--- a/src/phongo_structs.h
+++ b/src/phongo_structs.h
@@ -127,7 +127,6 @@ typedef struct {
 
 typedef struct {
 	mongoc_read_prefs_t* read_preference;
-	HashTable*           properties;
 	zend_object          std;
 } phongo_readpreference_t;
 

--- a/tests/manager/bug0851-001.phpt
+++ b/tests/manager/bug0851-001.phpt
@@ -51,5 +51,9 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/manager/manager-ctor-read_preference-001.phpt
+++ b/tests/manager/manager-ctor-read_preference-001.phpt
@@ -26,6 +26,12 @@ foreach ($tests as $test) {
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -41,16 +47,30 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -66,11 +86,19 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/manager/manager-ctor-read_preference-002.phpt
+++ b/tests/manager/manager-ctor-read_preference-002.phpt
@@ -24,31 +24,51 @@ foreach ($tests as $test) {
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1231)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1231)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(2000)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1231)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1231)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/manager/manager-getreadpreference-001.phpt
+++ b/tests/manager/manager-getreadpreference-001.phpt
@@ -29,18 +29,42 @@ foreach ($tests as $i => $test) {
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -58,6 +82,10 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -75,6 +103,10 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -87,5 +119,9 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
       string(2) "ca"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/readPreference/bug0146-001.phpt
+++ b/tests/readPreference/bug0146-001.phpt
@@ -58,6 +58,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["session"]=>
   NULL
@@ -96,6 +102,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(16) "primaryPreferred"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["session"]=>
   NULL
@@ -134,6 +146,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(9) "secondary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["session"]=>
   NULL
@@ -172,6 +190,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(18) "secondaryPreferred"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["session"]=>
   NULL
@@ -210,6 +234,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "nearest"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["session"]=>
   NULL

--- a/tests/readPreference/bug0851-001.phpt
+++ b/tests/readPreference/bug0851-001.phpt
@@ -43,5 +43,9 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/readPreference/bug1598-002.phpt
+++ b/tests/readPreference/bug1598-002.phpt
@@ -8,7 +8,12 @@ PHPC-1598: ReadPreference get_gc should delegate to zend_std_get_properties
 
 /* Store an additional object reference as a public property on the
  * ReadPreference. This will leak if get_gc returns internally cached properties
- * (from our get_properties handler) instead of zend_std_get_properties. */
+ * (from our get_properties handler) instead of zend_std_get_properties.
+ *
+ * Note: since ReadPreference uses typed properties, PHP stores dynamic
+ * properties in a separate obj->properties HashTable. This HashTable is itself
+ * a GC-collectable value, so 3 cycles are collected: the stdClass, the
+ * ReadPreference object, and the dynamic properties HashTable. */
 $a = new stdClass;
 $a->rp = new MongoDB\Driver\ReadPreference('primary');
 $a->rp->a = $a;
@@ -24,5 +29,5 @@ printf("Collected cycles: %d\n", gc_collect_cycles());
 <?php exit(0); ?>
 --EXPECT--
 Collected cycles: 0
-Collected cycles: 2
+Collected cycles: 3
 ===DONE===

--- a/tests/readPreference/bug1698-001.phpt
+++ b/tests/readPreference/bug1698-001.phpt
@@ -21,7 +21,7 @@ var_dump($uriTagSets);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\ReadPreference)#%d (2) {
+object(MongoDB\Driver\ReadPreference)#%d (4) {
   ["mode"]=>
   string(9) "secondary"
   ["tags"]=>
@@ -32,6 +32,10 @@ object(MongoDB\Driver\ReadPreference)#%d (2) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 array(2) {
   ["mode"]=>
@@ -45,7 +49,7 @@ array(2) {
     }
   }
 }
-object(MongoDB\Driver\ReadPreference)#%d (2) {
+object(MongoDB\Driver\ReadPreference)#%d (4) {
   ["mode"]=>
   string(9) "secondary"
   ["tags"]=>
@@ -56,6 +60,10 @@ object(MongoDB\Driver\ReadPreference)#%d (2) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 array(1) {
   [0]=>
@@ -64,7 +72,7 @@ array(1) {
     string(2) "ny"
   }
 }
-object(MongoDB\Driver\ReadPreference)#%d (2) {
+object(MongoDB\Driver\ReadPreference)#%d (4) {
   ["mode"]=>
   string(9) "secondary"
   ["tags"]=>
@@ -75,6 +83,10 @@ object(MongoDB\Driver\ReadPreference)#%d (2) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 array(1) {
   [0]=>

--- a/tests/readPreference/readpreference-compare-001.phpt
+++ b/tests/readPreference/readpreference-compare-001.phpt
@@ -1,0 +1,45 @@
+--TEST--
+MongoDB\Driver\ReadPreference equality comparison
+--FILE--
+<?php
+
+$tests = [
+    'same mode' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY) == new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY),
+    'same mode and tag sets' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'east']]) == new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'east']]),
+    'same mode and maxStalenessSeconds' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 120]) == new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 120]),
+    'different modes' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY) == new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY),
+    'different tag sets' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'east']]) == new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'west']]),
+    'different maxStalenessSeconds' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 120]) == new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 180]),
+    'one has tag sets and the other does not' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'east']]) == new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY),
+    'one has maxStalenessSeconds and the other does not' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 120]) == new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY),
+    'different hedges' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => ['enabled' => false]]) == new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => ['enabled' => true]]),
+    'one has hedges sets and the other does not' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => ['enabled' => true]]) == new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY),
+    'Object comparison fallback if one value is not a ReadPreference' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY) == new MongoDB\BSON\Int64('1'),
+];
+
+foreach ($tests as $test => $result) {
+    echo "Testing $test: ";
+    var_dump($result);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
+Testing same mode: bool(true)
+Testing same mode and tag sets: bool(true)
+Testing same mode and maxStalenessSeconds: bool(true)
+Testing different modes: bool(false)
+Testing different tag sets: bool(false)
+Testing different maxStalenessSeconds: bool(false)
+Testing one has tag sets and the other does not: bool(false)
+Testing one has maxStalenessSeconds and the other does not: bool(false)
+Testing different hedges: bool(false)
+Testing one has hedges sets and the other does not: bool(false)
+Testing Object comparison fallback if one value is not a ReadPreference: bool(false)
+===DONE===

--- a/tests/readPreference/readpreference-ctor-001.phpt
+++ b/tests/readPreference/readpreference-ctor-001.phpt
@@ -15,6 +15,12 @@ var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECOND
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -27,15 +33,29 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
       string(3) "one"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/readPreference/readpreference-ctor-002.phpt
+++ b/tests/readPreference/readpreference-ctor-002.phpt
@@ -37,60 +37,150 @@ foreach ($data as $item) {
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }

--- a/tests/readPreference/readpreference-debug-001.phpt
+++ b/tests/readPreference/readpreference-debug-001.phpt
@@ -30,26 +30,62 @@ Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -62,6 +98,10 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -84,16 +124,28 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
   ["hedge"]=>
   object(stdClass)#%d (%d) {
     ["enabled"]=>

--- a/tests/readPreference/readpreference-getHedge-001.phpt
+++ b/tests/readPreference/readpreference-getHedge-001.phpt
@@ -15,6 +15,7 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => $test]);
     var_dump($rp->getHedge());
+    var_dump($rp->hedge);
 }
 
 ?>
@@ -26,9 +27,16 @@ Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is 
 Deprecated: Method MongoDB\Driver\ReadPreference::getHedge() is deprecated in %s
 NULL
 
+Deprecated: main(): Property MongoDB\Driver\ReadPreference::hedge is deprecated in %s
+NULL
+
 Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
 
 Deprecated: Method MongoDB\Driver\ReadPreference::getHedge() is deprecated in %s
+object(stdClass)#%d (%d) {
+  ["enabled"]=>
+  bool(true)
+}
 object(stdClass)#%d (%d) {
   ["enabled"]=>
   bool(true)
@@ -41,10 +49,18 @@ object(stdClass)#%d (%d) {
   ["enabled"]=>
   bool(true)
 }
+object(stdClass)#%d (%d) {
+  ["enabled"]=>
+  bool(true)
+}
 
 Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
 
 Deprecated: Method MongoDB\Driver\ReadPreference::getHedge() is deprecated in %s
+object(stdClass)#%d (%d) {
+  ["foo"]=>
+  string(3) "bar"
+}
 object(stdClass)#%d (%d) {
   ["foo"]=>
   string(3) "bar"

--- a/tests/readPreference/readpreference-getMaxStalenessMS-001.phpt
+++ b/tests/readPreference/readpreference-getMaxStalenessMS-001.phpt
@@ -16,6 +16,7 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => $test]);
     var_dump($rp->getMaxStalenessSeconds());
+    var_dump($rp->maxStalenessSeconds);
 }
 
 ?>
@@ -23,8 +24,13 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 int(-1)
+int(-1)
+int(90)
+int(90)
 int(90)
 int(90)
 int(1000)
+int(1000)
+int(2147483647)
 int(2147483647)
 ===DONE===

--- a/tests/readPreference/readpreference-getMaxStalenessMS-002.phpt
+++ b/tests/readPreference/readpreference-getMaxStalenessMS-002.phpt
@@ -16,6 +16,7 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference("secondary", null, ['maxStalenessSeconds' => $test]);
     var_dump($rp->getMaxStalenessSeconds());
+    var_dump($rp->maxStalenessSeconds);
 }
 
 ?>
@@ -23,8 +24,13 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 int(-1)
+int(-1)
+int(90)
+int(90)
 int(90)
 int(90)
 int(1000)
+int(1000)
+int(2147483647)
 int(2147483647)
 ===DONE===

--- a/tests/readPreference/readpreference-getModeString-001.phpt
+++ b/tests/readPreference/readpreference-getModeString-001.phpt
@@ -14,6 +14,7 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference($test);
     var_dump($rp->getModeString());
+    var_dump($rp->mode);
 }
 
 ?>
@@ -21,8 +22,13 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 string(7) "primary"
+string(7) "primary"
+string(16) "primaryPreferred"
 string(16) "primaryPreferred"
 string(9) "secondary"
+string(9) "secondary"
 string(18) "secondaryPreferred"
+string(18) "secondaryPreferred"
+string(7) "nearest"
 string(7) "nearest"
 ===DONE===

--- a/tests/readPreference/readpreference-getTagSets-001.phpt
+++ b/tests/readPreference/readpreference-getTagSets-001.phpt
@@ -13,16 +13,19 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED, $test);
     var_dump($rp->getTagSets());
+    var_dump($rp->tags);
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 array(0) {
 }
+NULL
 array(0) {
 }
+NULL
 array(2) {
   [0]=>
   array(1) {
@@ -31,6 +34,16 @@ array(2) {
   }
   [1]=>
   array(0) {
+  }
+}
+array(2) {
+  [0]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "ny"
+  }
+  [1]=>
+  object(stdClass)#%d (%d) {
   }
 }
 array(3) {
@@ -48,6 +61,23 @@ array(3) {
   }
   [2]=>
   array(0) {
+  }
+}
+array(3) {
+  [0]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "ny"
+  }
+  [1]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "sf"
+    ["use"]=>
+    string(9) "reporting"
+  }
+  [2]=>
+  object(stdClass)#%d (%d) {
   }
 }
 ===DONE===

--- a/tests/readPreference/readpreference-getTagSets-002.phpt
+++ b/tests/readPreference/readpreference-getTagSets-002.phpt
@@ -13,16 +13,19 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference("secondaryPreferred", $test);
     var_dump($rp->getTagSets());
+    var_dump($rp->tags);
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 array(0) {
 }
+NULL
 array(0) {
 }
+NULL
 array(2) {
   [0]=>
   array(1) {
@@ -31,6 +34,16 @@ array(2) {
   }
   [1]=>
   array(0) {
+  }
+}
+array(2) {
+  [0]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "ny"
+  }
+  [1]=>
+  object(stdClass)#%d (%d) {
   }
 }
 array(3) {
@@ -48,6 +61,23 @@ array(3) {
   }
   [2]=>
   array(0) {
+  }
+}
+array(3) {
+  [0]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "ny"
+  }
+  [1]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "sf"
+    ["use"]=>
+    string(9) "reporting"
+  }
+  [2]=>
+  object(stdClass)#%d (%d) {
   }
 }
 ===DONE===

--- a/tests/readPreference/readpreference-serialization-002.phpt
+++ b/tests/readPreference/readpreference-serialization-002.phpt
@@ -33,61 +33,133 @@ Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:7:"primary";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:7:"primary";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:16:"primaryPreferred";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:16:"primaryPreferred";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:9:"secondary";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:18:"secondaryPreferred";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:18:"secondaryPreferred";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:7:"nearest";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:7:"nearest";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:9:"secondary";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
@@ -101,8 +173,12 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":2:{s:4:"mode";s:9:"secondary";s:4:"tags";a:1:{i:0;O:8:"stdClass":1:{s:2:"dc";s:2:"ny";}}}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";a:1:{i:0;O:8:"stdClass":1:{s:2:"dc";s:2:"ny";}}s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
@@ -114,6 +190,10 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
@@ -137,8 +217,12 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":2:{s:4:"mode";s:9:"secondary";s:4:"tags";a:3:{i:0;O:8:"stdClass":1:{s:2:"dc";s:2:"ny";}i:1;O:8:"stdClass":2:{s:2:"dc";s:2:"sf";s:3:"use";s:9:"reporting";}i:2;O:8:"stdClass":0:{}}}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";a:3:{i:0;O:8:"stdClass":1:{s:2:"dc";s:2:"ny";}i:1;O:8:"stdClass":2:{s:2:"dc";s:2:"sf";s:3:"use";s:9:"reporting";}i:2;O:8:"stdClass":0:{}}s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
@@ -160,37 +244,57 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":2:{s:4:"mode";s:9:"secondary";s:19:"maxStalenessSeconds";i:1000;}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";N;s:19:"maxStalenessSeconds";i:1000;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
   ["hedge"]=>
   object(stdClass)#%d (%d) {
     ["enabled"]=>
     bool(true)
   }
 }
-O:29:"MongoDB\Driver\ReadPreference":2:{s:4:"mode";s:9:"secondary";s:5:"hedge";O:8:"stdClass":1:{s:7:"enabled";b:1;}}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";O:8:"stdClass":1:{s:7:"enabled";b:1;}}
 
 Deprecated: MongoDB\Driver\ReadPreference::__unserialize(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
   ["hedge"]=>
   object(stdClass)#%d (%d) {
     ["enabled"]=>

--- a/tests/readPreference/readpreference-set_state-001.phpt
+++ b/tests/readPreference/readpreference-set_state-001.phpt
@@ -28,22 +28,37 @@ foreach ($tests as $fields) {
 --EXPECTF--
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'primary',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'primaryPreferred',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondaryPreferred',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'nearest',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
@@ -55,6 +70,8 @@ foreach ($tests as $fields) {
        'dc' => 'ny',
     ),
   ),
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
@@ -74,11 +91,15 @@ foreach ($tests as $fields) {
     (object) array(
     ),
   ),
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
+   'tags' => NULL,
    'maxStalenessSeconds' => 1000,
+   'hedge' => NULL,
 ))
 
 ===DONE===

--- a/tests/readPreference/readpreference-var_export-001.phpt
+++ b/tests/readPreference/readpreference-var_export-001.phpt
@@ -27,21 +27,39 @@ foreach ($tests as $test) {
 --EXPECTF--
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'primary',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'primaryPreferred',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondaryPreferred',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'nearest',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'primary',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
@@ -52,6 +70,8 @@ foreach ($tests as $test) {
        'dc' => 'ny',
     ),
   ),
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
@@ -70,9 +90,13 @@ foreach ($tests as $test) {
     (object) array(
     ),
   ),
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
+   'tags' => NULL,
    'maxStalenessSeconds' => 1000,
+   'hedge' => NULL,
 ))
 ===DONE===

--- a/tests/session/session-debug-005.phpt
+++ b/tests/session/session-debug-005.phpt
@@ -78,6 +78,12 @@ object(MongoDB\Driver\Session)#%d (%d) {
     object(MongoDB\Driver\ReadPreference)#%d (%d) {
       ["mode"]=>
       string(7) "primary"
+      ["tags"]=>
+      NULL
+      ["maxStalenessSeconds"]=>
+      int(-1)
+      ["hedge"]=>
+      NULL
     }
   }
 }

--- a/tests/session/session-debug-006.phpt
+++ b/tests/session/session-debug-006.phpt
@@ -66,6 +66,12 @@ object(MongoDB\Driver\Session)#%d (%d) {
     object(MongoDB\Driver\ReadPreference)#%d (%d) {
       ["mode"]=>
       string(16) "primaryPreferred"
+      ["tags"]=>
+      NULL
+      ["maxStalenessSeconds"]=>
+      int(-1)
+      ["hedge"]=>
+      NULL
     }
     ["writeConcern"]=>
     object(MongoDB\Driver\WriteConcern)#%d (%d) {

--- a/tests/session/session-getTransactionOptions-001.phpt
+++ b/tests/session/session-getTransactionOptions-001.phpt
@@ -37,18 +37,30 @@ foreach ($options as $test) {
 NULL
 array(1) {
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
 }
 array(2) {
   ["maxCommitTimeMS"]=>
   int(1)
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
 }
 array(2) {
@@ -58,23 +70,41 @@ array(2) {
     string(8) "majority"
   }
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
 }
 array(1) {
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(16) "primaryPreferred"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
 }
 array(2) {
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["writeConcern"]=>
   object(MongoDB\Driver\WriteConcern)#%d (1) {


### PR DESCRIPTION
PHPC-2379

I revisited the topic of proper properties for value objects based on recent work on object comparisons and the `get_properties_for` handler. For the time being, I've only done the work for the `MongoDB\Driver\ReadPreference` class, but the concept applies to all other value objects (see list below).

I've left comments in the code itself to elaborate on some of the changes, but the TL;DR is that we can do away with the static `get_properties_hash` function (which serves no other purpose than to build a list of properties for the various methods that need them) and some of the other handlers. In fact, we no longer need to implement the `__serialize` method and the `get_debug_info` object handler as these dump public properties by default. There are multiple test changes associated with this as our own handlers often would not serialise properties that were "unset" or contained default values.

Here is the list of classes this concept would apply to:
- `MongoDB\Driver\ReadConcern`
- `MongoDB\Driver\WriteConcern`
- `MongoDB\Driver\WriteError`
- `MongoDB\Driver\WriteResult`
- `MongoDB\Driver\Exception\CommandException`
- `MongoDB\Driver\Exception\WriteException`
- `MongoDB\Driver\Monitoring\CommandFailedEvent`
- `MongoDB\Driver\Monitoring\CommandStartedEvent`
- `MongoDB\Driver\Monitoring\CommandSucceededEvent`
- `MongoDB\Driver\Monitoring\ServerChangedEvent`
- `MongoDB\Driver\Monitoring\ServerClosedEvent`
- `MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent`
- `MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent`
- `MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent`
- `MongoDB\Driver\Monitoring\ServerOpeningEvent`
- `MongoDB\Driver\Monitoring\TopologyChangedEvent`
- `MongoDB\Driver\Monitoring\TopologyClosedEvent`
- `MongoDB\Driver\Monitoring\TopologyOpeningEvent`

These changes would also apply to all BSON classes, although they would not be as useful as the corresponding methods (which should eventually be deprecated) are mandated by the interfaces, which can't contain properties until PHP 8.4. For some of the other classes (e.g. `MongoDB\Driver\Server`), the value of a property may change over time (e.g. the server description or latency) so I'm not sure whether we would want to use hooked properties for those. I would suggest discussing that separately and splitting PHPC-2379 if we decide to go this route.