### PR TITLE
PHPC-2500: Skip errorLabels assignment for non-RuntimeException exceptions

### DIFF
--- a/src/phongo_error.c
+++ b/src/phongo_error.c
@@ -32,7 +32,6 @@ void phongo_add_exception_prop(const char* prop, size_t prop_len, zval* value)
 	if (EG(exception)) {
 		zval ex;
 		ZVAL_OBJ(&ex, EG(exception));
-		ZEND_ASSERT(zend_hash_str_exists(&Z_OBJCE(ex)->properties_info, prop, prop_len) && "Exception class does not declare property");
 		zend_update_property(Z_OBJCE(ex), Z_OBJ_P(&ex), prop, prop_len, value);
 	}
 }
@@ -151,7 +150,12 @@ void phongo_exception_add_error_labels(const bson_t* reply)
 	zval        labels;
 	uint32_t    label_count = 0;
 
-	if (!reply) {
+	if (!reply || !EG(exception)) {
+		return;
+	}
+
+	/* errorLabels is only declared on RuntimeException and its subclasses. */
+	if (!instanceof_function(EG(exception)->ce, phongo_runtimeexception_ce)) {
 		return;
 	}
 

--- a/src/phongo_error.c
+++ b/src/phongo_error.c
@@ -27,7 +27,7 @@
  * or command should select ExecutionTimeoutException. */
 #define PHONGO_SERVER_ERROR_EXCEEDED_TIME_LIMIT 50
 
-void phongo_add_exception_prop(const char* prop, int prop_len, zval* value)
+void phongo_add_exception_prop(const char* prop, size_t prop_len, zval* value)
 {
 	if (EG(exception)) {
 		zval ex;

--- a/src/phongo_error.c
+++ b/src/phongo_error.c
@@ -32,6 +32,7 @@ void phongo_add_exception_prop(const char* prop, int prop_len, zval* value)
 	if (EG(exception)) {
 		zval ex;
 		ZVAL_OBJ(&ex, EG(exception));
+		ZEND_ASSERT(zend_hash_str_exists(&Z_OBJCE(ex)->properties_info, prop, prop_len) && "Exception class does not declare property");
 		zend_update_property(Z_OBJCE(ex), Z_OBJ_P(&ex), prop, prop_len, value);
 	}
 }

--- a/src/phongo_error.h
+++ b/src/phongo_error.h
@@ -29,7 +29,7 @@ typedef enum {
 	PHONGO_ERROR_LOGIC             = 9
 } phongo_error_domain_t;
 
-void              phongo_add_exception_prop(const char* prop, int prop_len, zval* value);
+void              phongo_add_exception_prop(const char* prop, size_t prop_len, zval* value);
 zend_class_entry* phongo_exception_from_mongoc_domain(mongoc_error_domain_t domain, mongoc_error_code_t code);
 zend_class_entry* phongo_exception_from_phongo_domain(phongo_error_domain_t domain);
 void              phongo_exception_add_error_labels(const bson_t* reply);


### PR DESCRIPTION
Fixes PHPC-2500.

While implementing `BulkWriteCommandException`, a dynamic property deprecation notice was observed at runtime:

```
Deprecated: Creation of dynamic property Exception::$bulkWriteCommandResult is deprecated
```

This was caused by `phongo_exception_add_error_labels()` unconditionally calling `phongo_add_exception_prop()` with `"errorLabels"` after any exception thrown via `phongo_throw_exception_from_bson_error_t_and_reply()` — including `InvalidArgumentException`, which does not inherit from `MongoDB\Driver\Exception\RuntimeException` and does not declare that property.

An initial approach added a `ZEND_ASSERT` in `phongo_add_exception_prop()` to catch mismatched property names in debug builds. However, `ZEND_ASSERT` is a no-op in release builds, leaving the dynamic property creation silently in place in production.

This commit instead adds a proper runtime guard in `phongo_exception_add_error_labels()`: the assignment is skipped entirely if the current exception is not an instance of `RuntimeException`. This is the correct fix because:

- `errorLabels` is semantically meaningful only on `RuntimeException` and its subclasses (`ServerException`, `CommandException`, `BulkWriteException`, etc.), which represent server-side or network failures that can carry labels such as `TransientTransactionError`.
- Exception types outside this hierarchy (e.g. `InvalidArgumentException`) represent client-side validation errors that occur before any server interaction and can never carry error labels.
- The guard is effective in both debug and release builds, unlike `ZEND_ASSERT`.

Also fixes `prop_len` type in `phongo_add_exception_prop()` from `int` to `size_t` to match the `zend_update_property()` and `zend_hash_str_exists()` signatures.