### PR TITLE
Make bson-enum_error resilient to PHP 8.6 interface handler order

### DIFF
--- a/tests/bson/bson-enum_error-003.phpt
+++ b/tests/bson/bson-enum_error-003.phpt
@@ -15,5 +15,5 @@ enum MyEnum implements MongoDB\BSON\Persistable
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
-Fatal error: Enum class MyEnum cannot implement interface MongoDB\BSON\Persistable in %s on line %d
+--EXPECTREGEX--
+Fatal error: Enum class MyEnum cannot implement interface MongoDB\\BSON\\(Persistable|Unserializable) in .+ on line \d+

--- a/tests/bson/bson-enum_error-004.phpt
+++ b/tests/bson/bson-enum_error-004.phpt
@@ -15,5 +15,5 @@ enum MyBackedEnum: int implements MongoDB\BSON\Persistable
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECTF--
-Fatal error: Enum class MyBackedEnum cannot implement interface MongoDB\BSON\Persistable in %s on line %d
+--EXPECTREGEX--
+Fatal error: Enum class MyBackedEnum cannot implement interface MongoDB\\BSON\\(Persistable|Unserializable) in .+ on line \d+


### PR DESCRIPTION
Backport of #1953 to v2.2.

PHP is calling the `interface_gets_implemented` handlers in a different order since https://github.com/php/php-src/pull/18622

The [`Persistable`](https://github.com/mongodb/mongo-php-driver/blob/v2.x/src/BSON/Persistable.stub.php) interface extends `Unserializable` which is the one that cannot be implemented.