### PR TITLE
PHPC-2699: Add typed, read-only properties for value objects and events

### DIFF
--- a/src/MongoDB/Exception/BulkWriteException.stub.php
+++ b/src/MongoDB/Exception/BulkWriteException.stub.php
@@ -9,8 +9,7 @@ namespace MongoDB\Driver\Exception;
 
 class BulkWriteException extends ServerException
 {
-    /** @var \MongoDB\Driver\WriteResult */
-    protected $writeResult;
+    public readonly \MongoDB\Driver\WriteResult $writeResult;
 
     final public function getWriteResult(): \MongoDB\Driver\WriteResult {}
 }

--- a/src/MongoDB/Exception/BulkWriteException_arginfo.h
+++ b/src/MongoDB/Exception/BulkWriteException_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3a09fcb79df6117de9924cfce65ba8762d9c8bc2 */
+ * Stub hash: 3f5cb39269196e24c33e5f9393b2e5e25fc771c3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Exception_BulkWriteException_getWriteResult, 0, 0, MongoDB\\Driver\\WriteResult, 0)
 ZEND_END_ARG_INFO()
@@ -20,10 +20,11 @@ static zend_class_entry *register_class_MongoDB_Driver_Exception_BulkWriteExcept
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "BulkWriteException", class_MongoDB_Driver_Exception_BulkWriteException_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_ServerException);
 
+	zend_string *property_writeResult_class_MongoDB_Driver_WriteResult = zend_string_init("MongoDB\\Driver\\WriteResult", sizeof("MongoDB\\Driver\\WriteResult")-1, 1);
 	zval property_writeResult_default_value;
-	ZVAL_NULL(&property_writeResult_default_value);
+	ZVAL_UNDEF(&property_writeResult_default_value);
 	zend_string *property_writeResult_name = zend_string_init("writeResult", sizeof("writeResult") - 1, 1);
-	zend_declare_property_ex(class_entry, property_writeResult_name, &property_writeResult_default_value, ZEND_ACC_PROTECTED, NULL);
+	zend_declare_typed_property(class_entry, property_writeResult_name, &property_writeResult_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_writeResult_class_MongoDB_Driver_WriteResult, 0, 0));
 	zend_string_release(property_writeResult_name);
 
 	return class_entry;

--- a/src/MongoDB/Exception/CommandException.stub.php
+++ b/src/MongoDB/Exception/CommandException.stub.php
@@ -9,8 +9,7 @@ namespace MongoDB\Driver\Exception;
 
 class CommandException extends ServerException
 {
-    /** @var object */
-    protected $resultDocument;
+    public readonly object $resultDocument;
 
     final public function getResultDocument(): object {}
 }

--- a/src/MongoDB/Exception/CommandException_arginfo.h
+++ b/src/MongoDB/Exception/CommandException_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 55cb6773eee137316b8b5a78cd1050b061b2e24e */
+ * Stub hash: a34c85582624ddbc462e429ba71d3309c4bcb4a3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Exception_CommandException_getResultDocument, 0, 0, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
@@ -21,9 +21,9 @@ static zend_class_entry *register_class_MongoDB_Driver_Exception_CommandExceptio
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_ServerException);
 
 	zval property_resultDocument_default_value;
-	ZVAL_NULL(&property_resultDocument_default_value);
+	ZVAL_UNDEF(&property_resultDocument_default_value);
 	zend_string *property_resultDocument_name = zend_string_init("resultDocument", sizeof("resultDocument") - 1, 1);
-	zend_declare_property_ex(class_entry, property_resultDocument_name, &property_resultDocument_default_value, ZEND_ACC_PROTECTED, NULL);
+	zend_declare_typed_property(class_entry, property_resultDocument_name, &property_resultDocument_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
 	zend_string_release(property_resultDocument_name);
 
 	return class_entry;

--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -18,6 +18,7 @@
 
 #include <php.h>
 #include <Zend/zend_interfaces.h>
+#include <Zend/zend_exceptions.h>
 
 #include "phongo.h"
 #include "phongo_bson_encode.h"
@@ -160,6 +161,50 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getServerConnect
 	RETURN_LONG(intern->server_connection_id);
 }
 
+static void phongo_commandfailedevent_update_properties(phongo_commandfailedevent_t* intern)
+{
+	char              operation_id[24], request_id[24];
+	phongo_bson_state reply_state;
+
+	PHONGO_BSON_INIT_STATE(reply_state);
+
+	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
+	zend_update_property_long(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("commandName"), intern->command_name);
+	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("databaseName"), intern->database_name);
+	zend_update_property_long(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("durationMicros"), intern->duration_micros);
+	zend_update_property(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("error"), &intern->z_error);
+
+	if (phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
+		zend_update_property(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("reply"), &reply_state.zchild);
+	}
+	zval_ptr_dtor(&reply_state.zchild);
+
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
+	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("operationId"), operation_id);
+
+	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
+	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("requestId"), request_id);
+
+	if (intern->has_service_id) {
+		zval service_id;
+
+		if (phongo_objectid_new(&service_id, &intern->service_id)) {
+			zend_update_property(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("serviceId"), &service_id);
+			zval_ptr_dtor(&service_id);
+		}
+	} else {
+		zend_update_property_null(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("serviceId"));
+	}
+
+	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
+	if (intern->server_connection_id == -1) {
+		zend_update_property_null(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("serverConnectionId"));
+	} else {
+		zend_update_property_long(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("serverConnectionId"), intern->server_connection_id);
+	}
+}
+
 /* MongoDB\Driver\Monitoring\CommandFailedEvent object handlers */
 static zend_object_handlers phongo_handler_commandfailedevent;
 
@@ -195,71 +240,46 @@ static zend_object* phongo_commandfailedevent_create_object(zend_class_entry* cl
 	return &intern->std;
 }
 
-static HashTable* phongo_commandfailedevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(commandfailedevent, object);
-
-	zval              retval = ZVAL_STATIC_INIT;
-	char              operation_id[24], request_id[24];
-	phongo_bson_state reply_state;
-
-	PHONGO_BSON_INIT_STATE(reply_state);
-
-	*is_temp = 1;
-	array_init_size(&retval, 10);
-
-	ADD_ASSOC_STRING(&retval, "host", intern->host.host);
-	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
-	ADD_ASSOC_STRING(&retval, "commandName", intern->command_name);
-	ADD_ASSOC_INT64(&retval, "durationMicros", intern->duration_micros);
-
-	ADD_ASSOC_ZVAL_EX(&retval, "error", &intern->z_error);
-	Z_ADDREF(intern->z_error);
-
-	if (!phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
-		zval_ptr_dtor(&reply_state.zchild);
-		goto done;
-	}
-
-	ADD_ASSOC_ZVAL(&retval, "reply", &reply_state.zchild);
-
-	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
-	ADD_ASSOC_STRING(&retval, "operationId", operation_id);
-
-	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
-	ADD_ASSOC_STRING(&retval, "requestId", request_id);
-
-	if (intern->has_service_id) {
-		zval service_id;
-
-		if (!phongo_objectid_new(&service_id, &intern->service_id)) {
-			/* Exception should already have been thrown */
-			goto done;
-		}
-
-		ADD_ASSOC_ZVAL_EX(&retval, "serviceId", &service_id);
-	} else {
-		ADD_ASSOC_NULL_EX(&retval, "serviceId");
-	}
-
-	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (intern->server_connection_id == -1) {
-		ADD_ASSOC_NULL_EX(&retval, "serverConnectionId");
-	} else {
-		ADD_ASSOC_LONG_EX(&retval, "serverConnectionId", intern->server_connection_id);
-	}
-
-done:
-	return Z_ARRVAL(retval);
-}
-
 void phongo_commandfailedevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_commandfailedevent_ce                = register_class_MongoDB_Driver_Monitoring_CommandFailedEvent();
 	phongo_commandfailedevent_ce->create_object = phongo_commandfailedevent_create_object;
 
 	memcpy(&phongo_handler_commandfailedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_commandfailedevent.get_debug_info = phongo_commandfailedevent_get_debug_info;
-	phongo_handler_commandfailedevent.free_obj       = phongo_commandfailedevent_free_object;
-	phongo_handler_commandfailedevent.offset         = XtOffsetOf(phongo_commandfailedevent_t, std);
+	phongo_handler_commandfailedevent.free_obj = phongo_commandfailedevent_free_object;
+	phongo_handler_commandfailedevent.offset   = XtOffsetOf(phongo_commandfailedevent_t, std);
+}
+
+void phongo_commandfailedevent_init(zval* return_value, const mongoc_apm_command_failed_t* event)
+{
+	PHONGO_INTERN_INIT_EX(commandfailedevent, return_value);
+
+	bson_error_t tmp_error = { 0 };
+
+	memcpy(&intern->host, mongoc_apm_command_failed_get_host(event), sizeof(mongoc_host_list_t));
+
+	intern->command_name         = estrdup(mongoc_apm_command_failed_get_command_name(event));
+	intern->database_name        = estrdup(mongoc_apm_command_failed_get_database_name(event));
+	intern->server_id            = mongoc_apm_command_failed_get_server_id(event);
+	intern->operation_id         = mongoc_apm_command_failed_get_operation_id(event);
+	intern->request_id           = mongoc_apm_command_failed_get_request_id(event);
+	intern->duration_micros      = mongoc_apm_command_failed_get_duration(event);
+	intern->reply                = bson_copy(mongoc_apm_command_failed_get_reply(event));
+	intern->server_connection_id = mongoc_apm_command_failed_get_server_connection_id_int64(event);
+	intern->has_service_id       = mongoc_apm_command_failed_get_service_id(event) != NULL;
+
+	if (intern->has_service_id) {
+		bson_oid_copy(mongoc_apm_command_failed_get_service_id(event), &intern->service_id);
+	}
+
+	/* We need to process and convert the error right here, otherwise
+	 * debug_info will turn into a recursive loop, and with the wrong trace
+	 * locations */
+	mongoc_apm_command_failed_get_error(event, &tmp_error);
+
+	object_init_ex(&intern->z_error, phongo_exception_from_mongoc_domain(tmp_error.domain, tmp_error.code));
+	zend_update_property_string(zend_ce_exception, Z_OBJ_P(&intern->z_error), ZEND_STRL("message"), tmp_error.message);
+	zend_update_property_long(zend_ce_exception, Z_OBJ_P(&intern->z_error), ZEND_STRL("code"), tmp_error.code);
+
+	phongo_commandfailedevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/CommandFailedEvent.stub.php
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.stub.php
@@ -10,6 +10,18 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class CommandFailedEvent
 {
+    public readonly string $host;
+    public readonly int $port;
+    public readonly string $commandName;
+    public readonly string $databaseName;
+    public readonly int $durationMicros;
+    public readonly \Exception $error;
+    public readonly object $reply;
+    public readonly string $operationId;
+    public readonly string $requestId;
+    public readonly ?\MongoDB\BSON\ObjectId $serviceId;
+    public readonly ?int $serverConnectionId;
+
     final private function __construct() {}
 
     final public function getCommandName(): string {}

--- a/src/MongoDB/Monitoring/CommandFailedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandFailedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5ee4ff6e75a00cb4456ef87a15dd1d35fa0d3bdd */
+ * Stub hash: 9a242bf0efd045145ad51f4fbeab587a59c8dd78 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -70,6 +70,74 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandFailedE
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "CommandFailedEvent", class_MongoDB_Driver_Monitoring_CommandFailedEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
+	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_host_name);
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
+	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_port_name);
+
+	zval property_commandName_default_value;
+	ZVAL_UNDEF(&property_commandName_default_value);
+	zend_string *property_commandName_name = zend_string_init("commandName", sizeof("commandName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_commandName_name, &property_commandName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_commandName_name);
+
+	zval property_databaseName_default_value;
+	ZVAL_UNDEF(&property_databaseName_default_value);
+	zend_string *property_databaseName_name = zend_string_init("databaseName", sizeof("databaseName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_databaseName_name);
+
+	zval property_durationMicros_default_value;
+	ZVAL_UNDEF(&property_durationMicros_default_value);
+	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
+	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_durationMicros_name);
+
+	zend_string *property_error_class_Exception = zend_string_init("Exception", sizeof("Exception")-1, 1);
+	zval property_error_default_value;
+	ZVAL_UNDEF(&property_error_default_value);
+	zend_string *property_error_name = zend_string_init("error", sizeof("error") - 1, 1);
+	zend_declare_typed_property(class_entry, property_error_name, &property_error_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_error_class_Exception, 0, 0));
+	zend_string_release(property_error_name);
+
+	zval property_reply_default_value;
+	ZVAL_UNDEF(&property_reply_default_value);
+	zend_string *property_reply_name = zend_string_init("reply", sizeof("reply") - 1, 1);
+	zend_declare_typed_property(class_entry, property_reply_name, &property_reply_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
+	zend_string_release(property_reply_name);
+
+	zval property_operationId_default_value;
+	ZVAL_UNDEF(&property_operationId_default_value);
+	zend_string *property_operationId_name = zend_string_init("operationId", sizeof("operationId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_operationId_name, &property_operationId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_operationId_name);
+
+	zval property_requestId_default_value;
+	ZVAL_UNDEF(&property_requestId_default_value);
+	zend_string *property_requestId_name = zend_string_init("requestId", sizeof("requestId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_requestId_name, &property_requestId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_requestId_name);
+
+	zend_string *property_serviceId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zval property_serviceId_default_value;
+	ZVAL_UNDEF(&property_serviceId_default_value);
+	zend_string *property_serviceId_name = zend_string_init("serviceId", sizeof("serviceId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_serviceId_name, &property_serviceId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_serviceId_class_MongoDB_BSON_ObjectId, 0, MAY_BE_NULL));
+	zend_string_release(property_serviceId_name);
+
+	zval property_serverConnectionId_default_value;
+	ZVAL_UNDEF(&property_serverConnectionId_default_value);
+	zend_string *property_serverConnectionId_name = zend_string_init("serverConnectionId", sizeof("serverConnectionId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_serverConnectionId_name, &property_serverConnectionId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_serverConnectionId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -142,6 +142,48 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getServerConnec
 	RETURN_LONG(intern->server_connection_id);
 }
 
+static void phongo_commandstartedevent_update_properties(phongo_commandstartedevent_t* intern)
+{
+	char              operation_id[24], request_id[24];
+	phongo_bson_state command_state;
+
+	PHONGO_BSON_INIT_STATE(command_state);
+
+	zend_update_property_string(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
+	zend_update_property_long(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+	zend_update_property_string(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("commandName"), intern->command_name);
+	zend_update_property_string(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("databaseName"), intern->database_name);
+
+	if (phongo_bson_to_zval_ex(intern->command, &command_state)) {
+		zend_update_property(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("command"), &command_state.zchild);
+	}
+	zval_ptr_dtor(&command_state.zchild);
+
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
+	zend_update_property_string(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("operationId"), operation_id);
+
+	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
+	zend_update_property_string(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("requestId"), request_id);
+
+	if (intern->has_service_id) {
+		zval service_id;
+
+		if (phongo_objectid_new(&service_id, &intern->service_id)) {
+			zend_update_property(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("serviceId"), &service_id);
+			zval_ptr_dtor(&service_id);
+		}
+	} else {
+		zend_update_property_null(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("serviceId"));
+	}
+
+	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
+	if (intern->server_connection_id == -1) {
+		zend_update_property_null(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("serverConnectionId"));
+	} else {
+		zend_update_property_long(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("serverConnectionId"), intern->server_connection_id);
+	}
+}
+
 /* MongoDB\Driver\Monitoring\CommandStartedEvent object handlers */
 static zend_object_handlers phongo_handler_commandstartedevent;
 
@@ -173,68 +215,34 @@ static zend_object* phongo_commandstartedevent_create_object(zend_class_entry* c
 	return &intern->std;
 }
 
-static HashTable* phongo_commandstartedevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(commandstartedevent, object);
-
-	zval              retval = ZVAL_STATIC_INIT;
-	char              operation_id[24], request_id[24];
-	phongo_bson_state command_state;
-
-	PHONGO_BSON_INIT_STATE(command_state);
-
-	*is_temp = 1;
-	array_init_size(&retval, 9);
-
-	ADD_ASSOC_STRING(&retval, "host", intern->host.host);
-	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
-	ADD_ASSOC_STRING(&retval, "commandName", intern->command_name);
-	ADD_ASSOC_STRING(&retval, "databaseName", intern->database_name);
-
-	if (!phongo_bson_to_zval_ex(intern->command, &command_state)) {
-		zval_ptr_dtor(&command_state.zchild);
-		goto done;
-	}
-
-	ADD_ASSOC_ZVAL(&retval, "command", &command_state.zchild);
-
-	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
-	ADD_ASSOC_STRING(&retval, "operationId", operation_id);
-
-	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
-	ADD_ASSOC_STRING(&retval, "requestId", request_id);
-
-	if (intern->has_service_id) {
-		zval service_id;
-
-		if (!phongo_objectid_new(&service_id, &intern->service_id)) {
-			/* Exception should already have been thrown */
-			goto done;
-		}
-
-		ADD_ASSOC_ZVAL_EX(&retval, "serviceId", &service_id);
-	} else {
-		ADD_ASSOC_NULL_EX(&retval, "serviceId");
-	}
-
-	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (intern->server_connection_id == -1) {
-		ADD_ASSOC_NULL_EX(&retval, "serverConnectionId");
-	} else {
-		ADD_ASSOC_LONG_EX(&retval, "serverConnectionId", intern->server_connection_id);
-	}
-
-done:
-	return Z_ARRVAL(retval);
-}
-
 void phongo_commandstartedevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_commandstartedevent_ce                = register_class_MongoDB_Driver_Monitoring_CommandStartedEvent();
 	phongo_commandstartedevent_ce->create_object = phongo_commandstartedevent_create_object;
 
 	memcpy(&phongo_handler_commandstartedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_commandstartedevent.get_debug_info = phongo_commandstartedevent_get_debug_info;
-	phongo_handler_commandstartedevent.free_obj       = phongo_commandstartedevent_free_object;
-	phongo_handler_commandstartedevent.offset         = XtOffsetOf(phongo_commandstartedevent_t, std);
+	phongo_handler_commandstartedevent.free_obj = phongo_commandstartedevent_free_object;
+	phongo_handler_commandstartedevent.offset   = XtOffsetOf(phongo_commandstartedevent_t, std);
+}
+
+void phongo_commandstartedevent_init(zval* return_value, const mongoc_apm_command_started_t* event)
+{
+	PHONGO_INTERN_INIT_EX(commandstartedevent, return_value);
+
+	memcpy(&intern->host, mongoc_apm_command_started_get_host(event), sizeof(mongoc_host_list_t));
+
+	intern->command_name         = estrdup(mongoc_apm_command_started_get_command_name(event));
+	intern->database_name        = estrdup(mongoc_apm_command_started_get_database_name(event));
+	intern->server_id            = mongoc_apm_command_started_get_server_id(event);
+	intern->operation_id         = mongoc_apm_command_started_get_operation_id(event);
+	intern->request_id           = mongoc_apm_command_started_get_request_id(event);
+	intern->command              = bson_copy(mongoc_apm_command_started_get_command(event));
+	intern->server_connection_id = mongoc_apm_command_started_get_server_connection_id_int64(event);
+	intern->has_service_id       = mongoc_apm_command_started_get_service_id(event) != NULL;
+
+	if (intern->has_service_id) {
+		bson_oid_copy(mongoc_apm_command_started_get_service_id(event), &intern->service_id);
+	}
+
+	phongo_commandstartedevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/CommandStartedEvent.stub.php
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.stub.php
@@ -10,6 +10,16 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class CommandStartedEvent
 {
+    public readonly string $host;
+    public readonly int $port;
+    public readonly string $commandName;
+    public readonly string $databaseName;
+    public readonly object $command;
+    public readonly string $operationId;
+    public readonly string $requestId;
+    public readonly ?\MongoDB\BSON\ObjectId $serviceId;
+    public readonly ?int $serverConnectionId;
+
     final private function __construct() {}
 
     final public function getCommand(): object {}

--- a/src/MongoDB/Monitoring/CommandStartedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandStartedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c52ae0c5f78d5a61839b24517cc7823f7d9701ad */
+ * Stub hash: 4201347a0af241aed07d3a2a638af34a7cc17425 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandStartedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -61,6 +61,61 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandStarted
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "CommandStartedEvent", class_MongoDB_Driver_Monitoring_CommandStartedEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
+	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_host_name);
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
+	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_port_name);
+
+	zval property_commandName_default_value;
+	ZVAL_UNDEF(&property_commandName_default_value);
+	zend_string *property_commandName_name = zend_string_init("commandName", sizeof("commandName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_commandName_name, &property_commandName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_commandName_name);
+
+	zval property_databaseName_default_value;
+	ZVAL_UNDEF(&property_databaseName_default_value);
+	zend_string *property_databaseName_name = zend_string_init("databaseName", sizeof("databaseName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_databaseName_name);
+
+	zval property_command_default_value;
+	ZVAL_UNDEF(&property_command_default_value);
+	zend_string *property_command_name = zend_string_init("command", sizeof("command") - 1, 1);
+	zend_declare_typed_property(class_entry, property_command_name, &property_command_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
+	zend_string_release(property_command_name);
+
+	zval property_operationId_default_value;
+	ZVAL_UNDEF(&property_operationId_default_value);
+	zend_string *property_operationId_name = zend_string_init("operationId", sizeof("operationId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_operationId_name, &property_operationId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_operationId_name);
+
+	zval property_requestId_default_value;
+	ZVAL_UNDEF(&property_requestId_default_value);
+	zend_string *property_requestId_name = zend_string_init("requestId", sizeof("requestId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_requestId_name, &property_requestId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_requestId_name);
+
+	zend_string *property_serviceId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zval property_serviceId_default_value;
+	ZVAL_UNDEF(&property_serviceId_default_value);
+	zend_string *property_serviceId_name = zend_string_init("serviceId", sizeof("serviceId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_serviceId_name, &property_serviceId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_serviceId_class_MongoDB_BSON_ObjectId, 0, MAY_BE_NULL));
+	zend_string_release(property_serviceId_name);
+
+	zval property_serverConnectionId_default_value;
+	ZVAL_UNDEF(&property_serverConnectionId_default_value);
+	zend_string *property_serverConnectionId_name = zend_string_init("serverConnectionId", sizeof("serverConnectionId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_serverConnectionId_name, &property_serverConnectionId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_serverConnectionId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -151,6 +151,49 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getServerConn
 	RETURN_LONG(intern->server_connection_id);
 }
 
+static void phongo_commandsucceededevent_update_properties(phongo_commandsucceededevent_t* intern)
+{
+	char              operation_id[24], request_id[24];
+	phongo_bson_state reply_state;
+
+	PHONGO_BSON_INIT_STATE(reply_state);
+
+	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
+	zend_update_property_long(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("commandName"), intern->command_name);
+	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("databaseName"), intern->database_name);
+	zend_update_property_long(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("durationMicros"), intern->duration_micros);
+
+	if (phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
+		zend_update_property(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("reply"), &reply_state.zchild);
+	}
+	zval_ptr_dtor(&reply_state.zchild);
+
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
+	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("operationId"), operation_id);
+
+	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
+	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("requestId"), request_id);
+
+	if (intern->has_service_id) {
+		zval service_id;
+
+		if (phongo_objectid_new(&service_id, &intern->service_id)) {
+			zend_update_property(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("serviceId"), &service_id);
+			zval_ptr_dtor(&service_id);
+		}
+	} else {
+		zend_update_property_null(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("serviceId"));
+	}
+
+	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
+	if (intern->server_connection_id == -1) {
+		zend_update_property_null(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("serverConnectionId"));
+	} else {
+		zend_update_property_long(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("serverConnectionId"), intern->server_connection_id);
+	}
+}
+
 /* MongoDB\Driver\Monitoring\CommandSucceededEvent object handlers */
 static zend_object_handlers phongo_handler_commandsucceededevent;
 
@@ -182,68 +225,35 @@ static zend_object* phongo_commandsucceededevent_create_object(zend_class_entry*
 	return &intern->std;
 }
 
-static HashTable* phongo_commandsucceededevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(commandsucceededevent, object);
-
-	zval              retval = ZVAL_STATIC_INIT;
-	char              operation_id[24], request_id[24];
-	phongo_bson_state reply_state;
-
-	PHONGO_BSON_INIT_STATE(reply_state);
-
-	*is_temp = 1;
-	array_init_size(&retval, 9);
-
-	ADD_ASSOC_STRING(&retval, "host", intern->host.host);
-	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
-	ADD_ASSOC_STRING(&retval, "commandName", intern->command_name);
-	ADD_ASSOC_INT64(&retval, "durationMicros", intern->duration_micros);
-
-	if (!phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
-		zval_ptr_dtor(&reply_state.zchild);
-		goto done;
-	}
-
-	ADD_ASSOC_ZVAL(&retval, "reply", &reply_state.zchild);
-
-	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
-	ADD_ASSOC_STRING(&retval, "operationId", operation_id);
-
-	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
-	ADD_ASSOC_STRING(&retval, "requestId", request_id);
-
-	if (intern->has_service_id) {
-		zval service_id;
-
-		if (!phongo_objectid_new(&service_id, &intern->service_id)) {
-			/* Exception should already have been thrown */
-			goto done;
-		}
-
-		ADD_ASSOC_ZVAL_EX(&retval, "serviceId", &service_id);
-	} else {
-		ADD_ASSOC_NULL_EX(&retval, "serviceId");
-	}
-
-	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (intern->server_connection_id == -1) {
-		ADD_ASSOC_NULL_EX(&retval, "serverConnectionId");
-	} else {
-		ADD_ASSOC_LONG_EX(&retval, "serverConnectionId", intern->server_connection_id);
-	}
-
-done:
-	return Z_ARRVAL(retval);
-}
-
 void phongo_commandsucceededevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_commandsucceededevent_ce                = register_class_MongoDB_Driver_Monitoring_CommandSucceededEvent();
 	phongo_commandsucceededevent_ce->create_object = phongo_commandsucceededevent_create_object;
 
 	memcpy(&phongo_handler_commandsucceededevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_commandsucceededevent.get_debug_info = phongo_commandsucceededevent_get_debug_info;
-	phongo_handler_commandsucceededevent.free_obj       = phongo_commandsucceededevent_free_object;
-	phongo_handler_commandsucceededevent.offset         = XtOffsetOf(phongo_commandsucceededevent_t, std);
+	phongo_handler_commandsucceededevent.free_obj = phongo_commandsucceededevent_free_object;
+	phongo_handler_commandsucceededevent.offset   = XtOffsetOf(phongo_commandsucceededevent_t, std);
+}
+
+void phongo_commandsucceededevent_init(zval* return_value, const mongoc_apm_command_succeeded_t* event)
+{
+	PHONGO_INTERN_INIT_EX(commandsucceededevent, return_value);
+
+	memcpy(&intern->host, mongoc_apm_command_succeeded_get_host(event), sizeof(mongoc_host_list_t));
+
+	intern->command_name         = estrdup(mongoc_apm_command_succeeded_get_command_name(event));
+	intern->database_name        = estrdup(mongoc_apm_command_succeeded_get_database_name(event));
+	intern->server_id            = mongoc_apm_command_succeeded_get_server_id(event);
+	intern->operation_id         = mongoc_apm_command_succeeded_get_operation_id(event);
+	intern->request_id           = mongoc_apm_command_succeeded_get_request_id(event);
+	intern->duration_micros      = mongoc_apm_command_succeeded_get_duration(event);
+	intern->reply                = bson_copy(mongoc_apm_command_succeeded_get_reply(event));
+	intern->server_connection_id = mongoc_apm_command_succeeded_get_server_connection_id_int64(event);
+	intern->has_service_id       = mongoc_apm_command_succeeded_get_service_id(event) != NULL;
+
+	if (intern->has_service_id) {
+		bson_oid_copy(mongoc_apm_command_succeeded_get_service_id(event), &intern->service_id);
+	}
+
+	phongo_commandsucceededevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.stub.php
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.stub.php
@@ -10,6 +10,17 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class CommandSucceededEvent
 {
+    public readonly string $host;
+    public readonly int $port;
+    public readonly string $commandName;
+    public readonly string $databaseName;
+    public readonly int $durationMicros;
+    public readonly object $reply;
+    public readonly string $operationId;
+    public readonly string $requestId;
+    public readonly ?\MongoDB\BSON\ObjectId $serviceId;
+    public readonly ?int $serverConnectionId;
+
     final private function __construct() {}
 
     final public function getCommandName(): string {}

--- a/src/MongoDB/Monitoring/CommandSucceededEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d2dfb06b218c9da74356d1b8b322eb79d50e4f90 */
+ * Stub hash: 97e5abaecaa34efe4cddf058cd701ec5c2890b96 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSucceededEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -65,6 +65,67 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandSucceed
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "CommandSucceededEvent", class_MongoDB_Driver_Monitoring_CommandSucceededEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
+	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_host_name);
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
+	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_port_name);
+
+	zval property_commandName_default_value;
+	ZVAL_UNDEF(&property_commandName_default_value);
+	zend_string *property_commandName_name = zend_string_init("commandName", sizeof("commandName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_commandName_name, &property_commandName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_commandName_name);
+
+	zval property_databaseName_default_value;
+	ZVAL_UNDEF(&property_databaseName_default_value);
+	zend_string *property_databaseName_name = zend_string_init("databaseName", sizeof("databaseName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_databaseName_name);
+
+	zval property_durationMicros_default_value;
+	ZVAL_UNDEF(&property_durationMicros_default_value);
+	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
+	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_durationMicros_name);
+
+	zval property_reply_default_value;
+	ZVAL_UNDEF(&property_reply_default_value);
+	zend_string *property_reply_name = zend_string_init("reply", sizeof("reply") - 1, 1);
+	zend_declare_typed_property(class_entry, property_reply_name, &property_reply_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
+	zend_string_release(property_reply_name);
+
+	zval property_operationId_default_value;
+	ZVAL_UNDEF(&property_operationId_default_value);
+	zend_string *property_operationId_name = zend_string_init("operationId", sizeof("operationId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_operationId_name, &property_operationId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_operationId_name);
+
+	zval property_requestId_default_value;
+	ZVAL_UNDEF(&property_requestId_default_value);
+	zend_string *property_requestId_name = zend_string_init("requestId", sizeof("requestId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_requestId_name, &property_requestId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_requestId_name);
+
+	zend_string *property_serviceId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zval property_serviceId_default_value;
+	ZVAL_UNDEF(&property_serviceId_default_value);
+	zend_string *property_serviceId_name = zend_string_init("serviceId", sizeof("serviceId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_serviceId_name, &property_serviceId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_serviceId_class_MongoDB_BSON_ObjectId, 0, MAY_BE_NULL));
+	zend_string_release(property_serviceId_name);
+
+	zval property_serverConnectionId_default_value;
+	ZVAL_UNDEF(&property_serverConnectionId_default_value);
+	zend_string *property_serverConnectionId_name = zend_string_init("serverConnectionId", sizeof("serverConnectionId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_serverConnectionId_name, &property_serverConnectionId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_serverConnectionId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerChangedEvent.c
+++ b/src/MongoDB/Monitoring/ServerChangedEvent.c
@@ -81,6 +81,27 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_ServerChangedEvent, getTopologyId)
 	phongo_objectid_new(return_value, &intern->topology_id);
 }
 
+static void phongo_serverchangedevent_update_properties(phongo_serverchangedevent_t* intern)
+{
+	zval topology_id, new_sd, old_sd;
+
+	zend_update_property_string(phongo_serverchangedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
+	zend_update_property_long(phongo_serverchangedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+
+	if (phongo_objectid_new(&topology_id, &intern->topology_id)) {
+		zend_update_property(phongo_serverchangedevent_ce, &intern->std, ZEND_STRL("topologyId"), &topology_id);
+		zval_ptr_dtor(&topology_id);
+	}
+
+	phongo_serverdescription_init(&new_sd, intern->new_server_description);
+	zend_update_property(phongo_serverchangedevent_ce, &intern->std, ZEND_STRL("newDescription"), &new_sd);
+	zval_ptr_dtor(&new_sd);
+
+	phongo_serverdescription_init(&old_sd, intern->old_server_description);
+	zend_update_property(phongo_serverchangedevent_ce, &intern->std, ZEND_STRL("previousDescription"), &old_sd);
+	zval_ptr_dtor(&old_sd);
+}
+
 /* MongoDB\Driver\Monitoring\ServerChangedEvent object handlers */
 static zend_object_handlers phongo_handler_serverchangedevent;
 
@@ -108,52 +129,24 @@ static zend_object* phongo_serverchangedevent_create_object(zend_class_entry* cl
 	return &intern->std;
 }
 
-static HashTable* phongo_serverchangedevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serverchangedevent, object);
-
-	zval retval = ZVAL_STATIC_INIT;
-
-	*is_temp = 1;
-	array_init_size(&retval, 4);
-
-	ADD_ASSOC_STRING(&retval, "host", intern->host.host);
-	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
-
-	{
-		zval topology_id;
-
-		if (!phongo_objectid_new(&topology_id, &intern->topology_id)) {
-			/* Exception should already have been thrown */
-			goto done;
-		}
-
-		ADD_ASSOC_ZVAL_EX(&retval, "topologyId", &topology_id);
-	}
-
-	{
-		zval new_sd;
-		phongo_serverdescription_init(&new_sd, intern->new_server_description);
-		ADD_ASSOC_ZVAL_EX(&retval, "newDescription", &new_sd);
-	}
-
-	{
-		zval old_sd;
-		phongo_serverdescription_init(&old_sd, intern->old_server_description);
-		ADD_ASSOC_ZVAL_EX(&retval, "oldDescription", &old_sd);
-	}
-
-done:
-	return Z_ARRVAL(retval);
-}
-
 void phongo_serverchangedevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_serverchangedevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerChangedEvent();
 	phongo_serverchangedevent_ce->create_object = phongo_serverchangedevent_create_object;
 
 	memcpy(&phongo_handler_serverchangedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serverchangedevent.get_debug_info = phongo_serverchangedevent_get_debug_info;
-	phongo_handler_serverchangedevent.free_obj       = phongo_serverchangedevent_free_object;
-	phongo_handler_serverchangedevent.offset         = XtOffsetOf(phongo_serverchangedevent_t, std);
+	phongo_handler_serverchangedevent.free_obj = phongo_serverchangedevent_free_object;
+	phongo_handler_serverchangedevent.offset   = XtOffsetOf(phongo_serverchangedevent_t, std);
+}
+
+void phongo_serverchangedevent_init(zval* return_value, const mongoc_apm_server_changed_t* event)
+{
+	PHONGO_INTERN_INIT_EX(serverchangedevent, return_value);
+
+	memcpy(&intern->host, mongoc_apm_server_changed_get_host(event), sizeof(mongoc_host_list_t));
+	mongoc_apm_server_changed_get_topology_id(event, &intern->topology_id);
+	intern->new_server_description = mongoc_server_description_new_copy(mongoc_apm_server_changed_get_new_description(event));
+	intern->old_server_description = mongoc_server_description_new_copy(mongoc_apm_server_changed_get_previous_description(event));
+
+	phongo_serverchangedevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/ServerChangedEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerChangedEvent.stub.php
@@ -10,6 +10,12 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class ServerChangedEvent
 {
+    public readonly string $host;
+    public readonly int $port;
+    public readonly \MongoDB\BSON\ObjectId $topologyId;
+    public readonly \MongoDB\Driver\ServerDescription $newDescription;
+    public readonly \MongoDB\Driver\ServerDescription $previousDescription;
+
     final private function __construct() {}
 
     final public function getPort(): int {}

--- a/src/MongoDB/Monitoring/ServerChangedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerChangedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d681e2e9936f0846fe8ee7fa6eb25bb218d85902 */
+ * Stub hash: 3433024518babbd96607749cfd0380ddb21cc5ce */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerChangedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -44,6 +44,39 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerChangedE
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerChangedEvent", class_MongoDB_Driver_Monitoring_ServerChangedEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
+	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_host_name);
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
+	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_port_name);
+
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
+
+	zend_string *property_newDescription_class_MongoDB_Driver_ServerDescription = zend_string_init("MongoDB\\Driver\\ServerDescription", sizeof("MongoDB\\Driver\\ServerDescription")-1, 1);
+	zval property_newDescription_default_value;
+	ZVAL_UNDEF(&property_newDescription_default_value);
+	zend_string *property_newDescription_name = zend_string_init("newDescription", sizeof("newDescription") - 1, 1);
+	zend_declare_typed_property(class_entry, property_newDescription_name, &property_newDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_newDescription_class_MongoDB_Driver_ServerDescription, 0, 0));
+	zend_string_release(property_newDescription_name);
+
+	zend_string *property_previousDescription_class_MongoDB_Driver_ServerDescription = zend_string_init("MongoDB\\Driver\\ServerDescription", sizeof("MongoDB\\Driver\\ServerDescription")-1, 1);
+	zval property_previousDescription_default_value;
+	ZVAL_UNDEF(&property_previousDescription_default_value);
+	zend_string *property_previousDescription_name = zend_string_init("previousDescription", sizeof("previousDescription") - 1, 1);
+	zend_declare_typed_property(class_entry, property_previousDescription_name, &property_previousDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousDescription_class_MongoDB_Driver_ServerDescription, 0, 0));
+	zend_string_release(property_previousDescription_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerClosedEvent.c
+++ b/src/MongoDB/Monitoring/ServerClosedEvent.c
@@ -57,6 +57,19 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, getTopologyId)
 	phongo_objectid_new(return_value, &intern->topology_id);
 }
 
+static void phongo_serverclosedevent_update_properties(phongo_serverclosedevent_t* intern)
+{
+	zval topology_id;
+
+	zend_update_property_string(phongo_serverclosedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
+	zend_update_property_long(phongo_serverclosedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+
+	if (phongo_objectid_new(&topology_id, &intern->topology_id)) {
+		zend_update_property(phongo_serverclosedevent_ce, &intern->std, ZEND_STRL("topologyId"), &topology_id);
+		zval_ptr_dtor(&topology_id);
+	}
+}
+
 /* MongoDB\Driver\Monitoring\ServerClosedEvent object handlers */
 static zend_object_handlers phongo_handler_serverclosedevent;
 
@@ -76,40 +89,22 @@ static zend_object* phongo_serverclosedevent_create_object(zend_class_entry* cla
 	return &intern->std;
 }
 
-static HashTable* phongo_serverclosedevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serverclosedevent, object);
-
-	zval retval = ZVAL_STATIC_INIT;
-
-	*is_temp = 1;
-	array_init_size(&retval, 3);
-
-	ADD_ASSOC_STRING(&retval, "host", intern->host.host);
-	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
-
-	{
-		zval topology_id;
-
-		if (!phongo_objectid_new(&topology_id, &intern->topology_id)) {
-			/* Exception should already have been thrown */
-			goto done;
-		}
-
-		ADD_ASSOC_ZVAL_EX(&retval, "topologyId", &topology_id);
-	}
-
-done:
-	return Z_ARRVAL(retval);
-}
-
 void phongo_serverclosedevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_serverclosedevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerClosedEvent();
 	phongo_serverclosedevent_ce->create_object = phongo_serverclosedevent_create_object;
 
 	memcpy(&phongo_handler_serverclosedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serverclosedevent.get_debug_info = phongo_serverclosedevent_get_debug_info;
-	phongo_handler_serverclosedevent.free_obj       = phongo_serverclosedevent_free_object;
-	phongo_handler_serverclosedevent.offset         = XtOffsetOf(phongo_serverclosedevent_t, std);
+	phongo_handler_serverclosedevent.free_obj = phongo_serverclosedevent_free_object;
+	phongo_handler_serverclosedevent.offset   = XtOffsetOf(phongo_serverclosedevent_t, std);
+}
+
+void phongo_serverclosedevent_init(zval* return_value, const mongoc_apm_server_closed_t* event)
+{
+	PHONGO_INTERN_INIT_EX(serverclosedevent, return_value);
+
+	memcpy(&intern->host, mongoc_apm_server_closed_get_host(event), sizeof(mongoc_host_list_t));
+	mongoc_apm_server_closed_get_topology_id(event, &intern->topology_id);
+
+	phongo_serverclosedevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/ServerClosedEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerClosedEvent.stub.php
@@ -10,6 +10,10 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class ServerClosedEvent
 {
+    public readonly string $host;
+    public readonly int $port;
+    public readonly \MongoDB\BSON\ObjectId $topologyId;
+
     final private function __construct() {}
 
     final public function getPort(): int {}

--- a/src/MongoDB/Monitoring/ServerClosedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerClosedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 05a48b4966fb49c82a6ef48b360a93fdc2919f77 */
+ * Stub hash: a2c6e5876d344618d543ff0e4c76794d9f82624c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerClosedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -35,6 +35,25 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerClosedEv
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerClosedEvent", class_MongoDB_Driver_Monitoring_ServerClosedEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
+	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_host_name);
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
+	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_port_name);
+
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.c
@@ -16,6 +16,7 @@
 
 #include <php.h>
 #include <Zend/zend_interfaces.h>
+#include <Zend/zend_exceptions.h>
 
 #include "phongo.h"
 #include "phongo_error.h"
@@ -75,6 +76,15 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, isAwaite
 	RETVAL_BOOL(intern->awaited);
 }
 
+static void phongo_serverheartbeatfailedevent_update_properties(phongo_serverheartbeatfailedevent_t* intern)
+{
+	zend_update_property_string(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
+	zend_update_property_long(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+	zend_update_property_bool(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("awaited"), intern->awaited);
+	zend_update_property_long(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("durationMicros"), intern->duration_micros);
+	zend_update_property(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("error"), &intern->z_error);
+}
+
 /* MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent object handlers */
 static zend_object_handlers phongo_handler_serverheartbeatfailedevent;
 
@@ -98,33 +108,34 @@ static zend_object* phongo_serverheartbeatfailedevent_create_object(zend_class_e
 	return &intern->std;
 }
 
-static HashTable* phongo_serverheartbeatfailedevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serverheartbeatfailedevent, object);
-
-	zval retval = ZVAL_STATIC_INIT;
-
-	*is_temp = 1;
-	array_init_size(&retval, 5);
-
-	ADD_ASSOC_STRING(&retval, "host", intern->host.host);
-	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
-	ADD_ASSOC_BOOL_EX(&retval, "awaited", intern->awaited);
-	ADD_ASSOC_INT64(&retval, "durationMicros", intern->duration_micros);
-
-	ADD_ASSOC_ZVAL_EX(&retval, "error", &intern->z_error);
-	Z_ADDREF(intern->z_error);
-
-	return Z_ARRVAL(retval);
-}
-
 void phongo_serverheartbeatfailedevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_serverheartbeatfailedevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent();
 	phongo_serverheartbeatfailedevent_ce->create_object = phongo_serverheartbeatfailedevent_create_object;
 
 	memcpy(&phongo_handler_serverheartbeatfailedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serverheartbeatfailedevent.get_debug_info = phongo_serverheartbeatfailedevent_get_debug_info;
-	phongo_handler_serverheartbeatfailedevent.free_obj       = phongo_serverheartbeatfailedevent_free_object;
-	phongo_handler_serverheartbeatfailedevent.offset         = XtOffsetOf(phongo_serverheartbeatfailedevent_t, std);
+	phongo_handler_serverheartbeatfailedevent.free_obj = phongo_serverheartbeatfailedevent_free_object;
+	phongo_handler_serverheartbeatfailedevent.offset   = XtOffsetOf(phongo_serverheartbeatfailedevent_t, std);
+}
+
+void phongo_serverheartbeatfailedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_failed_t* event)
+{
+	PHONGO_INTERN_INIT_EX(serverheartbeatfailedevent, return_value);
+
+	bson_error_t tmp_error = { 0 };
+
+	memcpy(&intern->host, mongoc_apm_server_heartbeat_failed_get_host(event), sizeof(mongoc_host_list_t));
+	intern->awaited         = mongoc_apm_server_heartbeat_failed_get_awaited(event);
+	intern->duration_micros = mongoc_apm_server_heartbeat_failed_get_duration(event);
+
+	/* We need to process and convert the error right here, otherwise
+	 * debug_info will turn into a recursive loop, and with the wrong trace
+	 * locations */
+	mongoc_apm_server_heartbeat_failed_get_error(event, &tmp_error);
+
+	object_init_ex(&intern->z_error, phongo_exception_from_mongoc_domain(tmp_error.domain, tmp_error.code));
+	zend_update_property_string(zend_ce_exception, Z_OBJ_P(&intern->z_error), ZEND_STRL("message"), tmp_error.message);
+	zend_update_property_long(zend_ce_exception, Z_OBJ_P(&intern->z_error), ZEND_STRL("code"), tmp_error.code);
+
+	phongo_serverheartbeatfailedevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.stub.php
@@ -10,9 +10,15 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class ServerHeartbeatFailedEvent
 {
+    public readonly string $host;
+    public readonly int $port;
+    public readonly bool $awaited;
+    public readonly int $durationMicros;
+    public readonly \Exception $error;
+
     final private function __construct() {}
 
-    final public function getDurationMicros() : int{}
+    final public function getDurationMicros(): int {}
 
     final public function getError(): \Exception {}
 

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ba0a81f27f99579e332ef8d3a3a477b3ebe1ec31 */
+ * Stub hash: b78a5918928c8b54c49f380978e527c15db14bca */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -44,6 +44,37 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerHeartbeatFailedEvent", class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
+	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_host_name);
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
+	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_port_name);
+
+	zval property_awaited_default_value;
+	ZVAL_UNDEF(&property_awaited_default_value);
+	zend_string *property_awaited_name = zend_string_init("awaited", sizeof("awaited") - 1, 1);
+	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_awaited_name);
+
+	zval property_durationMicros_default_value;
+	ZVAL_UNDEF(&property_durationMicros_default_value);
+	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
+	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_durationMicros_name);
+
+	zend_string *property_error_class_Exception = zend_string_init("Exception", sizeof("Exception")-1, 1);
+	zval property_error_default_value;
+	ZVAL_UNDEF(&property_error_default_value);
+	zend_string *property_error_name = zend_string_init("error", sizeof("error") - 1, 1);
+	zend_declare_typed_property(class_entry, property_error_name, &property_error_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_error_class_Exception, 0, 0));
+	zend_string_release(property_error_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.c
@@ -55,6 +55,13 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, isAwait
 	RETVAL_BOOL(intern->awaited);
 }
 
+static void phongo_serverheartbeatstartedevent_update_properties(phongo_serverheartbeatstartedevent_t* intern)
+{
+	zend_update_property_string(phongo_serverheartbeatstartedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
+	zend_update_property_long(phongo_serverheartbeatstartedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+	zend_update_property_bool(phongo_serverheartbeatstartedevent_ce, &intern->std, ZEND_STRL("awaited"), intern->awaited);
+}
+
 /* MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent object handlers */
 static zend_object_handlers phongo_handler_serverheartbeatstartedevent;
 
@@ -74,31 +81,22 @@ static zend_object* phongo_serverheartbeatstartedevent_create_object(zend_class_
 	return &intern->std;
 }
 
-static HashTable* phongo_serverheartbeatstartedevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serverheartbeatstartedevent, object);
-
-	zval retval = ZVAL_STATIC_INIT;
-
-	*is_temp = 1;
-	array_init_size(&retval, 4);
-
-	ADD_ASSOC_STRING(&retval, "host", intern->host.host);
-	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
-	ADD_ASSOC_BOOL_EX(&retval, "awaited", intern->awaited);
-
-	return Z_ARRVAL(retval);
-}
-
 void phongo_serverheartbeatstartedevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_serverheartbeatstartedevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent();
 	phongo_serverheartbeatstartedevent_ce->create_object = phongo_serverheartbeatstartedevent_create_object;
 
 	memcpy(&phongo_handler_serverheartbeatstartedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serverheartbeatstartedevent.get_debug_info = phongo_serverheartbeatstartedevent_get_debug_info;
-	phongo_handler_serverheartbeatstartedevent.free_obj       = phongo_serverheartbeatstartedevent_free_object;
-	phongo_handler_serverheartbeatstartedevent.offset         = XtOffsetOf(phongo_serverheartbeatstartedevent_t, std);
+	phongo_handler_serverheartbeatstartedevent.free_obj = phongo_serverheartbeatstartedevent_free_object;
+	phongo_handler_serverheartbeatstartedevent.offset   = XtOffsetOf(phongo_serverheartbeatstartedevent_t, std);
+}
 
-	return;
+void phongo_serverheartbeatstartedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_started_t* event)
+{
+	PHONGO_INTERN_INIT_EX(serverheartbeatstartedevent, return_value);
+
+	memcpy(&intern->host, mongoc_apm_server_heartbeat_started_get_host(event), sizeof(mongoc_host_list_t));
+	intern->awaited = mongoc_apm_server_heartbeat_started_get_awaited(event);
+
+	phongo_serverheartbeatstartedevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.stub.php
@@ -10,6 +10,10 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class ServerHeartbeatStartedEvent
 {
+    public readonly string $host;
+    public readonly int $port;
+    public readonly bool $awaited;
+
     final private function __construct() {}
 
     final public function getPort(): int {}

--- a/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7cb420cf908d682f770a9dbc20473e075af9ce53 */
+ * Stub hash: 9a0f4bf9a1ac308158f596c4c6010a094bca3e7e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -35,6 +35,24 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerHeartbeatStartedEvent", class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
+	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_host_name);
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
+	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_port_name);
+
+	zval property_awaited_default_value;
+	ZVAL_UNDEF(&property_awaited_default_value);
+	zend_string *property_awaited_name = zend_string_init("awaited", sizeof("awaited") - 1, 1);
+	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_awaited_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
@@ -84,6 +84,23 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, isAwa
 	RETVAL_BOOL(intern->awaited);
 }
 
+static void phongo_serverheartbeatsucceededevent_update_properties(phongo_serverheartbeatsucceededevent_t* intern)
+{
+	phongo_bson_state reply_state;
+
+	PHONGO_BSON_INIT_STATE(reply_state);
+
+	zend_update_property_string(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
+	zend_update_property_long(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+	zend_update_property_bool(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("awaited"), intern->awaited);
+	zend_update_property_long(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("durationMicros"), intern->duration_micros);
+
+	if (phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
+		zend_update_property(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("reply"), &reply_state.zchild);
+	}
+	zval_ptr_dtor(&reply_state.zchild);
+}
+
 /* MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent object handlers */
 static zend_object_handlers phongo_handler_serverheartbeatsucceededevent;
 
@@ -107,43 +124,24 @@ static zend_object* phongo_serverheartbeatsucceededevent_create_object(zend_clas
 	return &intern->std;
 }
 
-static HashTable* phongo_serverheartbeatsucceededevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serverheartbeatsucceededevent, object);
-
-	zval              retval = ZVAL_STATIC_INIT;
-	phongo_bson_state reply_state;
-
-	PHONGO_BSON_INIT_STATE(reply_state);
-
-	*is_temp = 1;
-	array_init_size(&retval, 4);
-
-	ADD_ASSOC_STRING(&retval, "host", intern->host.host);
-	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
-	ADD_ASSOC_BOOL_EX(&retval, "awaited", intern->awaited);
-	ADD_ASSOC_INT64(&retval, "durationMicros", intern->duration_micros);
-
-	if (!phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
-		zval_ptr_dtor(&reply_state.zchild);
-		goto done;
-	}
-
-	ADD_ASSOC_ZVAL(&retval, "reply", &reply_state.zchild);
-
-done:
-	return Z_ARRVAL(retval);
-}
-
 void phongo_serverheartbeatsucceededevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_serverheartbeatsucceededevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent();
 	phongo_serverheartbeatsucceededevent_ce->create_object = phongo_serverheartbeatsucceededevent_create_object;
 
 	memcpy(&phongo_handler_serverheartbeatsucceededevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serverheartbeatsucceededevent.get_debug_info = phongo_serverheartbeatsucceededevent_get_debug_info;
-	phongo_handler_serverheartbeatsucceededevent.free_obj       = phongo_serverheartbeatsucceededevent_free_object;
-	phongo_handler_serverheartbeatsucceededevent.offset         = XtOffsetOf(phongo_serverheartbeatsucceededevent_t, std);
+	phongo_handler_serverheartbeatsucceededevent.free_obj = phongo_serverheartbeatsucceededevent_free_object;
+	phongo_handler_serverheartbeatsucceededevent.offset   = XtOffsetOf(phongo_serverheartbeatsucceededevent_t, std);
+}
 
-	return;
+void phongo_serverheartbeatsucceededevent_init(zval* return_value, const mongoc_apm_server_heartbeat_succeeded_t* event)
+{
+	PHONGO_INTERN_INIT_EX(serverheartbeatsucceededevent, return_value);
+
+	memcpy(&intern->host, mongoc_apm_server_heartbeat_succeeded_get_host(event), sizeof(mongoc_host_list_t));
+	intern->awaited         = mongoc_apm_server_heartbeat_succeeded_get_awaited(event);
+	intern->duration_micros = mongoc_apm_server_heartbeat_succeeded_get_duration(event);
+	intern->reply           = bson_copy(mongoc_apm_server_heartbeat_succeeded_get_reply(event));
+
+	phongo_serverheartbeatsucceededevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.stub.php
@@ -10,9 +10,15 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class ServerHeartbeatSucceededEvent
 {
+    public readonly string $host;
+    public readonly int $port;
+    public readonly bool $awaited;
+    public readonly int $durationMicros;
+    public readonly object $reply;
+
     final private function __construct() {}
 
-    final public function getDurationMicros() : int{}
+    final public function getDurationMicros(): int {}
 
     final public function getReply(): object {}
 

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dce5c76853a5c0a532be89796806527d37d018a1 */
+ * Stub hash: 92a37524aa7fdab043eabba7407db7d44ebcd472 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -44,6 +44,36 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerHeartbeatSucceededEvent", class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
+	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_host_name);
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
+	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_port_name);
+
+	zval property_awaited_default_value;
+	ZVAL_UNDEF(&property_awaited_default_value);
+	zend_string *property_awaited_name = zend_string_init("awaited", sizeof("awaited") - 1, 1);
+	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_awaited_name);
+
+	zval property_durationMicros_default_value;
+	ZVAL_UNDEF(&property_durationMicros_default_value);
+	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
+	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_durationMicros_name);
+
+	zval property_reply_default_value;
+	ZVAL_UNDEF(&property_reply_default_value);
+	zend_string *property_reply_name = zend_string_init("reply", sizeof("reply") - 1, 1);
+	zend_declare_typed_property(class_entry, property_reply_name, &property_reply_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
+	zend_string_release(property_reply_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerOpeningEvent.c
+++ b/src/MongoDB/Monitoring/ServerOpeningEvent.c
@@ -57,6 +57,19 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, getTopologyId)
 	phongo_objectid_new(return_value, &intern->topology_id);
 }
 
+static void phongo_serveropeningevent_update_properties(phongo_serveropeningevent_t* intern)
+{
+	zval topology_id;
+
+	zend_update_property_string(phongo_serveropeningevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
+	zend_update_property_long(phongo_serveropeningevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+
+	if (phongo_objectid_new(&topology_id, &intern->topology_id)) {
+		zend_update_property(phongo_serveropeningevent_ce, &intern->std, ZEND_STRL("topologyId"), &topology_id);
+		zval_ptr_dtor(&topology_id);
+	}
+}
+
 /* MongoDB\Driver\Monitoring\ServerOpeningEvent object handlers */
 static zend_object_handlers phongo_handler_serveropeningevent;
 
@@ -76,40 +89,22 @@ static zend_object* phongo_serveropeningevent_create_object(zend_class_entry* cl
 	return &intern->std;
 }
 
-static HashTable* phongo_serveropeningevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serveropeningevent, object);
-
-	zval retval = ZVAL_STATIC_INIT;
-
-	*is_temp = 1;
-	array_init_size(&retval, 3);
-
-	ADD_ASSOC_STRING(&retval, "host", intern->host.host);
-	ADD_ASSOC_LONG_EX(&retval, "port", intern->host.port);
-
-	{
-		zval topology_id;
-
-		if (!phongo_objectid_new(&topology_id, &intern->topology_id)) {
-			/* Exception should already have been thrown */
-			goto done;
-		}
-
-		ADD_ASSOC_ZVAL_EX(&retval, "topologyId", &topology_id);
-	}
-
-done:
-	return Z_ARRVAL(retval);
-}
-
 void phongo_serveropeningevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_serveropeningevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerOpeningEvent();
 	phongo_serveropeningevent_ce->create_object = phongo_serveropeningevent_create_object;
 
 	memcpy(&phongo_handler_serveropeningevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serveropeningevent.get_debug_info = phongo_serveropeningevent_get_debug_info;
-	phongo_handler_serveropeningevent.free_obj       = phongo_serveropeningevent_free_object;
-	phongo_handler_serveropeningevent.offset         = XtOffsetOf(phongo_serveropeningevent_t, std);
+	phongo_handler_serveropeningevent.free_obj = phongo_serveropeningevent_free_object;
+	phongo_handler_serveropeningevent.offset   = XtOffsetOf(phongo_serveropeningevent_t, std);
+}
+
+void phongo_serveropeningevent_init(zval* return_value, const mongoc_apm_server_opening_t* event)
+{
+	PHONGO_INTERN_INIT_EX(serveropeningevent, return_value);
+
+	memcpy(&intern->host, mongoc_apm_server_opening_get_host(event), sizeof(mongoc_host_list_t));
+	mongoc_apm_server_opening_get_topology_id(event, &intern->topology_id);
+
+	phongo_serveropeningevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/ServerOpeningEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerOpeningEvent.stub.php
@@ -10,6 +10,10 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class ServerOpeningEvent
 {
+    public readonly string $host;
+    public readonly int $port;
+    public readonly \MongoDB\BSON\ObjectId $topologyId;
+
     final private function __construct() {}
 
     final public function getPort(): int {}

--- a/src/MongoDB/Monitoring/ServerOpeningEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerOpeningEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 017f3508070fe14083d8839f97ad0d6788470639 */
+ * Stub hash: d7f6e4ad2b7b44634cbcbc665db33bf6e0d4de4c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerOpeningEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -35,6 +35,25 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerOpeningE
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerOpeningEvent", class_MongoDB_Driver_Monitoring_ServerOpeningEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
+	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_host_name);
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
+	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_port_name);
+
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/TopologyChangedEvent.c
+++ b/src/MongoDB/Monitoring/TopologyChangedEvent.c
@@ -60,6 +60,24 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_TopologyChangedEvent, getTopologyId)
 	phongo_objectid_new(return_value, &intern->topology_id);
 }
 
+static void phongo_topologychangedevent_update_properties(phongo_topologychangedevent_t* intern)
+{
+	zval topology_id, new_td, old_td;
+
+	if (phongo_objectid_new(&topology_id, &intern->topology_id)) {
+		zend_update_property(phongo_topologychangedevent_ce, &intern->std, ZEND_STRL("topologyId"), &topology_id);
+		zval_ptr_dtor(&topology_id);
+	}
+
+	phongo_topologydescription_init(&new_td, intern->new_topology_description);
+	zend_update_property(phongo_topologychangedevent_ce, &intern->std, ZEND_STRL("newDescription"), &new_td);
+	zval_ptr_dtor(&new_td);
+
+	phongo_topologydescription_init(&old_td, intern->old_topology_description);
+	zend_update_property(phongo_topologychangedevent_ce, &intern->std, ZEND_STRL("previousDescription"), &old_td);
+	zval_ptr_dtor(&old_td);
+}
+
 /* MongoDB\Driver\Monitoring\TopologyChangedEvent object handlers */
 static zend_object_handlers phongo_handler_topologychangedevent;
 
@@ -87,49 +105,23 @@ static zend_object* phongo_topologychangedevent_create_object(zend_class_entry* 
 	return &intern->std;
 }
 
-static HashTable* phongo_topologychangedevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(topologychangedevent, object);
-
-	zval retval = ZVAL_STATIC_INIT;
-
-	*is_temp = 1;
-	array_init_size(&retval, 3);
-
-	{
-		zval topology_id;
-
-		if (!phongo_objectid_new(&topology_id, &intern->topology_id)) {
-			/* Exception should already have been thrown */
-			goto done;
-		}
-
-		ADD_ASSOC_ZVAL_EX(&retval, "topologyId", &topology_id);
-	}
-
-	{
-		zval new_td;
-		phongo_topologydescription_init(&new_td, intern->new_topology_description);
-		ADD_ASSOC_ZVAL_EX(&retval, "newDescription", &new_td);
-	}
-
-	{
-		zval old_td;
-		phongo_topologydescription_init(&old_td, intern->old_topology_description);
-		ADD_ASSOC_ZVAL_EX(&retval, "oldDescription", &old_td);
-	}
-
-done:
-	return Z_ARRVAL(retval);
-}
-
 void phongo_topologychangedevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_topologychangedevent_ce                = register_class_MongoDB_Driver_Monitoring_TopologyChangedEvent();
 	phongo_topologychangedevent_ce->create_object = phongo_topologychangedevent_create_object;
 
 	memcpy(&phongo_handler_topologychangedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_topologychangedevent.get_debug_info = phongo_topologychangedevent_get_debug_info;
-	phongo_handler_topologychangedevent.free_obj       = phongo_topologychangedevent_free_object;
-	phongo_handler_topologychangedevent.offset         = XtOffsetOf(phongo_topologychangedevent_t, std);
+	phongo_handler_topologychangedevent.free_obj = phongo_topologychangedevent_free_object;
+	phongo_handler_topologychangedevent.offset   = XtOffsetOf(phongo_topologychangedevent_t, std);
+}
+
+void phongo_topologychangedevent_init(zval* return_value, const mongoc_apm_topology_changed_t* event)
+{
+	PHONGO_INTERN_INIT_EX(topologychangedevent, return_value);
+
+	mongoc_apm_topology_changed_get_topology_id(event, &intern->topology_id);
+	intern->new_topology_description = mongoc_topology_description_new_copy(mongoc_apm_topology_changed_get_new_description(event));
+	intern->old_topology_description = mongoc_topology_description_new_copy(mongoc_apm_topology_changed_get_previous_description(event));
+
+	phongo_topologychangedevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/TopologyChangedEvent.stub.php
+++ b/src/MongoDB/Monitoring/TopologyChangedEvent.stub.php
@@ -10,6 +10,10 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class TopologyChangedEvent
 {
+    public readonly \MongoDB\BSON\ObjectId $topologyId;
+    public readonly \MongoDB\Driver\TopologyDescription $newDescription;
+    public readonly \MongoDB\Driver\TopologyDescription $previousDescription;
+
     final private function __construct() {}
 
     final public function getNewDescription(): \MongoDB\Driver\TopologyDescription {}

--- a/src/MongoDB/Monitoring/TopologyChangedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/TopologyChangedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 20071882771d0743a38efc1d7d7d19659cfb637b */
+ * Stub hash: bc706887153f946683941d01b12945ea8cd69e91 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyChangedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -34,6 +34,27 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_TopologyChange
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "TopologyChangedEvent", class_MongoDB_Driver_Monitoring_TopologyChangedEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
+
+	zend_string *property_newDescription_class_MongoDB_Driver_TopologyDescription = zend_string_init("MongoDB\\Driver\\TopologyDescription", sizeof("MongoDB\\Driver\\TopologyDescription")-1, 1);
+	zval property_newDescription_default_value;
+	ZVAL_UNDEF(&property_newDescription_default_value);
+	zend_string *property_newDescription_name = zend_string_init("newDescription", sizeof("newDescription") - 1, 1);
+	zend_declare_typed_property(class_entry, property_newDescription_name, &property_newDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_newDescription_class_MongoDB_Driver_TopologyDescription, 0, 0));
+	zend_string_release(property_newDescription_name);
+
+	zend_string *property_previousDescription_class_MongoDB_Driver_TopologyDescription = zend_string_init("MongoDB\\Driver\\TopologyDescription", sizeof("MongoDB\\Driver\\TopologyDescription")-1, 1);
+	zval property_previousDescription_default_value;
+	ZVAL_UNDEF(&property_previousDescription_default_value);
+	zend_string *property_previousDescription_name = zend_string_init("previousDescription", sizeof("previousDescription") - 1, 1);
+	zend_declare_typed_property(class_entry, property_previousDescription_name, &property_previousDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousDescription_class_MongoDB_Driver_TopologyDescription, 0, 0));
+	zend_string_release(property_previousDescription_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/TopologyClosedEvent.c
+++ b/src/MongoDB/Monitoring/TopologyClosedEvent.c
@@ -37,6 +37,16 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_TopologyClosedEvent, getTopologyId)
 	phongo_objectid_new(return_value, &intern->topology_id);
 }
 
+static void phongo_topologyclosedevent_update_properties(phongo_topologyclosedevent_t* intern)
+{
+	zval topology_id;
+
+	if (phongo_objectid_new(&topology_id, &intern->topology_id)) {
+		zend_update_property(phongo_topologyclosedevent_ce, &intern->std, ZEND_STRL("topologyId"), &topology_id);
+		zval_ptr_dtor(&topology_id);
+	}
+}
+
 /* MongoDB\Driver\Monitoring\TopologyClosedEvent object handlers */
 static zend_object_handlers phongo_handler_topologyclosedevent;
 
@@ -56,37 +66,21 @@ static zend_object* phongo_topologyclosedevent_create_object(zend_class_entry* c
 	return &intern->std;
 }
 
-static HashTable* phongo_topologyclosedevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(topologyclosedevent, object);
-
-	zval retval = ZVAL_STATIC_INIT;
-
-	*is_temp = 1;
-	array_init_size(&retval, 1);
-
-	{
-		zval topology_id;
-
-		if (!phongo_objectid_new(&topology_id, &intern->topology_id)) {
-			/* Exception should already have been thrown */
-			goto done;
-		}
-
-		ADD_ASSOC_ZVAL_EX(&retval, "topologyId", &topology_id);
-	}
-
-done:
-	return Z_ARRVAL(retval);
-}
-
 void phongo_topologyclosedevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_topologyclosedevent_ce                = register_class_MongoDB_Driver_Monitoring_TopologyClosedEvent();
 	phongo_topologyclosedevent_ce->create_object = phongo_topologyclosedevent_create_object;
 
 	memcpy(&phongo_handler_topologyclosedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_topologyclosedevent.get_debug_info = phongo_topologyclosedevent_get_debug_info;
-	phongo_handler_topologyclosedevent.free_obj       = phongo_topologyclosedevent_free_object;
-	phongo_handler_topologyclosedevent.offset         = XtOffsetOf(phongo_topologyclosedevent_t, std);
+	phongo_handler_topologyclosedevent.free_obj = phongo_topologyclosedevent_free_object;
+	phongo_handler_topologyclosedevent.offset   = XtOffsetOf(phongo_topologyclosedevent_t, std);
+}
+
+void phongo_topologyclosedevent_init(zval* return_value, const mongoc_apm_topology_closed_t* event)
+{
+	PHONGO_INTERN_INIT_EX(topologyclosedevent, return_value);
+
+	mongoc_apm_topology_closed_get_topology_id(event, &intern->topology_id);
+
+	phongo_topologyclosedevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/TopologyClosedEvent.stub.php
+++ b/src/MongoDB/Monitoring/TopologyClosedEvent.stub.php
@@ -10,6 +10,8 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class TopologyClosedEvent
 {
+    public readonly \MongoDB\BSON\ObjectId $topologyId;
+
     final private function __construct() {}
 
     final public function getTopologyId(): \MongoDB\BSON\ObjectId {}

--- a/src/MongoDB/Monitoring/TopologyClosedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/TopologyClosedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c636ee276d6ebc18186a6ef4b8f67c48f5b4c29c */
+ * Stub hash: 644621167d1bf91bd04be273dc5ba0824477a10d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyClosedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -25,6 +25,13 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_TopologyClosed
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "TopologyClosedEvent", class_MongoDB_Driver_Monitoring_TopologyClosedEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/TopologyOpeningEvent.c
+++ b/src/MongoDB/Monitoring/TopologyOpeningEvent.c
@@ -37,6 +37,16 @@ static PHP_METHOD(MongoDB_Driver_Monitoring_TopologyOpeningEvent, getTopologyId)
 	phongo_objectid_new(return_value, &intern->topology_id);
 }
 
+static void phongo_topologyopeningevent_update_properties(phongo_topologyopeningevent_t* intern)
+{
+	zval topology_id;
+
+	if (phongo_objectid_new(&topology_id, &intern->topology_id)) {
+		zend_update_property(phongo_topologyopeningevent_ce, &intern->std, ZEND_STRL("topologyId"), &topology_id);
+		zval_ptr_dtor(&topology_id);
+	}
+}
+
 /* MongoDB\Driver\Monitoring\TopologyOpeningEvent object handlers */
 static zend_object_handlers phongo_handler_topologyopeningevent;
 
@@ -56,37 +66,21 @@ static zend_object* phongo_topologyopeningevent_create_object(zend_class_entry* 
 	return &intern->std;
 }
 
-static HashTable* phongo_topologyopeningevent_get_debug_info(zend_object* object, int* is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(topologyopeningevent, object);
-
-	zval retval = ZVAL_STATIC_INIT;
-
-	*is_temp = 1;
-	array_init_size(&retval, 1);
-
-	{
-		zval topology_id;
-
-		if (!phongo_objectid_new(&topology_id, &intern->topology_id)) {
-			/* Exception should already have been thrown */
-			goto done;
-		}
-
-		ADD_ASSOC_ZVAL_EX(&retval, "topologyId", &topology_id);
-	}
-
-done:
-	return Z_ARRVAL(retval);
-}
-
 void phongo_topologyopeningevent_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_topologyopeningevent_ce                = register_class_MongoDB_Driver_Monitoring_TopologyOpeningEvent();
 	phongo_topologyopeningevent_ce->create_object = phongo_topologyopeningevent_create_object;
 
 	memcpy(&phongo_handler_topologyopeningevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_topologyopeningevent.get_debug_info = phongo_topologyopeningevent_get_debug_info;
-	phongo_handler_topologyopeningevent.free_obj       = phongo_topologyopeningevent_free_object;
-	phongo_handler_topologyopeningevent.offset         = XtOffsetOf(phongo_topologyopeningevent_t, std);
+	phongo_handler_topologyopeningevent.free_obj = phongo_topologyopeningevent_free_object;
+	phongo_handler_topologyopeningevent.offset   = XtOffsetOf(phongo_topologyopeningevent_t, std);
+}
+
+void phongo_topologyopeningevent_init(zval* return_value, const mongoc_apm_topology_opening_t* event)
+{
+	PHONGO_INTERN_INIT_EX(topologyopeningevent, return_value);
+
+	mongoc_apm_topology_opening_get_topology_id(event, &intern->topology_id);
+
+	phongo_topologyopeningevent_update_properties(intern);
 }

--- a/src/MongoDB/Monitoring/TopologyOpeningEvent.stub.php
+++ b/src/MongoDB/Monitoring/TopologyOpeningEvent.stub.php
@@ -10,6 +10,8 @@ namespace MongoDB\Driver\Monitoring;
 /** @not-serializable */
 final class TopologyOpeningEvent
 {
+    public readonly \MongoDB\BSON\ObjectId $topologyId;
+
     final private function __construct() {}
 
     final public function getTopologyId(): \MongoDB\BSON\ObjectId {}

--- a/src/MongoDB/Monitoring/TopologyOpeningEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/TopologyOpeningEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6ab1a9ad8b25b5d09ce12c1b0fa0e69885432d6f */
+ * Stub hash: a56da9b725311ccba7aa401f90604709af7ae2f9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyOpeningEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -25,6 +25,13 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_TopologyOpenin
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "TopologyOpeningEvent", class_MongoDB_Driver_Monitoring_TopologyOpeningEvent_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/ReadConcern.c
+++ b/src/MongoDB/ReadConcern.c
@@ -25,6 +25,17 @@
 
 zend_class_entry* phongo_readconcern_ce;
 
+static void phongo_readconcern_update_properties(phongo_readconcern_t* intern)
+{
+	const char* level = mongoc_read_concern_get_level(intern->read_concern);
+
+	if (level) {
+		zend_update_property_string(phongo_readconcern_ce, &intern->std, ZEND_STRL("level"), level);
+	} else {
+		zend_update_property_null(phongo_readconcern_ce, &intern->std, ZEND_STRL("level"));
+	}
+}
+
 /* Initialize the object from a HashTable and return whether it was successful.
  * An exception will be thrown on error. */
 static bool phongo_readconcern_init_from_hash(phongo_readconcern_t* intern, HashTable* props)
@@ -36,12 +47,13 @@ static bool phongo_readconcern_init_from_hash(phongo_readconcern_t* intern, Hash
 	if ((level = zend_hash_str_find(props, "level", sizeof("level") - 1))) {
 		if (Z_TYPE_P(level) == IS_STRING) {
 			mongoc_read_concern_set_level(intern->read_concern, Z_STRVAL_P(level));
-			return true;
+		} else if (Z_TYPE_P(level) != IS_NULL) {
+			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s initialization requires \"level\" string field", ZSTR_VAL(phongo_readconcern_ce->name));
+			goto failure;
 		}
-
-		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s initialization requires \"level\" string field", ZSTR_VAL(phongo_readconcern_ce->name));
-		goto failure;
 	}
+
+	phongo_readconcern_update_properties(intern);
 
 	return true;
 
@@ -69,6 +81,8 @@ static PHP_METHOD(MongoDB_Driver_ReadConcern, __construct)
 	if (level) {
 		mongoc_read_concern_set_level(intern->read_concern, level);
 	}
+
+	phongo_readconcern_update_properties(intern);
 }
 
 static PHP_METHOD(MongoDB_Driver_ReadConcern, __set_state)
@@ -115,44 +129,29 @@ static PHP_METHOD(MongoDB_Driver_ReadConcern, isDefault)
 	RETURN_BOOL(mongoc_read_concern_is_default(intern->read_concern));
 }
 
-static HashTable* phongo_readconcern_get_properties_hash(zend_object* object, bool is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(readconcern, object);
-
-	HashTable*  props;
-	const char* level;
-
-	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_temp, intern, props, 1);
-
-	if (!intern->read_concern) {
-		return props;
-	}
-
-	level = mongoc_read_concern_get_level(intern->read_concern);
-
-	if (level) {
-		zval z_level;
-
-		ZVAL_STRING(&z_level, level);
-		zend_hash_str_update(props, "level", sizeof("level") - 1, &z_level);
-	}
-
-	return props;
-}
-
 static PHP_METHOD(MongoDB_Driver_ReadConcern, bsonSerialize)
 {
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	ZVAL_ARR(return_value, phongo_readconcern_get_properties_hash(Z_OBJ_P(getThis()), true));
+	array_init_size(return_value, 1);
+
+	{
+		zend_string* string_key;
+		zval*        val;
+
+		ZEND_HASH_FOREACH_STR_KEY_VAL_IND(HASH_OF(getThis()), string_key, val)
+		{
+			if (Z_TYPE_P(val) == IS_NULL) {
+				continue;
+			}
+
+			Z_TRY_ADDREF_P(val);
+			add_assoc_zval(return_value, ZSTR_VAL(string_key), val);
+		}
+		ZEND_HASH_FOREACH_END();
+	}
+
 	convert_to_object(return_value);
-}
-
-static PHP_METHOD(MongoDB_Driver_ReadConcern, __serialize)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	RETURN_ARR(phongo_readconcern_get_properties_hash(Z_OBJ_P(getThis()), true));
 }
 
 static PHP_METHOD(MongoDB_Driver_ReadConcern, __unserialize)
@@ -175,11 +174,6 @@ static void phongo_readconcern_free_object(zend_object* object)
 
 	zend_object_std_dtor(&intern->std);
 
-	if (intern->properties) {
-		zend_hash_destroy(intern->properties);
-		FREE_HASHTABLE(intern->properties);
-	}
-
 	if (intern->read_concern) {
 		mongoc_read_concern_destroy(intern->read_concern);
 	}
@@ -194,33 +188,22 @@ static zend_object* phongo_readconcern_create_object(zend_class_entry* class_typ
 	return &intern->std;
 }
 
-static HashTable* phongo_readconcern_get_debug_info(zend_object* object, int* is_temp)
-{
-	*is_temp = 1;
-	return phongo_readconcern_get_properties_hash(object, true);
-}
-
-static HashTable* phongo_readconcern_get_properties(zend_object* object)
-{
-	return phongo_readconcern_get_properties_hash(object, false);
-}
-
 void phongo_readconcern_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_readconcern_ce                = register_class_MongoDB_Driver_ReadConcern(phongo_serializable_ce);
 	phongo_readconcern_ce->create_object = phongo_readconcern_create_object;
 
 	memcpy(&phongo_handler_readconcern, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_readconcern.get_debug_info = phongo_readconcern_get_debug_info;
-	phongo_handler_readconcern.get_properties = phongo_readconcern_get_properties;
-	phongo_handler_readconcern.free_obj       = phongo_readconcern_free_object;
-	phongo_handler_readconcern.offset         = XtOffsetOf(phongo_readconcern_t, std);
+	phongo_handler_readconcern.free_obj = phongo_readconcern_free_object;
+	phongo_handler_readconcern.offset   = XtOffsetOf(phongo_readconcern_t, std);
 }
 
 void phongo_readconcern_init(zval* return_value, const mongoc_read_concern_t* read_concern)
 {
 	PHONGO_INTERN_INIT_EX(readconcern, return_value);
 	intern->read_concern = mongoc_read_concern_copy(read_concern);
+
+	phongo_readconcern_update_properties(intern);
 }
 
 const mongoc_read_concern_t* phongo_read_concern_from_zval(zval* zread_concern)

--- a/src/MongoDB/ReadConcern.stub.php
+++ b/src/MongoDB/ReadConcern.stub.php
@@ -39,6 +39,8 @@ final class ReadConcern implements \MongoDB\BSON\Serializable
      */
     public const SNAPSHOT = UNKNOWN;
 
+    public readonly string|null $level;
+
     final public function __construct(?string $level = null) {}
 
     final public function getLevel(): ?string {}
@@ -50,7 +52,4 @@ final class ReadConcern implements \MongoDB\BSON\Serializable
     final public function bsonSerialize(): \stdClass {}
 
     final public function __unserialize(array $data): void {}
-
-    final public function __serialize(): array {}
-
 }

--- a/src/MongoDB/ReadConcern_arginfo.h
+++ b/src/MongoDB/ReadConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2eb20e3e6be24e99cbbfe9d7888d5b8b99fc609f */
+ * Stub hash: 814c09622ce8f209f6573cbb3d4945bc377824e7 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, level, IS_STRING, 1, "null")
@@ -22,9 +22,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern___serialize, 0, 0, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
-
 
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __construct);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, getLevel);
@@ -32,7 +29,6 @@ static ZEND_METHOD(MongoDB_Driver_ReadConcern, isDefault);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __set_state);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __unserialize);
-static ZEND_METHOD(MongoDB_Driver_ReadConcern, __serialize);
 
 
 static const zend_function_entry class_MongoDB_Driver_ReadConcern_methods[] = {
@@ -42,7 +38,6 @@ static const zend_function_entry class_MongoDB_Driver_ReadConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_ReadConcern, __set_state, arginfo_class_MongoDB_Driver_ReadConcern___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadConcern, bsonSerialize, arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadConcern, __unserialize, arginfo_class_MongoDB_Driver_ReadConcern___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	ZEND_ME(MongoDB_Driver_ReadConcern, __serialize, arginfo_class_MongoDB_Driver_ReadConcern___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -89,6 +84,12 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadConcern(zend_class_en
 	zend_string *const_SNAPSHOT_name = zend_string_init_interned("SNAPSHOT", sizeof("SNAPSHOT") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SNAPSHOT_name, &const_SNAPSHOT_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_SNAPSHOT_name);
+
+	zval property_level_default_value;
+	ZVAL_UNDEF(&property_level_default_value);
+	zend_string *property_level_name = zend_string_init("level", sizeof("level") - 1, 1);
+	zend_declare_typed_property(class_entry, property_level_name, &property_level_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_level_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -31,6 +31,71 @@
 
 zend_class_entry* phongo_readpreference_ce;
 
+static const char* phongo_readpreference_get_mode_string(const mongoc_read_prefs_t* read_prefs)
+{
+	switch (mongoc_read_prefs_get_mode(read_prefs)) {
+		case MONGOC_READ_PRIMARY:
+			return PHONGO_READ_PRIMARY;
+		case MONGOC_READ_PRIMARY_PREFERRED:
+			return PHONGO_READ_PRIMARY_PREFERRED;
+		case MONGOC_READ_SECONDARY:
+			return PHONGO_READ_SECONDARY;
+		case MONGOC_READ_SECONDARY_PREFERRED:
+			return PHONGO_READ_SECONDARY_PREFERRED;
+		case MONGOC_READ_NEAREST:
+			return PHONGO_READ_NEAREST;
+		default:
+			return "";
+	}
+}
+
+static void phongo_readpreference_update_properties(phongo_readpreference_t* intern)
+{
+	const bson_t* bson;
+
+	zend_update_property_string(phongo_readpreference_ce, &intern->std, ZEND_STRL("mode"), phongo_readpreference_get_mode_string(intern->read_preference));
+	zend_update_property_long(phongo_readpreference_ce, &intern->std, ZEND_STRL("maxStalenessSeconds"), mongoc_read_prefs_get_max_staleness_seconds(intern->read_preference));
+
+	bson = mongoc_read_prefs_get_tags(intern->read_preference);
+
+	if (!bson_empty0(bson)) {
+		phongo_bson_state state;
+
+		PHONGO_BSON_INIT_STATE(state);
+		state.map.root.type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+
+		if (!phongo_bson_to_zval_ex(bson, &state)) {
+			// Exception already thrown
+			zval_ptr_dtor(&state.zchild);
+			return;
+		}
+
+		zend_update_property(phongo_readpreference_ce, &intern->std, ZEND_STRL("tags"), &state.zchild);
+		zval_ptr_dtor(&state.zchild);
+	} else {
+		zend_update_property_null(phongo_readpreference_ce, &intern->std, ZEND_STRL("tags"));
+	}
+
+	bson = mongoc_read_prefs_get_hedge(intern->read_preference);
+
+	if (!bson_empty0(bson)) {
+		phongo_bson_state state;
+
+		PHONGO_BSON_INIT_STATE(state);
+
+		if (!phongo_bson_to_zval_ex(bson, &state)) {
+			// Exception already thrown
+			zval_ptr_dtor(&state.zchild);
+			return;
+		}
+
+		zend_update_property(phongo_readpreference_ce, &intern->std, ZEND_STRL("hedge"), &state.zchild);
+		zval_ptr_dtor(&state.zchild);
+	} else {
+		zend_update_property_null(phongo_readpreference_ce, &intern->std, ZEND_STRL("hedge"));
+	}
+}
+
 /* Initialize the object from a HashTable and return whether it was successful.
  * An exception will be thrown on error. */
 static bool phongo_readpreference_init_from_hash(phongo_readpreference_t* intern, HashTable* props)
@@ -83,7 +148,7 @@ static bool phongo_readpreference_init_from_hash(phongo_readpreference_t* intern
 
 			mongoc_read_prefs_set_tags(intern->read_preference, tags);
 			bson_destroy(tags);
-		} else {
+		} else if (Z_TYPE_P(tagSets) != IS_NULL) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s initialization requires \"tags\" field to be array", ZSTR_VAL(phongo_readpreference_ce->name));
 			goto failure;
 		}
@@ -134,7 +199,7 @@ static bool phongo_readpreference_init_from_hash(phongo_readpreference_t* intern
 
 			mongoc_read_prefs_set_hedge(intern->read_preference, hedge_doc);
 			bson_destroy(hedge_doc);
-		} else {
+		} else if (Z_TYPE_P(hedge) != IS_NULL) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s initialization requires \"hedge\" field to be an array or object", ZSTR_VAL(phongo_readpreference_ce->name));
 			goto failure;
 		}
@@ -145,30 +210,14 @@ static bool phongo_readpreference_init_from_hash(phongo_readpreference_t* intern
 		goto failure;
 	}
 
+	phongo_readpreference_update_properties(intern);
+
 	return true;
 
 failure:
 	mongoc_read_prefs_destroy(intern->read_preference);
 	intern->read_preference = NULL;
 	return false;
-}
-
-static const char* phongo_readpreference_get_mode_string(const mongoc_read_prefs_t* read_prefs)
-{
-	switch (mongoc_read_prefs_get_mode(read_prefs)) {
-		case MONGOC_READ_PRIMARY:
-			return PHONGO_READ_PRIMARY;
-		case MONGOC_READ_PRIMARY_PREFERRED:
-			return PHONGO_READ_PRIMARY_PREFERRED;
-		case MONGOC_READ_SECONDARY:
-			return PHONGO_READ_SECONDARY;
-		case MONGOC_READ_SECONDARY_PREFERRED:
-			return PHONGO_READ_SECONDARY_PREFERRED;
-		case MONGOC_READ_NEAREST:
-			return PHONGO_READ_NEAREST;
-		default:
-			return "";
-	}
 }
 
 /* Constructs a new ReadPreference */
@@ -280,6 +329,8 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, __construct)
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Read preference is not valid");
 		return;
 	}
+
+	phongo_readpreference_update_properties(intern);
 }
 
 static PHP_METHOD(MongoDB_Driver_ReadPreference, __set_state)
@@ -374,86 +425,32 @@ static PHP_METHOD(MongoDB_Driver_ReadPreference, getTagSets)
 	}
 }
 
-static HashTable* phongo_readpreference_get_properties_hash(zend_object* object, bool is_temp)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(readpreference, object);
-
-	HashTable*    props;
-	const bson_t* tags;
-	const bson_t* hedge;
-
-	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_temp, intern, props, 4);
-
-	if (!intern->read_preference) {
-		return props;
-	}
-
-	tags  = mongoc_read_prefs_get_tags(intern->read_preference);
-	hedge = mongoc_read_prefs_get_hedge(intern->read_preference);
-
-	{
-		zval z_mode;
-
-		ZVAL_STRING(&z_mode, phongo_readpreference_get_mode_string(intern->read_preference));
-		zend_hash_str_update(props, "mode", sizeof("mode") - 1, &z_mode);
-	}
-
-	if (!bson_empty0(tags)) {
-		phongo_bson_state state;
-
-		/* Use PHONGO_TYPEMAP_NATIVE_ARRAY for the root type since tags is an
-		 * array; however, inner documents and arrays can use the default. */
-		PHONGO_BSON_INIT_STATE(state);
-		state.map.root.type = PHONGO_TYPEMAP_NATIVE_ARRAY;
-
-		if (!phongo_bson_to_zval_ex(tags, &state)) {
-			zval_ptr_dtor(&state.zchild);
-			goto done;
-		}
-
-		zend_hash_str_update(props, "tags", sizeof("tags") - 1, &state.zchild);
-	}
-
-	if (mongoc_read_prefs_get_max_staleness_seconds(intern->read_preference) != MONGOC_NO_MAX_STALENESS) {
-		/* Note: valid values for maxStalesnessSeconds will not exceed the range
-		 * of 32-bit signed integers, so conditional encoding is not necessary. */
-		long maxStalenessSeconds = mongoc_read_prefs_get_max_staleness_seconds(intern->read_preference);
-		zval z_max_ss;
-
-		ZVAL_LONG(&z_max_ss, maxStalenessSeconds);
-		zend_hash_str_update(props, "maxStalenessSeconds", sizeof("maxStalenessSeconds") - 1, &z_max_ss);
-	}
-
-	if (!bson_empty0(hedge)) {
-		phongo_bson_state state;
-
-		PHONGO_BSON_INIT_STATE(state);
-
-		if (!phongo_bson_to_zval_ex(hedge, &state)) {
-			zval_ptr_dtor(&state.zchild);
-			goto done;
-		}
-
-		zend_hash_str_update(props, "hedge", sizeof("hedge") - 1, &state.zchild);
-	}
-
-done:
-	return props;
-}
-
 static PHP_METHOD(MongoDB_Driver_ReadPreference, bsonSerialize)
 {
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	ZVAL_ARR(return_value, phongo_readpreference_get_properties_hash(Z_OBJ_P(getThis()), true));
+	array_init_size(return_value, 4);
+
+	{
+		zend_string* string_key;
+		zval*        val;
+
+		ZEND_HASH_FOREACH_STR_KEY_VAL_IND(HASH_OF(getThis()), string_key, val)
+		{
+			if (
+				(Z_TYPE_P(val) == IS_NULL) || (!strcmp(ZSTR_VAL(string_key), "maxStalenessSeconds") && Z_TYPE_P(val) == IS_LONG && Z_LVAL_P(val) == MONGOC_NO_MAX_STALENESS)) {
+				continue;
+			}
+
+			// Increase the refcount of our zval, as add_assoc_zval takes ownership, leading to the property value being
+			// freed once the return value goes out of scope
+			Z_TRY_ADDREF_P(val);
+			add_assoc_zval(return_value, ZSTR_VAL(string_key), val);
+		}
+		ZEND_HASH_FOREACH_END();
+	}
+
 	convert_to_object(return_value);
-}
-
-static PHP_METHOD(MongoDB_Driver_ReadPreference, __serialize)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	RETURN_ARR(phongo_readpreference_get_properties_hash(Z_OBJ_P(getThis()), true));
 }
 
 static PHP_METHOD(MongoDB_Driver_ReadPreference, __unserialize)
@@ -476,11 +473,6 @@ static void phongo_readpreference_free_object(zend_object* object)
 
 	zend_object_std_dtor(&intern->std);
 
-	if (intern->properties) {
-		zend_hash_destroy(intern->properties);
-		FREE_HASHTABLE(intern->properties);
-	}
-
 	if (intern->read_preference) {
 		mongoc_read_prefs_destroy(intern->read_preference);
 	}
@@ -495,15 +487,13 @@ static zend_object* phongo_readpreference_create_object(zend_class_entry* class_
 	return &intern->std;
 }
 
-static HashTable* phongo_readpreference_get_debug_info(zend_object* object, int* is_temp)
+static zval* phongo_readpreference_read_property(zend_object* zobj, zend_string* name, int type, void** cache_slot, zval* rv)
 {
-	*is_temp = 1;
-	return phongo_readpreference_get_properties_hash(object, true);
-}
+	if (!strcmp(ZSTR_VAL(name), "hedge")) {
+		php_error_docref(NULL, E_DEPRECATED, "Property MongoDB\\Driver\\ReadPreference::hedge is deprecated");
+	}
 
-static HashTable* phongo_readpreference_get_properties(zend_object* object)
-{
-	return phongo_readpreference_get_properties_hash(object, false);
+	return zend_std_read_property(zobj, name, type, cache_slot, rv);
 }
 
 void phongo_readpreference_init_ce(INIT_FUNC_ARGS)
@@ -512,16 +502,17 @@ void phongo_readpreference_init_ce(INIT_FUNC_ARGS)
 	phongo_readpreference_ce->create_object = phongo_readpreference_create_object;
 
 	memcpy(&phongo_handler_readpreference, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_readpreference.get_debug_info = phongo_readpreference_get_debug_info;
-	phongo_handler_readpreference.get_properties = phongo_readpreference_get_properties;
-	phongo_handler_readpreference.free_obj       = phongo_readpreference_free_object;
-	phongo_handler_readpreference.offset         = XtOffsetOf(phongo_readpreference_t, std);
+	phongo_handler_readpreference.read_property = phongo_readpreference_read_property;
+	phongo_handler_readpreference.free_obj      = phongo_readpreference_free_object;
+	phongo_handler_readpreference.offset        = XtOffsetOf(phongo_readpreference_t, std);
 }
 
 void phongo_readpreference_init(zval* return_value, const mongoc_read_prefs_t* read_prefs)
 {
 	PHONGO_INTERN_INIT_EX(readpreference, return_value);
 	intern->read_preference = mongoc_read_prefs_copy(read_prefs);
+
+	phongo_readpreference_update_properties(intern);
 }
 
 const mongoc_read_prefs_t* phongo_read_preference_from_zval(zval* zread_preference)

--- a/src/MongoDB/ReadPreference.stub.php
+++ b/src/MongoDB/ReadPreference.stub.php
@@ -51,6 +51,13 @@ final class ReadPreference implements \MongoDB\BSON\Serializable
      */
     public const SMALLEST_MAX_STALENESS_SECONDS = UNKNOWN;
 
+    public readonly string $mode;
+    public readonly array|null $tags;
+    public readonly int $maxStalenessSeconds;
+
+    /** @deprecated */
+    public readonly object|null $hedge;
+
     final public function __construct(string $mode, ?array $tagSets = null, ?array $options = null) {}
 
     /** @deprecated Hedged reads are deprecated in MongoDB 8.0 and will be removed in a future release */
@@ -67,6 +74,4 @@ final class ReadPreference implements \MongoDB\BSON\Serializable
     final public function bsonSerialize(): \stdClass {}
 
     final public function __unserialize(array $data): void {}
-
-    final public function __serialize(): array {}
 }

--- a/src/MongoDB/ReadPreference_arginfo.h
+++ b/src/MongoDB/ReadPreference_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ecf94da5562a2befc25e9770cc9970101823dcf2 */
+ * Stub hash: e7204ca51d594bcc92f399d4c2d5fe728114c1e4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_STRING, 0)
@@ -30,8 +30,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadPrefere
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_MongoDB_Driver_ReadPreference___serialize arginfo_class_MongoDB_Driver_ReadPreference_getTagSets
-
 
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __construct);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, getHedge);
@@ -41,7 +39,6 @@ static ZEND_METHOD(MongoDB_Driver_ReadPreference, getTagSets);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __set_state);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __unserialize);
-static ZEND_METHOD(MongoDB_Driver_ReadPreference, __serialize);
 
 
 static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] = {
@@ -53,7 +50,6 @@ static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] =
 	ZEND_ME(MongoDB_Driver_ReadPreference, __set_state, arginfo_class_MongoDB_Driver_ReadPreference___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, bsonSerialize, arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, __unserialize, arginfo_class_MongoDB_Driver_ReadPreference___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	ZEND_ME(MongoDB_Driver_ReadPreference, __serialize, arginfo_class_MongoDB_Driver_ReadPreference___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -112,6 +108,30 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadPreference(zend_class
 	zend_string *const_SMALLEST_MAX_STALENESS_SECONDS_name = zend_string_init_interned("SMALLEST_MAX_STALENESS_SECONDS", sizeof("SMALLEST_MAX_STALENESS_SECONDS") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SMALLEST_MAX_STALENESS_SECONDS_name, &const_SMALLEST_MAX_STALENESS_SECONDS_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_SMALLEST_MAX_STALENESS_SECONDS_name);
+
+	zval property_mode_default_value;
+	ZVAL_UNDEF(&property_mode_default_value);
+	zend_string *property_mode_name = zend_string_init("mode", sizeof("mode") - 1, 1);
+	zend_declare_typed_property(class_entry, property_mode_name, &property_mode_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_mode_name);
+
+	zval property_tags_default_value;
+	ZVAL_UNDEF(&property_tags_default_value);
+	zend_string *property_tags_name = zend_string_init("tags", sizeof("tags") - 1, 1);
+	zend_declare_typed_property(class_entry, property_tags_name, &property_tags_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
+	zend_string_release(property_tags_name);
+
+	zval property_maxStalenessSeconds_default_value;
+	ZVAL_UNDEF(&property_maxStalenessSeconds_default_value);
+	zend_string *property_maxStalenessSeconds_name = zend_string_init("maxStalenessSeconds", sizeof("maxStalenessSeconds") - 1, 1);
+	zend_declare_typed_property(class_entry, property_maxStalenessSeconds_name, &property_maxStalenessSeconds_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_maxStalenessSeconds_name);
+
+	zval property_hedge_default_value;
+	ZVAL_UNDEF(&property_hedge_default_value);
+	zend_string *property_hedge_name = zend_string_init("hedge", sizeof("hedge") - 1, 1);
+	zend_declare_typed_property(class_entry, property_hedge_name, &property_hedge_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT|MAY_BE_NULL));
+	zend_string_release(property_hedge_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -28,6 +28,39 @@
 
 zend_class_entry* phongo_writeconcern_ce;
 
+static void phongo_writeconcern_update_properties(phongo_writeconcern_t* intern)
+{
+	const char* wtag     = mongoc_write_concern_get_wtag(intern->write_concern);
+	int32_t     w        = mongoc_write_concern_get_w(intern->write_concern);
+	int64_t     wtimeout = mongoc_write_concern_get_wtimeout_int64(intern->write_concern);
+
+	if (wtag) {
+		zend_update_property_string(phongo_writeconcern_ce, &intern->std, ZEND_STRL("w"), wtag);
+	} else if (mongoc_write_concern_get_wmajority(intern->write_concern)) {
+		zend_update_property_string(phongo_writeconcern_ce, &intern->std, ZEND_STRL("w"), PHONGO_WRITE_CONCERN_W_MAJORITY);
+	} else if (w != MONGOC_WRITE_CONCERN_W_DEFAULT) {
+		zend_update_property_long(phongo_writeconcern_ce, &intern->std, ZEND_STRL("w"), w);
+	} else {
+		zend_update_property_null(phongo_writeconcern_ce, &intern->std, ZEND_STRL("w"));
+	}
+
+	if (mongoc_write_concern_journal_is_set(intern->write_concern)) {
+		zend_update_property_bool(phongo_writeconcern_ce, &intern->std, ZEND_STRL("j"), mongoc_write_concern_get_journal(intern->write_concern));
+	} else {
+		zend_update_property_null(phongo_writeconcern_ce, &intern->std, ZEND_STRL("j"));
+	}
+
+#if SIZEOF_ZEND_LONG == 4
+	if (wtimeout > INT32_MAX || wtimeout < INT32_MIN) {
+		zend_update_property_long(phongo_writeconcern_ce, &intern->std, ZEND_STRL("wtimeout"), (zend_long) INT32_MAX);
+	} else {
+		zend_update_property_long(phongo_writeconcern_ce, &intern->std, ZEND_STRL("wtimeout"), (zend_long) wtimeout);
+	}
+#else
+	zend_update_property_long(phongo_writeconcern_ce, &intern->std, ZEND_STRL("wtimeout"), (zend_long) wtimeout);
+#endif
+}
+
 /* Initialize the object from a HashTable and return whether it was successful.
  * An exception will be thrown on error. */
 static bool phongo_writeconcern_init_from_hash(phongo_writeconcern_t* intern, HashTable* props)
@@ -49,7 +82,7 @@ static bool phongo_writeconcern_init_from_hash(phongo_writeconcern_t* intern, Ha
 			} else {
 				mongoc_write_concern_set_wtag(intern->write_concern, Z_STRVAL_P(w));
 			}
-		} else {
+		} else if (Z_TYPE_P(w) != IS_NULL) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s initialization requires \"w\" field to be integer or string", ZSTR_VAL(phongo_writeconcern_ce->name));
 			goto failure;
 		}
@@ -72,7 +105,7 @@ static bool phongo_writeconcern_init_from_hash(phongo_writeconcern_t* intern, Ha
 			}
 
 			mongoc_write_concern_set_wtimeout_int64(intern->write_concern, timeout);
-		} else {
+		} else if (Z_TYPE_P(wtimeout) != IS_NULL) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s initialization requires \"wtimeout\" field to be integer or string", ZSTR_VAL(phongo_writeconcern_ce->name));
 			goto failure;
 		}
@@ -86,7 +119,7 @@ static bool phongo_writeconcern_init_from_hash(phongo_writeconcern_t* intern, Ha
 			}
 
 			mongoc_write_concern_set_journal(intern->write_concern, zend_is_true(j));
-		} else {
+		} else if (Z_TYPE_P(j) != IS_NULL) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "%s initialization requires \"j\" field to be boolean", ZSTR_VAL(phongo_writeconcern_ce->name));
 			goto failure;
 		}
@@ -96,6 +129,8 @@ static bool phongo_writeconcern_init_from_hash(phongo_writeconcern_t* intern, Ha
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Write concern is not valid");
 		goto failure;
 	}
+
+	phongo_writeconcern_update_properties(intern);
 
 	return true;
 
@@ -164,6 +199,8 @@ static PHP_METHOD(MongoDB_Driver_WriteConcern, __construct)
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Write concern is not valid");
 		return;
 	}
+
+	phongo_writeconcern_update_properties(intern);
 }
 
 static PHP_METHOD(MongoDB_Driver_WriteConcern, __set_state)
@@ -252,89 +289,39 @@ static PHP_METHOD(MongoDB_Driver_WriteConcern, isDefault)
 	RETURN_BOOL(mongoc_write_concern_is_default(intern->write_concern));
 }
 
-static HashTable* phongo_writeconcern_get_properties_hash(zend_object* object, bool is_temp, bool is_bson, bool is_serialize)
+static PHP_METHOD(MongoDB_Driver_WriteConcern, bsonSerialize)
 {
-	PHONGO_INTERN_FROM_Z_OBJ(writeconcern, object);
+	PHONGO_INTERN_FROM_THIS(writeconcern);
 
-	HashTable*  props;
 	const char* wtag;
 	int32_t     w;
 	int64_t     wtimeout;
 
-	PHONGO_GET_PROPERTY_HASH_INIT_PROPS(is_temp, intern, props, 4);
-
-	if (!intern->write_concern) {
-		return props;
-	}
+	PHONGO_PARSE_PARAMETERS_NONE();
 
 	wtag     = mongoc_write_concern_get_wtag(intern->write_concern);
 	w        = mongoc_write_concern_get_w(intern->write_concern);
 	wtimeout = mongoc_write_concern_get_wtimeout_int64(intern->write_concern);
 
-	{
-		zval z_w;
+	array_init_size(return_value, 3);
 
-		if (wtag) {
-			ZVAL_STRING(&z_w, wtag);
-			zend_hash_str_update(props, "w", sizeof("w") - 1, &z_w);
-		} else if (mongoc_write_concern_get_wmajority(intern->write_concern)) {
-			ZVAL_STRING(&z_w, PHONGO_WRITE_CONCERN_W_MAJORITY);
-			zend_hash_str_update(props, "w", sizeof("w") - 1, &z_w);
-		} else if (w != MONGOC_WRITE_CONCERN_W_DEFAULT) {
-			ZVAL_LONG(&z_w, w);
-			zend_hash_str_update(props, "w", sizeof("w") - 1, &z_w);
-		}
-
-		if (mongoc_write_concern_journal_is_set(intern->write_concern)) {
-			zval z_j;
-
-			ZVAL_BOOL(&z_j, mongoc_write_concern_get_journal(intern->write_concern));
-			zend_hash_str_update(props, "j", sizeof("j") - 1, &z_j);
-		}
-
-		if (wtimeout != 0) {
-			zval z_wtimeout;
-
-			if (is_bson) {
-				ZVAL_INT64(&z_wtimeout, wtimeout);
-			} else if (is_serialize) {
-				if (wtimeout > INT32_MAX || wtimeout < INT32_MIN) {
-					ZVAL_INT64_STRING(&z_wtimeout, wtimeout);
-				} else {
-					ZVAL_LONG(&z_wtimeout, wtimeout);
-				}
-			} else {
-#if SIZEOF_ZEND_LONG == 4
-				if (wtimeout > INT32_MAX || wtimeout < INT32_MIN) {
-					ZVAL_INT64_STRING(&z_wtimeout, wtimeout);
-				} else {
-					ZVAL_LONG(&z_wtimeout, wtimeout);
-				}
-#else
-				ZVAL_LONG(&z_wtimeout, wtimeout);
-#endif
-			}
-
-			zend_hash_str_update(props, "wtimeout", sizeof("wtimeout") - 1, &z_wtimeout);
-		}
+	if (wtag) {
+		ADD_ASSOC_STRING(return_value, "w", wtag);
+	} else if (mongoc_write_concern_get_wmajority(intern->write_concern)) {
+		ADD_ASSOC_STRING(return_value, "w", PHONGO_WRITE_CONCERN_W_MAJORITY);
+	} else if (w != MONGOC_WRITE_CONCERN_W_DEFAULT) {
+		ADD_ASSOC_LONG_EX(return_value, "w", w);
 	}
 
-	return props;
-}
+	if (mongoc_write_concern_journal_is_set(intern->write_concern)) {
+		ADD_ASSOC_BOOL_EX(return_value, "j", mongoc_write_concern_get_journal(intern->write_concern));
+	}
 
-static PHP_METHOD(MongoDB_Driver_WriteConcern, bsonSerialize)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
+	if (wtimeout != 0) {
+		ADD_ASSOC_INT64(return_value, "wtimeout", wtimeout);
+	}
 
-	ZVAL_ARR(return_value, phongo_writeconcern_get_properties_hash(Z_OBJ_P(getThis()), true, true, false));
 	convert_to_object(return_value);
-}
-
-static PHP_METHOD(MongoDB_Driver_WriteConcern, __serialize)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	RETURN_ARR(phongo_writeconcern_get_properties_hash(Z_OBJ_P(getThis()), true, false, true));
 }
 
 static PHP_METHOD(MongoDB_Driver_WriteConcern, __unserialize)
@@ -357,11 +344,6 @@ static void phongo_writeconcern_free_object(zend_object* object)
 
 	zend_object_std_dtor(&intern->std);
 
-	if (intern->properties) {
-		zend_hash_destroy(intern->properties);
-		FREE_HASHTABLE(intern->properties);
-	}
-
 	if (intern->write_concern) {
 		mongoc_write_concern_destroy(intern->write_concern);
 	}
@@ -376,33 +358,22 @@ static zend_object* phongo_writeconcern_create_object(zend_class_entry* class_ty
 	return &intern->std;
 }
 
-static HashTable* phongo_writeconcern_get_debug_info(zend_object* object, int* is_temp)
-{
-	*is_temp = 1;
-	return phongo_writeconcern_get_properties_hash(object, true, false, false);
-}
-
-static HashTable* phongo_writeconcern_get_properties(zend_object* object)
-{
-	return phongo_writeconcern_get_properties_hash(object, false, false, false);
-}
-
 void phongo_writeconcern_init_ce(INIT_FUNC_ARGS)
 {
 	phongo_writeconcern_ce                = register_class_MongoDB_Driver_WriteConcern(phongo_serializable_ce);
 	phongo_writeconcern_ce->create_object = phongo_writeconcern_create_object;
 
 	memcpy(&phongo_handler_writeconcern, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_writeconcern.get_debug_info = phongo_writeconcern_get_debug_info;
-	phongo_handler_writeconcern.get_properties = phongo_writeconcern_get_properties;
-	phongo_handler_writeconcern.free_obj       = phongo_writeconcern_free_object;
-	phongo_handler_writeconcern.offset         = XtOffsetOf(phongo_writeconcern_t, std);
+	phongo_handler_writeconcern.free_obj = phongo_writeconcern_free_object;
+	phongo_handler_writeconcern.offset   = XtOffsetOf(phongo_writeconcern_t, std);
 }
 
 void phongo_writeconcern_init(zval* return_value, const mongoc_write_concern_t* write_concern)
 {
 	PHONGO_INTERN_INIT_EX(writeconcern, return_value);
 	intern->write_concern = mongoc_write_concern_copy(write_concern);
+
+	phongo_writeconcern_update_properties(intern);
 }
 
 const mongoc_write_concern_t* phongo_write_concern_from_zval(zval* zwrite_concern)

--- a/src/MongoDB/WriteConcern.stub.php
+++ b/src/MongoDB/WriteConcern.stub.php
@@ -15,6 +15,12 @@ final class WriteConcern implements \MongoDB\BSON\Serializable
      */
     public const MAJORITY = UNKNOWN;
 
+    public readonly string|int|null $w;
+
+    public readonly bool|null $j;
+
+    public readonly int $wtimeout;
+
     final public function __construct(string|int $w, ?int $wtimeout = null, ?bool $journal = null) {}
 
     final public function getJournal(): ?bool {}
@@ -30,7 +36,4 @@ final class WriteConcern implements \MongoDB\BSON\Serializable
     final public function bsonSerialize(): \stdClass {}
 
     final public function __unserialize(array $data): void {}
-
-    final public function __serialize(): array {}
-
 }

--- a/src/MongoDB/WriteConcern_arginfo.h
+++ b/src/MongoDB/WriteConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1a859d43ebd260284aff6114b169cbe70869ae61 */
+ * Stub hash: 419a3a5ab13c377900e08013c3c91bd7a2b07200 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_MASK(0, w, MAY_BE_STRING|MAY_BE_LONG, NULL)
@@ -30,9 +30,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcer
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___serialize, 0, 0, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
-
 
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __construct);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, getJournal);
@@ -42,7 +39,6 @@ static ZEND_METHOD(MongoDB_Driver_WriteConcern, isDefault);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __set_state);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __unserialize);
-static ZEND_METHOD(MongoDB_Driver_WriteConcern, __serialize);
 
 
 static const zend_function_entry class_MongoDB_Driver_WriteConcern_methods[] = {
@@ -54,7 +50,6 @@ static const zend_function_entry class_MongoDB_Driver_WriteConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteConcern, __set_state, arginfo_class_MongoDB_Driver_WriteConcern___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteConcern, bsonSerialize, arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteConcern, __unserialize, arginfo_class_MongoDB_Driver_WriteConcern___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	ZEND_ME(MongoDB_Driver_WriteConcern, __serialize, arginfo_class_MongoDB_Driver_WriteConcern___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -73,6 +68,24 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteConcern(zend_class_e
 	zend_string *const_MAJORITY_name = zend_string_init_interned("MAJORITY", sizeof("MAJORITY") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_MAJORITY_name, &const_MAJORITY_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_MAJORITY_name);
+
+	zval property_w_default_value;
+	ZVAL_UNDEF(&property_w_default_value);
+	zend_string *property_w_name = zend_string_init("w", sizeof("w") - 1, 1);
+	zend_declare_typed_property(class_entry, property_w_name, &property_w_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_w_name);
+
+	zval property_j_default_value;
+	ZVAL_UNDEF(&property_j_default_value);
+	zend_string *property_j_name = zend_string_init("j", sizeof("j") - 1, 1);
+	zend_declare_typed_property(class_entry, property_j_name, &property_j_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL|MAY_BE_NULL));
+	zend_string_release(property_j_name);
+
+	zval property_wtimeout_default_value;
+	ZVAL_UNDEF(&property_wtimeout_default_value);
+	zend_string *property_wtimeout_name = zend_string_init("wtimeout", sizeof("wtimeout") - 1, 1);
+	zend_declare_typed_property(class_entry, property_wtimeout_name, &property_wtimeout_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_wtimeout_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/WriteError.c
+++ b/src/MongoDB/WriteError.c
@@ -99,26 +99,17 @@ static zend_object* phongo_writeerror_create_object(zend_class_entry* class_type
 	return &intern->std;
 }
 
-static HashTable* phongo_writeerror_get_debug_info(zend_object* object, int* is_temp)
+static void phongo_writeerror_update_properties(phongo_writeerror_t* intern)
 {
-	PHONGO_INTERN_FROM_Z_OBJ(writeerror, object);
+	zend_update_property_string(phongo_writeerror_ce, &intern->std, ZEND_STRL("message"), intern->message ? intern->message : "");
+	zend_update_property_long(phongo_writeerror_ce, &intern->std, ZEND_STRL("code"), intern->code);
+	zend_update_property_long(phongo_writeerror_ce, &intern->std, ZEND_STRL("index"), intern->index);
 
-	zval retval = ZVAL_STATIC_INIT;
-
-	*is_temp = 1;
-
-	array_init_size(&retval, 3);
-	ADD_ASSOC_STRING(&retval, "message", intern->message);
-	ADD_ASSOC_LONG_EX(&retval, "code", intern->code);
-	ADD_ASSOC_LONG_EX(&retval, "index", intern->index);
 	if (!Z_ISUNDEF(intern->info)) {
-		Z_ADDREF(intern->info);
-		ADD_ASSOC_ZVAL_EX(&retval, "info", &intern->info);
+		zend_update_property(phongo_writeerror_ce, &intern->std, ZEND_STRL("info"), &intern->info);
 	} else {
-		ADD_ASSOC_NULL_EX(&retval, "info");
+		zend_update_property_null(phongo_writeerror_ce, &intern->std, ZEND_STRL("info"));
 	}
-
-	return Z_ARRVAL(retval);
 }
 
 void phongo_writeerror_init_ce(INIT_FUNC_ARGS)
@@ -127,9 +118,8 @@ void phongo_writeerror_init_ce(INIT_FUNC_ARGS)
 	phongo_writeerror_ce->create_object = phongo_writeerror_create_object;
 
 	memcpy(&phongo_handler_writeerror, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_writeerror.get_debug_info = phongo_writeerror_get_debug_info;
-	phongo_handler_writeerror.free_obj       = phongo_writeerror_free_object;
-	phongo_handler_writeerror.offset         = XtOffsetOf(phongo_writeerror_t, std);
+	phongo_handler_writeerror.free_obj = phongo_writeerror_free_object;
+	phongo_handler_writeerror.offset   = XtOffsetOf(phongo_writeerror_t, std);
 }
 
 bool phongo_writeerror_init(zval* return_value, const bson_t* bson)
@@ -187,6 +177,8 @@ bool phongo_writeerror_init_ex(zval* return_value, const bson_t* bson, int32_t i
 	if (!intern->index && bson_iter_init_find(&iter, bson, "index") && BSON_ITER_HOLDS_INT32(&iter)) {
 		intern->index = bson_iter_int32(&iter);
 	}
+
+	phongo_writeerror_update_properties(intern);
 
 	return true;
 }

--- a/src/MongoDB/WriteError.stub.php
+++ b/src/MongoDB/WriteError.stub.php
@@ -10,6 +10,14 @@ namespace MongoDB\Driver;
 /** @not-serializable */
 final class WriteError
 {
+    public readonly string $message;
+
+    public readonly int $code;
+
+    public readonly int $index;
+
+    public readonly object|null $info;
+
     final private function __construct() {}
 
     final public function getCode(): int {}

--- a/src/MongoDB/WriteError_arginfo.h
+++ b/src/MongoDB/WriteError_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8f9ebc299c90e86c6a55ea39e02d5a1734d10402 */
+ * Stub hash: a31919ef78a0a36e04aab7db68ef5b235d3ec477 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteError___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -39,6 +39,30 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteError(void)
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "WriteError", class_MongoDB_Driver_WriteError_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_message_default_value;
+	ZVAL_UNDEF(&property_message_default_value);
+	zend_string *property_message_name = zend_string_init("message", sizeof("message") - 1, 1);
+	zend_declare_typed_property(class_entry, property_message_name, &property_message_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_message_name);
+
+	zval property_code_default_value;
+	ZVAL_UNDEF(&property_code_default_value);
+	zend_string *property_code_name = zend_string_init("code", sizeof("code") - 1, 1);
+	zend_declare_typed_property(class_entry, property_code_name, &property_code_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_code_name);
+
+	zval property_index_default_value;
+	ZVAL_UNDEF(&property_index_default_value);
+	zend_string *property_index_name = zend_string_init("index", sizeof("index") - 1, 1);
+	zend_declare_typed_property(class_entry, property_index_name, &property_index_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_index_name);
+
+	zval property_info_default_value;
+	ZVAL_UNDEF(&property_info_default_value);
+	zend_string *property_info_name = zend_string_init("info", sizeof("info") - 1, 1);
+	zend_declare_typed_property(class_entry, property_info_name, &property_info_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT|MAY_BE_NULL));
+	zend_string_release(property_info_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -42,6 +42,13 @@
 	}                                                                                  \
 	RETURN_LONG(0);
 
+#define PHONGO_WRITERESULT_UPDATE_PROP(prop, field)                                                                                                          \
+	if (mongoc_write_concern_is_acknowledged(intern->write_concern) && bson_iter_init_find(&iter, intern->reply, (field)) && BSON_ITER_HOLDS_INT32(&iter)) { \
+		zend_update_property_long(phongo_writeresult_ce, &intern->std, ZEND_STRL(prop), bson_iter_int32(&iter));                                             \
+	} else {                                                                                                                                                 \
+		zend_update_property_null(phongo_writeresult_ce, &intern->std, ZEND_STRL(prop));                                                                     \
+	}
+
 zend_class_entry* phongo_writeresult_ce;
 
 /* Populates return_value with a WriteConcernError object (if available).
@@ -149,6 +156,40 @@ static bool phongo_writeresult_get_error_replies(phongo_writeresult_t* intern, z
 	return true;
 }
 
+static void phongo_writeresult_get_upserted_ids(phongo_writeresult_t* intern, zval* return_value)
+{
+	bson_iter_t iter, child;
+
+	array_init(return_value);
+
+	if (bson_iter_init_find(&iter, intern->reply, "upserted") && BSON_ITER_HOLDS_ARRAY(&iter) && bson_iter_recurse(&iter, &child)) {
+		while (bson_iter_next(&child)) {
+			uint32_t          data_len;
+			const uint8_t*    data = NULL;
+			phongo_bson_state state;
+
+			/* Use PHONGO_TYPEMAP_NATIVE_ARRAY for the root type so we can
+			 * easily access the "index" and "_id" fields. */
+			PHONGO_BSON_INIT_STATE(state);
+			state.map.root.type = PHONGO_TYPEMAP_NATIVE_ARRAY;
+
+			if (!BSON_ITER_HOLDS_DOCUMENT(&child)) {
+				continue;
+			}
+
+			bson_iter_document(&child, &data_len, &data);
+
+			if (phongo_bson_data_to_zval_ex(data, data_len, &state)) {
+				zval* zid = php_array_fetchc(&state.zchild, "_id");
+				add_index_zval(return_value, php_array_fetchc_long(&state.zchild, "index"), zid);
+				zval_add_ref(zid);
+			}
+
+			zval_ptr_dtor(&state.zchild);
+		}
+	}
+}
+
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_WriteResult)
 
 /* Returns the number of documents that were inserted */
@@ -236,40 +277,11 @@ static PHP_METHOD(MongoDB_Driver_WriteResult, getUpsertedIds)
 {
 	PHONGO_INTERN_FROM_THIS(writeresult);
 
-	bson_iter_t iter, child;
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
 	PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED("getUpsertedIds");
 
-	array_init(return_value);
-
-	if (bson_iter_init_find(&iter, intern->reply, "upserted") && BSON_ITER_HOLDS_ARRAY(&iter) && bson_iter_recurse(&iter, &child)) {
-		while (bson_iter_next(&child)) {
-			uint32_t          data_len;
-			const uint8_t*    data = NULL;
-			phongo_bson_state state;
-
-			/* Use PHONGO_TYPEMAP_NATIVE_ARRAY for the root type so we can
-			 * easily access the "index" and "_id" fields. */
-			PHONGO_BSON_INIT_STATE(state);
-			state.map.root.type = PHONGO_TYPEMAP_NATIVE_ARRAY;
-
-			if (!BSON_ITER_HOLDS_DOCUMENT(&child)) {
-				continue;
-			}
-
-			bson_iter_document(&child, &data_len, &data);
-
-			if (phongo_bson_data_to_zval_ex(data, data_len, &state)) {
-				zval* zid = php_array_fetchc(&state.zchild, "_id");
-				add_index_zval(return_value, php_array_fetchc_long(&state.zchild, "index"), zid);
-				zval_add_ref(zid);
-			}
-
-			zval_ptr_dtor(&state.zchild);
-		}
-	}
+	phongo_writeresult_get_upserted_ids(intern, return_value);
 }
 
 /* Return any write concern error that occurred */
@@ -343,81 +355,60 @@ static zend_object* phongo_writeresult_create_object(zend_class_entry* class_typ
 	return &intern->std;
 }
 
-static HashTable* phongo_writeresult_get_debug_info(zend_object* object, int* is_temp)
+static void phongo_writeresult_update_properties(phongo_writeresult_t* intern)
 {
-	PHONGO_INTERN_FROM_Z_OBJ(writeresult, object);
-
-	zval        retval = ZVAL_STATIC_INIT;
 	bson_iter_t iter;
 
-	*is_temp = 1;
-	array_init_size(&retval, 10);
+	PHONGO_WRITERESULT_UPDATE_PROP("insertedCount", "nInserted");
+	PHONGO_WRITERESULT_UPDATE_PROP("matchedCount", "nMatched");
+	PHONGO_WRITERESULT_UPDATE_PROP("modifiedCount", "nModified");
+	PHONGO_WRITERESULT_UPDATE_PROP("deletedCount", "nRemoved");
+	PHONGO_WRITERESULT_UPDATE_PROP("upsertedCount", "nUpserted");
 
-#define PHONGO_WRITERESULT_SCP(field)                                                         \
-	if (bson_iter_init_find(&iter, intern->reply, (field)) && BSON_ITER_HOLDS_INT32(&iter)) { \
-		ADD_ASSOC_LONG_EX(&retval, (field), bson_iter_int32(&iter));                          \
-	} else {                                                                                  \
-		ADD_ASSOC_NULL_EX(&retval, (field));                                                  \
-	}
-
-	PHONGO_WRITERESULT_SCP("nInserted");
-	PHONGO_WRITERESULT_SCP("nMatched");
-	PHONGO_WRITERESULT_SCP("nModified");
-	PHONGO_WRITERESULT_SCP("nRemoved");
-	PHONGO_WRITERESULT_SCP("nUpserted");
-#undef PHONGO_WRITERESULT_SCP
-
-	if (bson_iter_init_find(&iter, intern->reply, "upserted") && BSON_ITER_HOLDS_ARRAY(&iter)) {
-		uint32_t          len;
-		const uint8_t*    data;
-		phongo_bson_state state;
-
-		PHONGO_BSON_INIT_DEBUG_STATE(state);
-		bson_iter_array(&iter, &len, &data);
-		if (!phongo_bson_data_to_zval_ex(data, len, &state)) {
-			zval_ptr_dtor(&state.zchild);
-			goto done;
-		}
-
-		ADD_ASSOC_ZVAL_EX(&retval, "upsertedIds", &state.zchild);
-	} else {
+	{
 		zval upsertedIds;
-		array_init(&upsertedIds);
-		ADD_ASSOC_ZVAL_EX(&retval, "upsertedIds", &upsertedIds);
+
+		phongo_writeresult_get_upserted_ids(intern, &upsertedIds);
+		zend_update_property(phongo_writeresult_ce, &intern->std, ZEND_STRL("upsertedIds"), &upsertedIds);
+		zval_ptr_dtor(&upsertedIds);
 	}
 
 	{
 		zval writeerrors;
-
 		phongo_writeresult_get_writeerrors(intern, &writeerrors);
-		ADD_ASSOC_ZVAL_EX(&retval, "writeErrors", &writeerrors);
+		zend_update_property(phongo_writeresult_ce, &intern->std, ZEND_STRL("writeErrors"), &writeerrors);
+		zval_ptr_dtor(&writeerrors);
 	}
 
 	{
 		zval writeconcernerror;
-
 		phongo_writeresult_get_writeconcernerror(intern, &writeconcernerror);
-		ADD_ASSOC_ZVAL_EX(&retval, "writeConcernError", &writeconcernerror);
+		zend_update_property(phongo_writeresult_ce, &intern->std, ZEND_STRL("writeConcernError"), &writeconcernerror);
+		zval_ptr_dtor(&writeconcernerror);
 	}
 
 	if (intern->write_concern) {
 		zval write_concern;
-
 		phongo_writeconcern_init(&write_concern, intern->write_concern);
-		ADD_ASSOC_ZVAL_EX(&retval, "writeConcern", &write_concern);
+		zend_update_property(phongo_writeresult_ce, &intern->std, ZEND_STRL("writeConcern"), &write_concern);
+		zval_ptr_dtor(&write_concern);
 	} else {
-		ADD_ASSOC_NULL_EX(&retval, "writeConcern");
+		zend_update_property_null(phongo_writeresult_ce, &intern->std, ZEND_STRL("writeConcern"));
 	}
 
 	{
 		zval error_replies;
-
 		phongo_writeresult_get_error_replies(intern, &error_replies);
-		ADD_ASSOC_ZVAL_EX(&retval, "errorReplies", &error_replies);
+		zend_update_property(phongo_writeresult_ce, &intern->std, ZEND_STRL("errorReplies"), &error_replies);
+		zval_ptr_dtor(&error_replies);
 	}
 
-done:
-	return Z_ARRVAL(retval);
+	{
+		zval server;
+		phongo_server_init(&server, &intern->manager, intern->server_id);
+		zend_update_property(phongo_writeresult_ce, &intern->std, ZEND_STRL("server"), &server);
+		zval_ptr_dtor(&server);
+	}
 }
 
 void phongo_writeresult_init_ce(INIT_FUNC_ARGS)
@@ -426,22 +417,26 @@ void phongo_writeresult_init_ce(INIT_FUNC_ARGS)
 	phongo_writeresult_ce->create_object = phongo_writeresult_create_object;
 
 	memcpy(&phongo_handler_writeresult, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_writeresult.get_debug_info = phongo_writeresult_get_debug_info;
-	phongo_handler_writeresult.free_obj       = phongo_writeresult_free_object;
-	phongo_handler_writeresult.offset         = XtOffsetOf(phongo_writeresult_t, std);
+	phongo_handler_writeresult.free_obj = phongo_writeresult_free_object;
+	phongo_handler_writeresult.offset   = XtOffsetOf(phongo_writeresult_t, std);
 }
 
-phongo_writeresult_t* phongo_writeresult_init(zval* return_value, bson_t* reply, zval* manager, uint32_t server_id)
+void phongo_writeresult_init(zval* return_value, bson_t* reply, zval* manager, uint32_t server_id, const mongoc_write_concern_t* write_concern)
 {
 	phongo_writeresult_t* writeresult;
 
 	object_init_ex(return_value, phongo_writeresult_ce);
 
-	writeresult            = Z_WRITERESULT_OBJ_P(return_value);
-	writeresult->reply     = bson_copy(reply);
-	writeresult->server_id = server_id;
+	writeresult                = Z_WRITERESULT_OBJ_P(return_value);
+	writeresult->reply         = bson_copy(reply);
+	writeresult->server_id     = server_id;
+	writeresult->write_concern = mongoc_write_concern_copy(write_concern);
 
 	ZVAL_ZVAL(&writeresult->manager, manager, 1, 0);
 
-	return writeresult;
+	phongo_writeresult_update_properties(writeresult);
 }
+
+#undef PHONGO_WRITERESULT_CHECK_ACKNOWLEDGED
+#undef PHONGO_WRITERESULT_RETURN_LONG_FROM_BSON_INT32
+#undef PHONGO_WRITERESULT_UPDATE_PROP

--- a/src/MongoDB/WriteResult.h
+++ b/src/MongoDB/WriteResult.h
@@ -23,6 +23,6 @@
 
 #include "phongo_structs.h"
 
-phongo_writeresult_t* phongo_writeresult_init(zval* return_value, bson_t* reply, zval* manager, uint32_t server_id);
+void phongo_writeresult_init(zval* return_value, bson_t* reply, zval* manager, uint32_t server_id, const mongoc_write_concern_t* write_concern);
 
 #endif /* PHONGO_WRITERESULT_H */

--- a/src/MongoDB/WriteResult.stub.php
+++ b/src/MongoDB/WriteResult.stub.php
@@ -10,6 +10,28 @@ namespace MongoDB\Driver;
 /** @not-serializable */
 final class WriteResult
 {
+    public readonly int|null $insertedCount;
+
+    public readonly int|null $matchedCount;
+
+    public readonly int|null $modifiedCount;
+
+    public readonly int|null $deletedCount;
+
+    public readonly int|null $upsertedCount;
+
+    public readonly Server $server;
+
+    public readonly array $upsertedIds;
+
+    public readonly array $writeErrors;
+
+    public readonly WriteConcernError|null $writeConcernError;
+
+    public readonly WriteConcern|null $writeConcern;
+
+    public readonly array $errorReplies;
+
     final private function __construct() {}
 
     final public function getInsertedCount(): int {}

--- a/src/MongoDB/WriteResult_arginfo.h
+++ b/src/MongoDB/WriteResult_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 217742ba620620cfaee2758070ff13e651620f87 */
+ * Stub hash: f75ffdff80697e2a32ac197b1901d6bf75180ab8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteResult___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -69,6 +69,75 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteResult(void)
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "WriteResult", class_MongoDB_Driver_WriteResult_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+
+	zval property_insertedCount_default_value;
+	ZVAL_UNDEF(&property_insertedCount_default_value);
+	zend_string *property_insertedCount_name = zend_string_init("insertedCount", sizeof("insertedCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_insertedCount_name, &property_insertedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_insertedCount_name);
+
+	zval property_matchedCount_default_value;
+	ZVAL_UNDEF(&property_matchedCount_default_value);
+	zend_string *property_matchedCount_name = zend_string_init("matchedCount", sizeof("matchedCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_matchedCount_name, &property_matchedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_matchedCount_name);
+
+	zval property_modifiedCount_default_value;
+	ZVAL_UNDEF(&property_modifiedCount_default_value);
+	zend_string *property_modifiedCount_name = zend_string_init("modifiedCount", sizeof("modifiedCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_modifiedCount_name, &property_modifiedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_modifiedCount_name);
+
+	zval property_deletedCount_default_value;
+	ZVAL_UNDEF(&property_deletedCount_default_value);
+	zend_string *property_deletedCount_name = zend_string_init("deletedCount", sizeof("deletedCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_deletedCount_name, &property_deletedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_deletedCount_name);
+
+	zval property_upsertedCount_default_value;
+	ZVAL_UNDEF(&property_upsertedCount_default_value);
+	zend_string *property_upsertedCount_name = zend_string_init("upsertedCount", sizeof("upsertedCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_upsertedCount_name, &property_upsertedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_upsertedCount_name);
+
+	zend_string *property_server_class_MongoDB_Driver_Server = zend_string_init("MongoDB\\Driver\\Server", sizeof("MongoDB\\Driver\\Server")-1, 1);
+	zval property_server_default_value;
+	ZVAL_UNDEF(&property_server_default_value);
+	zend_string *property_server_name = zend_string_init("server", sizeof("server") - 1, 1);
+	zend_declare_typed_property(class_entry, property_server_name, &property_server_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_server_class_MongoDB_Driver_Server, 0, 0));
+	zend_string_release(property_server_name);
+
+	zval property_upsertedIds_default_value;
+	ZVAL_UNDEF(&property_upsertedIds_default_value);
+	zend_string *property_upsertedIds_name = zend_string_init("upsertedIds", sizeof("upsertedIds") - 1, 1);
+	zend_declare_typed_property(class_entry, property_upsertedIds_name, &property_upsertedIds_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
+	zend_string_release(property_upsertedIds_name);
+
+	zval property_writeErrors_default_value;
+	ZVAL_UNDEF(&property_writeErrors_default_value);
+	zend_string *property_writeErrors_name = zend_string_init("writeErrors", sizeof("writeErrors") - 1, 1);
+	zend_declare_typed_property(class_entry, property_writeErrors_name, &property_writeErrors_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
+	zend_string_release(property_writeErrors_name);
+
+	zend_string *property_writeConcernError_class_MongoDB_Driver_WriteConcernError = zend_string_init("MongoDB\\Driver\\WriteConcernError", sizeof("MongoDB\\Driver\\WriteConcernError")-1, 1);
+	zval property_writeConcernError_default_value;
+	ZVAL_UNDEF(&property_writeConcernError_default_value);
+	zend_string *property_writeConcernError_name = zend_string_init("writeConcernError", sizeof("writeConcernError") - 1, 1);
+	zend_declare_typed_property(class_entry, property_writeConcernError_name, &property_writeConcernError_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_writeConcernError_class_MongoDB_Driver_WriteConcernError, 0, MAY_BE_NULL));
+	zend_string_release(property_writeConcernError_name);
+
+	zend_string *property_writeConcern_class_MongoDB_Driver_WriteConcern = zend_string_init("MongoDB\\Driver\\WriteConcern", sizeof("MongoDB\\Driver\\WriteConcern")-1, 1);
+	zval property_writeConcern_default_value;
+	ZVAL_UNDEF(&property_writeConcern_default_value);
+	zend_string *property_writeConcern_name = zend_string_init("writeConcern", sizeof("writeConcern") - 1, 1);
+	zend_declare_typed_property(class_entry, property_writeConcern_name, &property_writeConcern_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_writeConcern_class_MongoDB_Driver_WriteConcern, 0, MAY_BE_NULL));
+	zend_string_release(property_writeConcern_name);
+
+	zval property_errorReplies_default_value;
+	ZVAL_UNDEF(&property_errorReplies_default_value);
+	zend_string *property_errorReplies_name = zend_string_init("errorReplies", sizeof("errorReplies") - 1, 1);
+	zend_declare_typed_property(class_entry, property_errorReplies_name, &property_errorReplies_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
+	zend_string_release(property_errorReplies_name);
 
 	return class_entry;
 }

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -240,10 +240,9 @@ cleanup:
 
 static void phongo_apm_server_heartbeat_succeeded(const mongoc_apm_server_heartbeat_succeeded_t* event)
 {
-	mongoc_client_t*                        client;
-	HashTable*                              subscribers;
-	phongo_serverheartbeatsucceededevent_t* p_event;
-	zval                                    z_event;
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_server_heartbeat_succeeded_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_sdamsubscriber_ce, client);
@@ -253,14 +252,7 @@ static void phongo_apm_server_heartbeat_succeeded(const mongoc_apm_server_heartb
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_serverheartbeatsucceededevent_ce);
-	p_event = Z_SERVERHEARTBEATSUCCEEDEDEVENT_OBJ_P(&z_event);
-
-	memcpy(&p_event->host, mongoc_apm_server_heartbeat_succeeded_get_host(event), sizeof(mongoc_host_list_t));
-	p_event->awaited         = mongoc_apm_server_heartbeat_succeeded_get_awaited(event);
-	p_event->duration_micros = mongoc_apm_server_heartbeat_succeeded_get_duration(event);
-	p_event->reply           = bson_copy(mongoc_apm_server_heartbeat_succeeded_get_reply(event));
-
+	phongo_serverheartbeatsucceededevent_init(&z_event, event);
 	phongo_apm_dispatch_event(subscribers, "serverHeartbeatSucceeded", &z_event);
 	zval_ptr_dtor(&z_event);
 

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -100,10 +100,9 @@ static void phongo_apm_dispatch_event(HashTable* subscribers, const char* functi
 
 static void phongo_apm_command_started(const mongoc_apm_command_started_t* event)
 {
-	mongoc_client_t*              client;
-	HashTable*                    subscribers;
-	phongo_commandstartedevent_t* p_event;
-	zval                          z_event;
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_command_started_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_commandsubscriber_ce, client);
@@ -113,23 +112,7 @@ static void phongo_apm_command_started(const mongoc_apm_command_started_t* event
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_commandstartedevent_ce);
-	p_event = Z_COMMANDSTARTEDEVENT_OBJ_P(&z_event);
-
-	memcpy(&p_event->host, mongoc_apm_command_started_get_host(event), sizeof(mongoc_host_list_t));
-
-	p_event->command_name         = estrdup(mongoc_apm_command_started_get_command_name(event));
-	p_event->database_name        = estrdup(mongoc_apm_command_started_get_database_name(event));
-	p_event->server_id            = mongoc_apm_command_started_get_server_id(event);
-	p_event->operation_id         = mongoc_apm_command_started_get_operation_id(event);
-	p_event->request_id           = mongoc_apm_command_started_get_request_id(event);
-	p_event->command              = bson_copy(mongoc_apm_command_started_get_command(event));
-	p_event->server_connection_id = mongoc_apm_command_started_get_server_connection_id_int64(event);
-	p_event->has_service_id       = mongoc_apm_command_started_get_service_id(event) != NULL;
-
-	if (p_event->has_service_id) {
-		bson_oid_copy(mongoc_apm_command_started_get_service_id(event), &p_event->service_id);
-	}
+	phongo_commandstartedevent_init(&z_event, event);
 
 	phongo_apm_dispatch_event(subscribers, "commandStarted", &z_event);
 	zval_ptr_dtor(&z_event);

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -355,10 +355,9 @@ cleanup:
 
 static void phongo_apm_topology_opening(const mongoc_apm_topology_opening_t* event)
 {
-	mongoc_client_t*               client;
-	HashTable*                     subscribers;
-	phongo_topologyopeningevent_t* p_event;
-	zval                           z_event;
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_topology_opening_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_sdamsubscriber_ce, client);
@@ -368,11 +367,7 @@ static void phongo_apm_topology_opening(const mongoc_apm_topology_opening_t* eve
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_topologyopeningevent_ce);
-	p_event = Z_TOPOLOGYOPENINGEVENT_OBJ_P(&z_event);
-
-	mongoc_apm_topology_opening_get_topology_id(event, &p_event->topology_id);
-
+	phongo_topologyopeningevent_init(&z_event, event);
 	phongo_apm_dispatch_event(subscribers, "topologyOpening", &z_event);
 	zval_ptr_dtor(&z_event);
 

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -271,10 +271,9 @@ cleanup:
 
 static void phongo_apm_server_heartbeat_started(const mongoc_apm_server_heartbeat_started_t* event)
 {
-	mongoc_client_t*                      client;
-	HashTable*                            subscribers;
-	phongo_serverheartbeatstartedevent_t* p_event;
-	zval                                  z_event;
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_server_heartbeat_started_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_sdamsubscriber_ce, client);
@@ -284,12 +283,7 @@ static void phongo_apm_server_heartbeat_started(const mongoc_apm_server_heartbea
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_serverheartbeatstartedevent_ce);
-	p_event = Z_SERVERHEARTBEATSTARTEDEVENT_OBJ_P(&z_event);
-
-	memcpy(&p_event->host, mongoc_apm_server_heartbeat_started_get_host(event), sizeof(mongoc_host_list_t));
-	p_event->awaited = mongoc_apm_server_heartbeat_started_get_awaited(event);
-
+	phongo_serverheartbeatstartedevent_init(&z_event, event);
 	phongo_apm_dispatch_event(subscribers, "serverHeartbeatStarted", &z_event);
 	zval_ptr_dtor(&z_event);
 

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -309,10 +309,9 @@ cleanup:
 
 static void phongo_apm_topology_changed(const mongoc_apm_topology_changed_t* event)
 {
-	mongoc_client_t*               client;
-	HashTable*                     subscribers;
-	phongo_topologychangedevent_t* p_event;
-	zval                           z_event;
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_topology_changed_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_sdamsubscriber_ce, client);
@@ -322,13 +321,7 @@ static void phongo_apm_topology_changed(const mongoc_apm_topology_changed_t* eve
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_topologychangedevent_ce);
-	p_event = Z_TOPOLOGYCHANGEDEVENT_OBJ_P(&z_event);
-
-	mongoc_apm_topology_changed_get_topology_id(event, &p_event->topology_id);
-	p_event->new_topology_description = mongoc_topology_description_new_copy(mongoc_apm_topology_changed_get_new_description(event));
-	p_event->old_topology_description = mongoc_topology_description_new_copy(mongoc_apm_topology_changed_get_previous_description(event));
-
+	phongo_topologychangedevent_init(&z_event, event);
 	phongo_apm_dispatch_event(subscribers, "topologyChanged", &z_event);
 	zval_ptr_dtor(&z_event);
 

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -217,11 +217,9 @@ cleanup:
 
 static void phongo_apm_server_heartbeat_failed(const mongoc_apm_server_heartbeat_failed_t* event)
 {
-	mongoc_client_t*                     client;
-	HashTable*                           subscribers;
-	phongo_serverheartbeatfailedevent_t* p_event;
-	zval                                 z_event;
-	bson_error_t                         tmp_error = { 0 };
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_server_heartbeat_failed_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_sdamsubscriber_ce, client);
@@ -231,22 +229,7 @@ static void phongo_apm_server_heartbeat_failed(const mongoc_apm_server_heartbeat
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_serverheartbeatfailedevent_ce);
-	p_event = Z_SERVERHEARTBEATFAILEDEVENT_OBJ_P(&z_event);
-
-	memcpy(&p_event->host, mongoc_apm_server_heartbeat_failed_get_host(event), sizeof(mongoc_host_list_t));
-	p_event->awaited         = mongoc_apm_server_heartbeat_failed_get_awaited(event);
-	p_event->duration_micros = mongoc_apm_server_heartbeat_failed_get_duration(event);
-
-	/* We need to process and convert the error right here, otherwise
-	 * debug_info will turn into a recursive loop, and with the wrong trace
-	 * locations */
-	mongoc_apm_server_heartbeat_failed_get_error(event, &tmp_error);
-
-	object_init_ex(&p_event->z_error, phongo_exception_from_mongoc_domain(tmp_error.domain, tmp_error.code));
-	zend_update_property_string(zend_ce_exception, Z_OBJ_P(&p_event->z_error), ZEND_STRL("message"), tmp_error.message);
-	zend_update_property_long(zend_ce_exception, Z_OBJ_P(&p_event->z_error), ZEND_STRL("code"), tmp_error.code);
-
+	phongo_serverheartbeatfailedevent_init(&z_event, event);
 	phongo_apm_dispatch_event(subscribers, "serverHeartbeatFailed", &z_event);
 	zval_ptr_dtor(&z_event);
 

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -183,11 +183,9 @@ cleanup:
 
 static void phongo_apm_command_failed(const mongoc_apm_command_failed_t* event)
 {
-	mongoc_client_t*             client;
-	HashTable*                   subscribers;
-	phongo_commandfailedevent_t* p_event;
-	zval                         z_event;
-	bson_error_t                 tmp_error = { 0 };
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_command_failed_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_commandsubscriber_ce, client);
@@ -197,34 +195,7 @@ static void phongo_apm_command_failed(const mongoc_apm_command_failed_t* event)
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_commandfailedevent_ce);
-	p_event = Z_COMMANDFAILEDEVENT_OBJ_P(&z_event);
-
-	memcpy(&p_event->host, mongoc_apm_command_failed_get_host(event), sizeof(mongoc_host_list_t));
-
-	p_event->command_name         = estrdup(mongoc_apm_command_failed_get_command_name(event));
-	p_event->database_name        = estrdup(mongoc_apm_command_failed_get_database_name(event));
-	p_event->server_id            = mongoc_apm_command_failed_get_server_id(event);
-	p_event->operation_id         = mongoc_apm_command_failed_get_operation_id(event);
-	p_event->request_id           = mongoc_apm_command_failed_get_request_id(event);
-	p_event->duration_micros      = mongoc_apm_command_failed_get_duration(event);
-	p_event->reply                = bson_copy(mongoc_apm_command_failed_get_reply(event));
-	p_event->server_connection_id = mongoc_apm_command_failed_get_server_connection_id_int64(event);
-	p_event->has_service_id       = mongoc_apm_command_failed_get_service_id(event) != NULL;
-
-	if (p_event->has_service_id) {
-		bson_oid_copy(mongoc_apm_command_failed_get_service_id(event), &p_event->service_id);
-	}
-
-	/* We need to process and convert the error right here, otherwise
-	 * debug_info will turn into a recursive loop, and with the wrong trace
-	 * locations */
-	mongoc_apm_command_failed_get_error(event, &tmp_error);
-
-	object_init_ex(&p_event->z_error, phongo_exception_from_mongoc_domain(tmp_error.domain, tmp_error.code));
-	zend_update_property_string(zend_ce_exception, Z_OBJ_P(&p_event->z_error), ZEND_STRL("message"), tmp_error.message);
-	zend_update_property_long(zend_ce_exception, Z_OBJ_P(&p_event->z_error), ZEND_STRL("code"), tmp_error.code);
-
+	phongo_commandfailedevent_init(&z_event, event);
 	phongo_apm_dispatch_event(subscribers, "commandFailed", &z_event);
 	zval_ptr_dtor(&z_event);
 

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -124,10 +124,9 @@ cleanup:
 
 static void phongo_apm_command_succeeded(const mongoc_apm_command_succeeded_t* event)
 {
-	mongoc_client_t*                client;
-	HashTable*                      subscribers;
-	phongo_commandsucceededevent_t* p_event;
-	zval                            z_event;
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_command_succeeded_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_commandsubscriber_ce, client);
@@ -137,24 +136,7 @@ static void phongo_apm_command_succeeded(const mongoc_apm_command_succeeded_t* e
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_commandsucceededevent_ce);
-	p_event = Z_COMMANDSUCCEEDEDEVENT_OBJ_P(&z_event);
-
-	memcpy(&p_event->host, mongoc_apm_command_succeeded_get_host(event), sizeof(mongoc_host_list_t));
-
-	p_event->command_name         = estrdup(mongoc_apm_command_succeeded_get_command_name(event));
-	p_event->database_name        = estrdup(mongoc_apm_command_succeeded_get_database_name(event));
-	p_event->server_id            = mongoc_apm_command_succeeded_get_server_id(event);
-	p_event->operation_id         = mongoc_apm_command_succeeded_get_operation_id(event);
-	p_event->request_id           = mongoc_apm_command_succeeded_get_request_id(event);
-	p_event->duration_micros      = mongoc_apm_command_succeeded_get_duration(event);
-	p_event->reply                = bson_copy(mongoc_apm_command_succeeded_get_reply(event));
-	p_event->server_connection_id = mongoc_apm_command_succeeded_get_server_connection_id_int64(event);
-	p_event->has_service_id       = mongoc_apm_command_succeeded_get_service_id(event) != NULL;
-
-	if (p_event->has_service_id) {
-		bson_oid_copy(mongoc_apm_command_succeeded_get_service_id(event), &p_event->service_id);
-	}
+	phongo_commandsucceededevent_init(&z_event, event);
 
 	phongo_apm_dispatch_event(subscribers, "commandSucceeded", &z_event);
 	zval_ptr_dtor(&z_event);

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -286,10 +286,9 @@ cleanup:
 
 static void phongo_apm_server_opening(const mongoc_apm_server_opening_t* event)
 {
-	mongoc_client_t*             client;
-	HashTable*                   subscribers;
-	phongo_serveropeningevent_t* p_event;
-	zval                         z_event;
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_server_opening_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_sdamsubscriber_ce, client);
@@ -299,12 +298,7 @@ static void phongo_apm_server_opening(const mongoc_apm_server_opening_t* event)
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_serveropeningevent_ce);
-	p_event = Z_SERVEROPENINGEVENT_OBJ_P(&z_event);
-
-	memcpy(&p_event->host, mongoc_apm_server_opening_get_host(event), sizeof(mongoc_host_list_t));
-	mongoc_apm_server_opening_get_topology_id(event, &p_event->topology_id);
-
+	phongo_serveropeningevent_init(&z_event, event);
 	phongo_apm_dispatch_event(subscribers, "serverOpening", &z_event);
 	zval_ptr_dtor(&z_event);
 

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -332,10 +332,9 @@ cleanup:
 
 static void phongo_apm_topology_closed(const mongoc_apm_topology_closed_t* event)
 {
-	mongoc_client_t*              client;
-	HashTable*                    subscribers;
-	phongo_topologyclosedevent_t* p_event;
-	zval                          z_event;
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_topology_closed_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_sdamsubscriber_ce, client);
@@ -345,11 +344,7 @@ static void phongo_apm_topology_closed(const mongoc_apm_topology_closed_t* event
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_topologyclosedevent_ce);
-	p_event = Z_TOPOLOGYCLOSEDEVENT_OBJ_P(&z_event);
-
-	mongoc_apm_topology_closed_get_topology_id(event, &p_event->topology_id);
-
+	phongo_topologyclosedevent_init(&z_event, event);
 	phongo_apm_dispatch_event(subscribers, "topologyClosed", &z_event);
 	zval_ptr_dtor(&z_event);
 

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -194,10 +194,9 @@ cleanup:
 
 static void phongo_apm_server_closed(const mongoc_apm_server_closed_t* event)
 {
-	mongoc_client_t*            client;
-	HashTable*                  subscribers;
-	phongo_serverclosedevent_t* p_event;
-	zval                        z_event;
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_server_closed_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_sdamsubscriber_ce, client);
@@ -207,12 +206,7 @@ static void phongo_apm_server_closed(const mongoc_apm_server_closed_t* event)
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_serverclosedevent_ce);
-	p_event = Z_SERVERCLOSEDEVENT_OBJ_P(&z_event);
-
-	memcpy(&p_event->host, mongoc_apm_server_closed_get_host(event), sizeof(mongoc_host_list_t));
-	mongoc_apm_server_closed_get_topology_id(event, &p_event->topology_id);
-
+	phongo_serverclosedevent_init(&z_event, event);
 	phongo_apm_dispatch_event(subscribers, "serverClosed", &z_event);
 	zval_ptr_dtor(&z_event);
 

--- a/src/phongo_apm.c
+++ b/src/phongo_apm.c
@@ -171,10 +171,9 @@ cleanup:
 
 static void phongo_apm_server_changed(const mongoc_apm_server_changed_t* event)
 {
-	mongoc_client_t*             client;
-	HashTable*                   subscribers;
-	phongo_serverchangedevent_t* p_event;
-	zval                         z_event;
+	mongoc_client_t* client;
+	HashTable*       subscribers;
+	zval             z_event;
 
 	client      = mongoc_apm_server_changed_get_context(event);
 	subscribers = phongo_apm_get_subscribers_to_notify(phongo_sdamsubscriber_ce, client);
@@ -184,14 +183,7 @@ static void phongo_apm_server_changed(const mongoc_apm_server_changed_t* event)
 		goto cleanup;
 	}
 
-	object_init_ex(&z_event, phongo_serverchangedevent_ce);
-	p_event = Z_SERVERCHANGEDEVENT_OBJ_P(&z_event);
-
-	memcpy(&p_event->host, mongoc_apm_server_changed_get_host(event), sizeof(mongoc_host_list_t));
-	mongoc_apm_server_changed_get_topology_id(event, &p_event->topology_id);
-	p_event->new_server_description = mongoc_server_description_new_copy(mongoc_apm_server_changed_get_new_description(event));
-	p_event->old_server_description = mongoc_server_description_new_copy(mongoc_apm_server_changed_get_previous_description(event));
-
+	phongo_serverchangedevent_init(&z_event, event);
 	phongo_apm_dispatch_event(subscribers, "serverChanged", &z_event);
 	zval_ptr_dtor(&z_event);
 

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -36,5 +36,6 @@ void phongo_serverheartbeatsucceededevent_init(zval* return_value, const mongoc_
 void phongo_serveropeningevent_init(zval* return_value, const mongoc_apm_server_opening_t* event);
 void phongo_topologychangedevent_init(zval* return_value, const mongoc_apm_topology_changed_t* event);
 void phongo_topologyclosedevent_init(zval* return_value, const mongoc_apm_topology_closed_t* event);
+void phongo_topologyopeningevent_init(zval* return_value, const mongoc_apm_topology_opening_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -25,4 +25,6 @@ bool phongo_apm_set_callbacks(mongoc_client_t* client);
 bool phongo_apm_add_subscriber(HashTable* subscribers, zval* subscriber);
 bool phongo_apm_remove_subscriber(HashTable* subscribers, zval* subscriber);
 
+void phongo_commandfailedevent_init(zval* return_value, const mongoc_apm_command_failed_t* event);
+
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -27,5 +27,6 @@ bool phongo_apm_remove_subscriber(HashTable* subscribers, zval* subscriber);
 
 void phongo_commandfailedevent_init(zval* return_value, const mongoc_apm_command_failed_t* event);
 void phongo_commandstartedevent_init(zval* return_value, const mongoc_apm_command_started_t* event);
+void phongo_commandsucceededevent_init(zval* return_value, const mongoc_apm_command_succeeded_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -33,5 +33,6 @@ void phongo_serverclosedevent_init(zval* return_value, const mongoc_apm_server_c
 void phongo_serverheartbeatfailedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_failed_t* event);
 void phongo_serverheartbeatstartedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_started_t* event);
 void phongo_serverheartbeatsucceededevent_init(zval* return_value, const mongoc_apm_server_heartbeat_succeeded_t* event);
+void phongo_serveropeningevent_init(zval* return_value, const mongoc_apm_server_opening_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -28,5 +28,6 @@ bool phongo_apm_remove_subscriber(HashTable* subscribers, zval* subscriber);
 void phongo_commandfailedevent_init(zval* return_value, const mongoc_apm_command_failed_t* event);
 void phongo_commandstartedevent_init(zval* return_value, const mongoc_apm_command_started_t* event);
 void phongo_commandsucceededevent_init(zval* return_value, const mongoc_apm_command_succeeded_t* event);
+void phongo_serverchangedevent_init(zval* return_value, const mongoc_apm_server_changed_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -29,5 +29,6 @@ void phongo_commandfailedevent_init(zval* return_value, const mongoc_apm_command
 void phongo_commandstartedevent_init(zval* return_value, const mongoc_apm_command_started_t* event);
 void phongo_commandsucceededevent_init(zval* return_value, const mongoc_apm_command_succeeded_t* event);
 void phongo_serverchangedevent_init(zval* return_value, const mongoc_apm_server_changed_t* event);
+void phongo_serverclosedevent_init(zval* return_value, const mongoc_apm_server_closed_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -32,5 +32,6 @@ void phongo_serverchangedevent_init(zval* return_value, const mongoc_apm_server_
 void phongo_serverclosedevent_init(zval* return_value, const mongoc_apm_server_closed_t* event);
 void phongo_serverheartbeatfailedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_failed_t* event);
 void phongo_serverheartbeatstartedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_started_t* event);
+void phongo_serverheartbeatsucceededevent_init(zval* return_value, const mongoc_apm_server_heartbeat_succeeded_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -31,5 +31,6 @@ void phongo_commandsucceededevent_init(zval* return_value, const mongoc_apm_comm
 void phongo_serverchangedevent_init(zval* return_value, const mongoc_apm_server_changed_t* event);
 void phongo_serverclosedevent_init(zval* return_value, const mongoc_apm_server_closed_t* event);
 void phongo_serverheartbeatfailedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_failed_t* event);
+void phongo_serverheartbeatstartedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_started_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -26,5 +26,6 @@ bool phongo_apm_add_subscriber(HashTable* subscribers, zval* subscriber);
 bool phongo_apm_remove_subscriber(HashTable* subscribers, zval* subscriber);
 
 void phongo_commandfailedevent_init(zval* return_value, const mongoc_apm_command_failed_t* event);
+void phongo_commandstartedevent_init(zval* return_value, const mongoc_apm_command_started_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -35,5 +35,6 @@ void phongo_serverheartbeatstartedevent_init(zval* return_value, const mongoc_ap
 void phongo_serverheartbeatsucceededevent_init(zval* return_value, const mongoc_apm_server_heartbeat_succeeded_t* event);
 void phongo_serveropeningevent_init(zval* return_value, const mongoc_apm_server_opening_t* event);
 void phongo_topologychangedevent_init(zval* return_value, const mongoc_apm_topology_changed_t* event);
+void phongo_topologyclosedevent_init(zval* return_value, const mongoc_apm_topology_closed_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -34,5 +34,6 @@ void phongo_serverheartbeatfailedevent_init(zval* return_value, const mongoc_apm
 void phongo_serverheartbeatstartedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_started_t* event);
 void phongo_serverheartbeatsucceededevent_init(zval* return_value, const mongoc_apm_server_heartbeat_succeeded_t* event);
 void phongo_serveropeningevent_init(zval* return_value, const mongoc_apm_server_opening_t* event);
+void phongo_topologychangedevent_init(zval* return_value, const mongoc_apm_topology_changed_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_apm.h
+++ b/src/phongo_apm.h
@@ -30,5 +30,6 @@ void phongo_commandstartedevent_init(zval* return_value, const mongoc_apm_comman
 void phongo_commandsucceededevent_init(zval* return_value, const mongoc_apm_command_succeeded_t* event);
 void phongo_serverchangedevent_init(zval* return_value, const mongoc_apm_server_changed_t* event);
 void phongo_serverclosedevent_init(zval* return_value, const mongoc_apm_server_closed_t* event);
+void phongo_serverheartbeatfailedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_failed_t* event);
 
 #endif /* PHONGO_APM_H */

--- a/src/phongo_execute.c
+++ b/src/phongo_execute.c
@@ -236,9 +236,8 @@ bool phongo_execute_bulk_write(zval* manager, const char* namespace, phongo_bulk
 	mongoc_client_t*              client = NULL;
 	bson_error_t                  error  = { 0 };
 	int                           success;
-	bson_t                        reply = BSON_INITIALIZER;
-	mongoc_bulk_operation_t*      bulk  = bulk_write->bulk;
-	phongo_writeresult_t*         writeresult;
+	bson_t                        reply         = BSON_INITIALIZER;
+	mongoc_bulk_operation_t*      bulk          = bulk_write->bulk;
 	zval*                         zwriteConcern = NULL;
 	zval*                         zsession      = NULL;
 	const mongoc_write_concern_t* write_concern = NULL;
@@ -293,8 +292,7 @@ bool phongo_execute_bulk_write(zval* manager, const char* namespace, phongo_bulk
 	success              = mongoc_bulk_operation_execute(bulk, &reply, &error);
 	bulk_write->executed = true;
 
-	writeresult                = phongo_writeresult_init(return_value, &reply, manager, mongoc_bulk_operation_get_server_id(bulk));
-	writeresult->write_concern = mongoc_write_concern_copy(write_concern);
+	phongo_writeresult_init(return_value, &reply, manager, mongoc_bulk_operation_get_server_id(bulk), write_concern);
 
 	/* A BulkWriteException is always thrown if mongoc_bulk_operation_execute()
 	 * fails to ensure that the write result is accessible. If the error does

--- a/src/phongo_structs.h
+++ b/src/phongo_structs.h
@@ -121,7 +121,6 @@ typedef struct {
 
 typedef struct {
 	mongoc_read_concern_t* read_concern;
-	HashTable*             properties;
 	zend_object            std;
 } phongo_readconcern_t;
 

--- a/src/phongo_structs.h
+++ b/src/phongo_structs.h
@@ -127,7 +127,6 @@ typedef struct {
 
 typedef struct {
 	mongoc_read_prefs_t* read_preference;
-	HashTable*           properties;
 	zend_object          std;
 } phongo_readpreference_t;
 

--- a/src/phongo_structs.h
+++ b/src/phongo_structs.h
@@ -162,7 +162,6 @@ typedef struct {
 } phongo_topologydescription_t;
 
 typedef struct {
-	HashTable*              properties;
 	mongoc_write_concern_t* write_concern;
 	zend_object             std;
 } phongo_writeconcern_t;

--- a/tests/apm/commandFailedEvent-001.phpt
+++ b/tests/apm/commandFailedEvent-001.phpt
@@ -27,15 +27,25 @@ class MySubscriber implements MongoDB\Driver\Monitoring\CommandSubscriber
     public function commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event): void
     {
         var_dump($event->getCommandName());
+        var_dump($event->commandName);
         var_dump($event->getDatabaseName());
+        var_dump($event->databaseName);
         var_dump($event->getDurationMicros());
+        var_dump($event->durationMicros);
         echo "getDurationMicros() returns > 0: ", $event->getDurationMicros() > 0 ? 'yes' : 'no', "\n";
+        echo "durationMicros returns > 0: ", $event->durationMicros > 0 ? 'yes' : 'no', "\n";
         var_dump($event->getError() instanceof MongoDB\Driver\Exception\Exception);
+        var_dump($event->error instanceof MongoDB\Driver\Exception\Exception);
         var_dump($event->getHost());
+        var_dump($event->host);
         var_dump($event->getOperationId());
+        var_dump($event->operationId);
         var_dump($event->getPort());
+        var_dump($event->port);
         var_dump($event->getReply());
+        var_dump($event->reply);
         var_dump($event->getRequestId());
+        var_dump($event->requestId);
 
         /* Note: getServerConnectionId() and getServiceId() have more stringent
          * requirements and are tested separately. */
@@ -55,16 +65,30 @@ try {
 }
 
 ?>
+===DONE===
 --EXPECTF--
 string(18) "unsupportedCommand"
+string(18) "unsupportedCommand"
+string(5) "admin"
 string(5) "admin"
 int(%d)
+int(%d)
 getDurationMicros() returns > 0: yes
+durationMicros returns > 0: yes
+bool(true)
 bool(true)
 string(%d) "%s"
+string(%d) "%s"
 string(%d) "%d"
+string(%d) "%d"
+int(%d)
 int(%d)
 object(stdClass)#%d (%d) {
   %A
 }
+object(stdClass)#%d (%d) {
+  %A
+}
 string(%d) "%d"
+string(%d) "%d"
+===DONE===

--- a/tests/apm/commandFailedEvent-002.phpt
+++ b/tests/apm/commandFailedEvent-002.phpt
@@ -29,8 +29,10 @@ class MySubscriber implements MongoDB\Driver\Monitoring\CommandSubscriber
     public function commandFailed( \MongoDB\Driver\Monitoring\CommandFailedEvent $event ): void
     {
         echo "failed: ", $event->getCommandName(), "\n";
-        echo "- requestId matches: ", $this->startRequestId == $event->getRequestId() ? 'yes' : 'no', " \n";
-        echo "- operationId matches: ", $this->startOperationId == $event->getOperationId() ? 'yes' : 'no', " \n";
+        echo "- requestId matches method: ", $this->startRequestId == $event->getRequestId() ? 'yes' : 'no', "\n";
+        echo "- operationId matches method: ", $this->startOperationId == $event->getOperationId() ? 'yes' : 'no', "\n";
+        echo "- requestId matches property: ", $this->startRequestId == $event->requestId ? 'yes' : 'no', "\n";
+        echo "- operationId matches property: ", $this->startOperationId == $event->operationId ? 'yes' : 'no', "\n";
     }
 }
 
@@ -50,8 +52,12 @@ try {
     /* Swallow */
 }
 ?>
+===DONE===
 --EXPECT--
 started: aggregate
 failed: aggregate
-- requestId matches: yes 
-- operationId matches: yes
+- requestId matches method: yes
+- operationId matches method: yes
+- requestId matches property: yes
+- operationId matches property: yes
+===DONE===

--- a/tests/apm/commandFailedEvent-debug-001.phpt
+++ b/tests/apm/commandFailedEvent-debug-001.phpt
@@ -41,13 +41,15 @@ throws(function() use ($manager, $command) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\Monitoring\CommandFailedEvent)#%d (%d) {
+object(MongoDB\Driver\Monitoring\CommandFailedEvent)#%d (11) {
   ["host"]=>
   string(%d) "%s"
   ["port"]=>
   int(%d)
   ["commandName"]=>
   string(9) "aggregate"
+  ["databaseName"]=>
+  string(%d) "%s"
   ["durationMicros"]=>
   int(%d)
   ["error"]=>

--- a/tests/apm/commandStartedEvent-001.phpt
+++ b/tests/apm/commandStartedEvent-001.phpt
@@ -13,12 +13,19 @@ class MySubscriber implements MongoDB\Driver\Monitoring\CommandSubscriber
     public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event): void
     {
         var_dump($event->getCommand());
+        var_dump($event->command);
         var_dump($event->getCommandName());
+        var_dump($event->commandName);
         var_dump($event->getDatabaseName());
+        var_dump($event->databaseName);
         var_dump($event->getHost());
+        var_dump($event->host);
         var_dump($event->getOperationId());
+        var_dump($event->operationId);
         var_dump($event->getPort());
+        var_dump($event->port);
         var_dump($event->getRequestId());
+        var_dump($event->requestId);
 
         /* Note: getServerConnectionId() and getServiceId() have more stringent
          * requirements and are tested separately. */
@@ -42,13 +49,24 @@ $command = new MongoDB\Driver\Command(['ping' => 1]);
 $manager->executeCommand('admin', $command);
 
 ?>
+===DONE===
 --EXPECTF--
 object(stdClass)#%d (%d) {
   %A
 }
+object(stdClass)#%d (%d) {
+  %A
+}
+string(4) "ping"
 string(4) "ping"
 string(5) "admin"
+string(5) "admin"
+string(%d) "%s"
 string(%d) "%s"
 string(%d) "%d"
+string(%d) "%d"
+int(%d)
 int(%d)
 string(%d) "%d"
+string(%d) "%d"
+===DONE===

--- a/tests/apm/commandStartedEvent-002.phpt
+++ b/tests/apm/commandStartedEvent-002.phpt
@@ -12,7 +12,7 @@ class MySubscriber implements MongoDB\Driver\Monitoring\CommandSubscriber
 { 
     public function commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event): void
     {
-        printf("Observed commandStarted for %s\n", $event->getCommandName());
+        printf("Observed commandStarted for %s\n", $event->commandName);
     }
  
     public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event): void {}

--- a/tests/apm/commandStartedEvent-debug-001.phpt
+++ b/tests/apm/commandStartedEvent-debug-001.phpt
@@ -32,7 +32,7 @@ $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(['ping' => 1]
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\Monitoring\CommandStartedEvent)#%d (%d) {
+object(MongoDB\Driver\Monitoring\CommandStartedEvent)#%d (9) {
   ["host"]=>
   string(%d) "%s"
   ["port"]=>

--- a/tests/apm/commandSucceededEvent-001.phpt
+++ b/tests/apm/commandSucceededEvent-001.phpt
@@ -25,14 +25,23 @@ class MySubscriber implements MongoDB\Driver\Monitoring\CommandSubscriber
     public function commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event): void
     {
         var_dump($event->getCommandName());
+        var_dump($event->commandName);
         var_dump($event->getDatabaseName());
+        var_dump($event->databaseName);
         var_dump($event->getDurationMicros());
+        var_dump($event->durationMicros);
         echo "getDurationMicros() returns > 0: ", $event->getDurationMicros() > 0 ? 'yes' : 'no', "\n";
+        echo "durationMicros returns > 0: ", $event->durationMicros > 0 ? 'yes' : 'no', "\n";
         var_dump($event->getHost());
+        var_dump($event->host);
         var_dump($event->getOperationId());
+        var_dump($event->operationId);
         var_dump($event->getPort());
+        var_dump($event->port);
         var_dump($event->getReply());
+        var_dump($event->reply);
         var_dump($event->getRequestId());
+        var_dump($event->requestId);
 
         /* Note: getServerConnectionId() and getServiceId() have more stringent
          * requirements and are tested separately. */
@@ -52,15 +61,28 @@ $command = new MongoDB\Driver\Command(['ping' => 1]);
 $manager->executeCommand('admin', $command);
 
 ?>
+===DONE===
 --EXPECTF--
 string(4) "ping"
+string(4) "ping"
+string(5) "admin"
 string(5) "admin"
 int(%d)
+int(%d)
 getDurationMicros() returns > 0: yes
+durationMicros returns > 0: yes
+string(%d) "%s"
 string(%d) "%s"
 string(%d) "%d"
+string(%d) "%d"
+int(%d)
 int(%d)
 object(stdClass)#%d (%d) {
   %A
 }
+object(stdClass)#%d (%d) {
+  %A
+}
 string(%d) "%d"
+string(%d) "%d"
+===DONE===

--- a/tests/apm/commandSucceededEvent-002.phpt
+++ b/tests/apm/commandSucceededEvent-002.phpt
@@ -25,8 +25,10 @@ class MySubscriber implements MongoDB\Driver\Monitoring\CommandSubscriber
     public function commandSucceeded( \MongoDB\Driver\Monitoring\CommandSucceededEvent $event ): void
     {
         echo "succeeded: ", $event->getCommandName(), "\n";
-        echo "- requestId matches: ", $this->startRequestId == $event->getRequestId() ? 'yes' : 'no', " \n";
-        echo "- operationId matches: ", $this->startOperationId == $event->getOperationId() ? 'yes' : 'no', " \n";
+        echo "- requestId matches method: ", $this->startRequestId == $event->getRequestId() ? 'yes' : 'no', "\n";
+        echo "- operationId matches method: ", $this->startOperationId == $event->getOperationId() ? 'yes' : 'no', "\n";
+        echo "- requestId matches property: ", $this->startRequestId == $event->requestId ? 'yes' : 'no', "\n";
+        echo "- operationId matches property: ", $this->startOperationId == $event->operationId ? 'yes' : 'no', "\n";
     }
 
     public function commandFailed( \MongoDB\Driver\Monitoring\CommandFailedEvent $event ): void
@@ -41,8 +43,12 @@ MongoDB\Driver\Monitoring\addSubscriber( $subscriber );
 
 $cursor = $m->executeQuery( "demo.test", $query );
 ?>
+===DONE===
 --EXPECT--
 started: find
 succeeded: find
-- requestId matches: yes 
-- operationId matches: yes
+- requestId matches method: yes
+- operationId matches method: yes
+- requestId matches property: yes
+- operationId matches property: yes
+===DONE===

--- a/tests/apm/commandSucceededEvent-debug-001.phpt
+++ b/tests/apm/commandSucceededEvent-debug-001.phpt
@@ -32,13 +32,15 @@ $manager->executeCommand(DATABASE_NAME, new MongoDB\Driver\Command(['ping' => 1]
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\Monitoring\CommandSucceededEvent)#%d (%d) {
+object(MongoDB\Driver\Monitoring\CommandSucceededEvent)#%d (10) {
   ["host"]=>
   string(%d) "%s"
   ["port"]=>
   int(%d)
   ["commandName"]=>
   string(4) "ping"
+  ["databaseName"]=>
+  string(%d) "%s"
   ["durationMicros"]=>
   int(%d)
   ["reply"]=>

--- a/tests/apm/serverChangedEvent-001.phpt
+++ b/tests/apm/serverChangedEvent-001.phpt
@@ -21,10 +21,15 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
         $this->isObserved = true;
 
         printf("getHost() returns a string: %s\n", is_string($event->getHost()) ? 'yes' : 'no');
+        printf("host returns a string: %s\n", is_string($event->host) ? 'yes' : 'no');
         printf("getPort() returns an integer: %s\n", is_integer($event->getPort()) ? 'yes' : 'no');
+        printf("port returns an integer: %s\n", is_integer($event->port) ? 'yes' : 'no');
         printf("getTopologyId() returns an ObjectId: %s\n", ($event->getTopologyId() instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
+        printf("topologyId returns an ObjectId: %s\n", ($event->topologyId instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
         printf("getNewDescription() returns a ServerDescription: %s\n", ($event->getNewDescription() instanceof MongoDB\Driver\ServerDescription) ? 'yes' : 'no');
+        printf("newDescription returns a ServerDescription: %s\n", ($event->newDescription instanceof MongoDB\Driver\ServerDescription) ? 'yes' : 'no');
         printf("getPreviousDescription() returns a ServerDescription: %s\n", ($event->getPreviousDescription() instanceof MongoDB\Driver\ServerDescription) ? 'yes' : 'no');
+        printf("previousDescription returns a ServerDescription: %s\n", ($event->previousDescription instanceof MongoDB\Driver\ServerDescription) ? 'yes' : 'no');
 
         var_dump($event);
     }
@@ -57,10 +62,15 @@ $m->executeCommand(DATABASE_NAME, $command);
 <?php exit(0); ?>
 --EXPECTF--
 getHost() returns a string: yes
+host returns a string: yes
 getPort() returns an integer: yes
+port returns an integer: yes
 getTopologyId() returns an ObjectId: yes
+topologyId returns an ObjectId: yes
 getNewDescription() returns a ServerDescription: yes
+newDescription returns a ServerDescription: yes
 getPreviousDescription() returns a ServerDescription: yes
+previousDescription returns a ServerDescription: yes
 object(MongoDB\Driver\Monitoring\ServerChangedEvent)#%d (%d) {
   ["host"]=>
   string(%d) "%s"
@@ -74,7 +84,7 @@ object(MongoDB\Driver\Monitoring\ServerChangedEvent)#%d (%d) {
   ["newDescription"]=>
   object(MongoDB\Driver\ServerDescription)#%d (%d) {%A
   }
-  ["oldDescription"]=>
+  ["previousDescription"]=>
   object(MongoDB\Driver\ServerDescription)#%d (%d) {%A
   }
 }

--- a/tests/apm/serverClosedEvent-001.phpt
+++ b/tests/apm/serverClosedEvent-001.phpt
@@ -23,8 +23,11 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
         $this->isObserved = true;
 
         printf("getHost() returns a string: %s\n", is_string($event->getHost()) ? 'yes' : 'no');
+        printf("host returns a string: %s\n", is_string($event->host) ? 'yes' : 'no');
         printf("getPort() returns an integer: %s\n", is_integer($event->getPort()) ? 'yes' : 'no');
+        printf("port returns an integer: %s\n", is_integer($event->port) ? 'yes' : 'no');
         printf("getTopologyId() returns an ObjectId: %s\n", ($event->getTopologyId() instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
+        printf("topologyId returns an ObjectId: %s\n", ($event->topologyId instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
 
         var_dump($event);
     }
@@ -63,8 +66,11 @@ unset($m);
 <?php exit(0); ?>
 --EXPECTF--
 getHost() returns a string: yes
+host returns a string: yes
 getPort() returns an integer: yes
+port returns an integer: yes
 getTopologyId() returns an ObjectId: yes
+topologyId returns an ObjectId: yes
 object(MongoDB\Driver\Monitoring\ServerClosedEvent)#%d (%d) {
   ["host"]=>
   string(%d) "%s"

--- a/tests/apm/serverHeartbeatFailedEvent-001.phpt
+++ b/tests/apm/serverHeartbeatFailedEvent-001.phpt
@@ -19,10 +19,15 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
     public function serverHeartbeatFailed(MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent $event): void
     {
         printf("getDurationMicros() returns an integer: %s\n", is_integer($event->getDurationMicros()) ? 'yes' : 'no');
+        printf("durationMicros returns an integer: %s\n", is_integer($event->durationMicros) ? 'yes' : 'no');
         printf("getError() returns an Exception: %s\n", ($event->getError() instanceof Exception) ? 'yes' : 'no');
+        printf("error returns an Exception: %s\n", ($event->error instanceof Exception) ? 'yes' : 'no');
         printf("getHost() returns a string: %s\n", is_string($event->getHost()) ? 'yes' : 'no');
+        printf("host returns a string: %s\n", is_string($event->host) ? 'yes' : 'no');
         printf("getPort() returns an integer: %s\n", is_integer($event->getPort()) ? 'yes' : 'no');
+        printf("port returns an integer: %s\n", is_integer($event->port) ? 'yes' : 'no');
         printf("isAwaited() returns a bool: %s\n", is_bool($event->isAwaited()) ? 'yes' : 'no');
+        printf("awaited returns a bool: %s\n", is_bool($event->awaited) ? 'yes' : 'no');
 
         var_dump($event);
     }
@@ -62,10 +67,15 @@ configureFailPoint($m2, 'failCommand', 'off');
 <?php exit(0); ?>
 --EXPECTF--
 getDurationMicros() returns an integer: yes
+durationMicros returns an integer: yes
 getError() returns an Exception: yes
+error returns an Exception: yes
 getHost() returns a string: yes
+host returns a string: yes
 getPort() returns an integer: yes
+port returns an integer: yes
 isAwaited() returns a bool: yes
+awaited returns a bool: yes
 object(MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent)#%d (%d) {
   ["host"]=>
   string(%d) "%s"

--- a/tests/apm/serverHeartbeatStartedEvent-001.phpt
+++ b/tests/apm/serverHeartbeatStartedEvent-001.phpt
@@ -27,8 +27,11 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
         $this->isObserved = true;
 
         printf("getHost() returns a string: %s\n", is_string($event->getHost()) ? 'yes' : 'no');
+        printf("host returns a string: %s\n", is_string($event->host) ? 'yes' : 'no');
         printf("getPort() returns an integer: %s\n", is_integer($event->getPort()) ? 'yes' : 'no');
+        printf("port returns an integer: %s\n", is_integer($event->port) ? 'yes' : 'no');
         printf("isAwaited() returns a bool: %s\n", is_bool($event->isAwaited()) ? 'yes' : 'no');
+        printf("awaited returns a bool: %s\n", is_bool($event->awaited) ? 'yes' : 'no');
 
         var_dump($event);
     }
@@ -55,8 +58,11 @@ $m->executeCommand(DATABASE_NAME, $command);
 <?php exit(0); ?>
 --EXPECTF--
 getHost() returns a string: yes
+host returns a string: yes
 getPort() returns an integer: yes
+port returns an integer: yes
 isAwaited() returns a bool: yes
+awaited returns a bool: yes
 object(MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent)#%d (%d) {
   ["host"]=>
   string(%d) "%s"

--- a/tests/apm/serverHeartbeatSucceededEvent-001.phpt
+++ b/tests/apm/serverHeartbeatSucceededEvent-001.phpt
@@ -29,10 +29,15 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
         $this->isObserved = true;
 
         printf("getDurationMicros() returns an integer: %s\n", is_integer($event->getDurationMicros()) ? 'yes' : 'no');
+        printf("durationMicros returns an integer: %s\n", is_integer($event->durationMicros) ? 'yes' : 'no');
         printf("getHost() returns a string: %s\n", is_string($event->getHost()) ? 'yes' : 'no');
+        printf("host returns a string: %s\n", is_string($event->host) ? 'yes' : 'no');
         printf("getPort() returns an integer: %s\n", is_integer($event->getPort()) ? 'yes' : 'no');
+        printf("port returns an integer: %s\n", is_integer($event->port) ? 'yes' : 'no');
         printf("getReply() returns an object: %s\n", is_object($event->getReply()) ? 'yes' : 'no');
+        printf("reply returns an object: %s\n", is_object($event->reply) ? 'yes' : 'no');
         printf("isAwaited() returns a bool: %s\n", is_bool($event->isAwaited()) ? 'yes' : 'no');
+        printf("awaited returns a bool: %s\n", is_bool($event->awaited) ? 'yes' : 'no');
 
         var_dump($event);
     }
@@ -57,10 +62,15 @@ $m->executeCommand(DATABASE_NAME, $command);
 <?php exit(0); ?>
 --EXPECTF--
 getDurationMicros() returns an integer: yes
+durationMicros returns an integer: yes
 getHost() returns a string: yes
+host returns a string: yes
 getPort() returns an integer: yes
+port returns an integer: yes
 getReply() returns an object: yes
+reply returns an object: yes
 isAwaited() returns a bool: yes
+awaited returns a bool: yes
 object(MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent)#%d (%d) {
   ["host"]=>
   string(%d) "%s"

--- a/tests/apm/serverOpeningEvent-001.phpt
+++ b/tests/apm/serverOpeningEvent-001.phpt
@@ -31,8 +31,11 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
         $this->isObserved = true;
 
         printf("getHost() returns a string: %s\n", is_string($event->getHost()) ? 'yes' : 'no');
+        printf("host returns a string: %s\n", is_string($event->host) ? 'yes' : 'no');
         printf("getPort() returns an integer: %s\n", is_integer($event->getPort()) ? 'yes' : 'no');
+        printf("port returns an integer: %s\n", is_integer($event->port) ? 'yes' : 'no');
         printf("getTopologyId() returns an ObjectId: %s\n", ($event->getTopologyId() instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
+        printf("topologyId returns an ObjectId: %s\n", ($event->topologyId instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
 
         var_dump($event);
     }
@@ -55,8 +58,11 @@ $m->executeCommand(DATABASE_NAME, $command);
 <?php exit(0); ?>
 --EXPECTF--
 getHost() returns a string: yes
+host returns a string: yes
 getPort() returns an integer: yes
+port returns an integer: yes
 getTopologyId() returns an ObjectId: yes
+topologyId returns an ObjectId: yes
 object(MongoDB\Driver\Monitoring\ServerOpeningEvent)#%d (%d) {
   ["host"]=>
   string(%d) "%s"

--- a/tests/apm/topologyChangedEvent-001.phpt
+++ b/tests/apm/topologyChangedEvent-001.phpt
@@ -33,8 +33,11 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
         $this->isObserved = true;
 
         printf("getTopologyId() returns an ObjectId: %s\n", ($event->getTopologyId() instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
+        printf("topologyId returns an ObjectId: %s\n", ($event->topologyId instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
         printf("getNewDescription() returns a TopologyDescription: %s\n", ($event->getNewDescription() instanceof MongoDB\Driver\TopologyDescription) ? 'yes' : 'no');
+        printf("newDescription returns a TopologyDescription: %s\n", ($event->newDescription instanceof MongoDB\Driver\TopologyDescription) ? 'yes' : 'no');
         printf("getPreviousDescription() returns a TopologyDescription: %s\n", ($event->getPreviousDescription() instanceof MongoDB\Driver\TopologyDescription) ? 'yes' : 'no');
+        printf("previousDescription returns a TopologyDescription: %s\n", ($event->previousDescription instanceof MongoDB\Driver\TopologyDescription) ? 'yes' : 'no');
 
         var_dump($event);
     }
@@ -55,8 +58,11 @@ $m->executeCommand(DATABASE_NAME, $command);
 <?php exit(0); ?>
 --EXPECTF--
 getTopologyId() returns an ObjectId: yes
+topologyId returns an ObjectId: yes
 getNewDescription() returns a TopologyDescription: yes
+newDescription returns a TopologyDescription: yes
 getPreviousDescription() returns a TopologyDescription: yes
+previousDescription returns a TopologyDescription: yes
 object(MongoDB\Driver\Monitoring\TopologyChangedEvent)#%d (%d) {
   ["topologyId"]=>
   object(MongoDB\BSON\ObjectId)#%d (%d) {
@@ -66,7 +72,7 @@ object(MongoDB\Driver\Monitoring\TopologyChangedEvent)#%d (%d) {
   ["newDescription"]=>
   object(MongoDB\Driver\TopologyDescription)#%d (%d) {%A
   }
-  ["oldDescription"]=>
+  ["previousDescription"]=>
   object(MongoDB\Driver\TopologyDescription)#%d (%d) {%A
   }
 }

--- a/tests/apm/topologyClosedEvent-001.phpt
+++ b/tests/apm/topologyClosedEvent-001.phpt
@@ -26,6 +26,7 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
     public function topologyClosed(MongoDB\Driver\Monitoring\TopologyClosedEvent $event): void
     {
         printf("getTopologyId() returns an ObjectId: %s\n", ($event->getTopologyId() instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
+        printf("topologyId returns an ObjectId: %s\n", ($event->topologyId instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
 
         var_dump($event);
     }
@@ -52,6 +53,7 @@ unset($m);
 <?php exit(0); ?>
 --EXPECTF--
 getTopologyId() returns an ObjectId: yes
+topologyId returns an ObjectId: yes
 object(MongoDB\Driver\Monitoring\TopologyClosedEvent)#%d (%d) {
   ["topologyId"]=>
   object(MongoDB\BSON\ObjectId)#%d (%d) {

--- a/tests/apm/topologyOpeningEvent-001.phpt
+++ b/tests/apm/topologyOpeningEvent-001.phpt
@@ -28,6 +28,7 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
     public function topologyOpening(MongoDB\Driver\Monitoring\TopologyOpeningEvent $event): void
     {
         printf("getTopologyId() returns an ObjectId: %s\n", ($event->getTopologyId() instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
+        printf("topologyId returns an ObjectId: %s\n", ($event->topologyId instanceof MongoDB\BSON\ObjectId) ? 'yes' : 'no');
 
         var_dump($event);
     }
@@ -44,6 +45,7 @@ $m->executeCommand(DATABASE_NAME, $command);
 <?php exit(0); ?>
 --EXPECTF--
 getTopologyId() returns an ObjectId: yes
+topologyId returns an ObjectId: yes
 object(MongoDB\Driver\Monitoring\TopologyOpeningEvent)#%d (%d) {
   ["topologyId"]=>
   object(MongoDB\BSON\ObjectId)#%d (%d) {

--- a/tests/exception/bulkwriteexception-getwriteresult-001.phpt
+++ b/tests/exception/bulkwriteexception-getwriteresult-001.phpt
@@ -24,16 +24,19 @@ try {
 <?php exit(0); ?>
 --EXPECTF--
 object(MongoDB\Driver\WriteResult)#%d (%d) {
-  ["nInserted"]=>
+  ["insertedCount"]=>
   int(1)
-  ["nMatched"]=>
+  ["matchedCount"]=>
   int(0)
-  ["nModified"]=>
+  ["modifiedCount"]=>
   int(0)
-  ["nRemoved"]=>
+  ["deletedCount"]=>
   int(0)
-  ["nUpserted"]=>
+  ["upsertedCount"]=>
   int(0)
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {%A
+  }
   ["upsertedIds"]=>
   array(0) {
   }

--- a/tests/exception/bulkwriteexception-getwriteresult-001.phpt
+++ b/tests/exception/bulkwriteexception-getwriteresult-001.phpt
@@ -54,7 +54,13 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcernError"]=>
   NULL
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
+    ["w"]=>
+    NULL
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
+    int(0)
   }
   ["errorReplies"]=>
   array(0) {

--- a/tests/manager/bug0851-001.phpt
+++ b/tests/manager/bug0851-001.phpt
@@ -51,5 +51,9 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/manager/manager-ctor-read_preference-001.phpt
+++ b/tests/manager/manager-ctor-read_preference-001.phpt
@@ -26,6 +26,12 @@ foreach ($tests as $test) {
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -41,16 +47,30 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -66,11 +86,19 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/manager/manager-ctor-read_preference-002.phpt
+++ b/tests/manager/manager-ctor-read_preference-002.phpt
@@ -24,31 +24,51 @@ foreach ($tests as $test) {
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1231)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1231)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(2000)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1231)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1231)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/manager/manager-ctor-write_concern-001.phpt
+++ b/tests/manager/manager-ctor-write_concern-001.phpt
@@ -25,36 +25,68 @@ foreach ($tests as $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(0)
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
-  int(1)
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
-  string(8) "majority"
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
-  string(12) "customTagSet"
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
   int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(12) "customTagSet"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(0)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  string(8) "majority"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  string(12) "customTagSet"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
 ===DONE===

--- a/tests/manager/manager-ctor-write_concern-002.phpt
+++ b/tests/manager/manager-ctor-write_concern-002.phpt
@@ -27,51 +27,75 @@ foreach ($tests as $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
-  %rint\(4294967296\)|string\(10\) "4294967296"%r
+  %rint\(4294967296\)|int\(4294967295\)%r
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(2)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(12) "customTagSet"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(2)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(12) "customTagSet"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }

--- a/tests/manager/manager-ctor-write_concern-003.phpt
+++ b/tests/manager/manager-ctor-write_concern-003.phpt
@@ -21,20 +21,36 @@ foreach ($tests as $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
   ["j"]=>
   bool(true)
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
   ["j"]=>
   bool(false)
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
   ["j"]=>
   bool(true)
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
   ["j"]=>
   bool(false)
+  ["wtimeout"]=>
+  int(0)
 }
 ===DONE===

--- a/tests/manager/manager-ctor-write_concern-004.phpt
+++ b/tests/manager/manager-ctor-write_concern-004.phpt
@@ -29,44 +29,84 @@ foreach ($tests as $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
   int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
-  int(1)
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(0)
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
-  int(1)
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
   int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
   int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(0)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
+  int(0)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(0)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(0)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
   int(0)
 }
 ===DONE===

--- a/tests/manager/manager-ctor-write_concern-005.phpt
+++ b/tests/manager/manager-ctor-write_concern-005.phpt
@@ -18,22 +18,28 @@ foreach ($tests as $uri) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(2)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
-  %rint\(4294967296\)|string\(10\) "4294967296"%r
+  %rint\(4294967296\)|int\(4294967295\)%r
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
-  %rint\(4294967296\)|string\(10\) "4294967296"%r
+  %rint\(4294967296\)|int\(4294967295\)%r
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(12) "customTagSet"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
-  %rint\(4294967296\)|string\(10\) "4294967296"%r
+  %rint\(4294967296\)|int\(4294967295\)%r
 }
 ===DONE===

--- a/tests/manager/manager-ctor-write_concern-006.phpt
+++ b/tests/manager/manager-ctor-write_concern-006.phpt
@@ -22,21 +22,27 @@ foreach ($tests as $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(2)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(4294967296)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(4294967296)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(12) "customTagSet"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(4294967296)
 }

--- a/tests/manager/manager-executeBulkWrite_error-005.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-005.phpt
@@ -59,7 +59,13 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcernError"]=>
   NULL
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
+    ["w"]=>
+    NULL
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
+    int(0)
   }
   ["errorReplies"]=>
   array(0) {

--- a/tests/manager/manager-executeBulkWrite_error-005.phpt
+++ b/tests/manager/manager-executeBulkWrite_error-005.phpt
@@ -40,16 +40,19 @@ try {
 MongoDB\Driver\Exception\BulkWriteException(0): Bulk write failed due to previous MongoDB\Driver\Exception\ConnectionTimeoutException: Failed to send "delete" command with database "%s": Failed to read 4 bytes: socket error or timeout
 MongoDB\Driver\Exception\ConnectionTimeoutException(%d): Failed to send "delete" command with database "%s": Failed to read 4 bytes: socket error or timeout
 object(MongoDB\Driver\WriteResult)#%d (%d) {
-  ["nInserted"]=>
+  ["insertedCount"]=>
   int(1)
-  ["nMatched"]=>
+  ["matchedCount"]=>
   int(1)
-  ["nModified"]=>
+  ["modifiedCount"]=>
   int(1)
-  ["nRemoved"]=>
+  ["deletedCount"]=>
   int(0)
-  ["nUpserted"]=>
+  ["upsertedCount"]=>
   int(0)
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {%A
+  }
   ["upsertedIds"]=>
   array(0) {
   }

--- a/tests/manager/manager-getreadconcern-001.phpt
+++ b/tests/manager/manager-getreadconcern-001.phpt
@@ -28,6 +28,8 @@ foreach ($tests as $i => $test) {
 <?php exit(0); ?>
 --EXPECTF--
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
+  ["level"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
   ["level"]=>

--- a/tests/manager/manager-getreadpreference-001.phpt
+++ b/tests/manager/manager-getreadpreference-001.phpt
@@ -29,18 +29,42 @@ foreach ($tests as $i => $test) {
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -58,6 +82,10 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -75,6 +103,10 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -87,5 +119,9 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
       string(2) "ca"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/manager/manager-getwriteconcern-001.phpt
+++ b/tests/manager/manager-getwriteconcern-001.phpt
@@ -30,57 +30,91 @@ foreach ($tests as $i => $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
   ["j"]=>
   bool(true)
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
   ["j"]=>
   bool(true)
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
   ["j"]=>
   bool(false)
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(2)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(12) "customTagSet"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }

--- a/tests/readConcern/bug1598-002.phpt
+++ b/tests/readConcern/bug1598-002.phpt
@@ -24,5 +24,5 @@ printf("Collected cycles: %d\n", gc_collect_cycles());
 <?php exit(0); ?>
 --EXPECT--
 Collected cycles: 0
-Collected cycles: 2
+Collected cycles: 3
 ===DONE===

--- a/tests/readConcern/readconcern-compare-001.phpt
+++ b/tests/readConcern/readconcern-compare-001.phpt
@@ -1,0 +1,59 @@
+--TEST--
+MongoDB\Driver\ReadConcern equality comparison
+--FILE--
+<?php
+
+$tests = [
+    'same level' => [
+        'a' => new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL),
+        'b' => new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL)
+    ],
+    'same default (no level)' => [
+        'a' => new MongoDB\Driver\ReadConcern(),
+        'b' => new MongoDB\Driver\ReadConcern()
+    ],
+    'different levels' => [
+        'a' => new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL),
+        'b' => new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY)
+    ],
+    'one has level and the other does not' => [
+        'a' => new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL),
+        'b' => new MongoDB\Driver\ReadConcern()
+    ],
+    'Object comparison fallback if one value is not a ReadConcern' => [
+        'a' => new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::LOCAL),
+        'b' => new MongoDB\BSON\Int64('1')
+    ],
+];
+
+foreach ($tests as $name => $test) {
+    echo "\nTesting $name:\n";
+    var_dump($test['a'] <=> $test['b']);
+    var_dump($test['b'] <=> $test['a']);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+
+Testing same level:
+int(0)
+int(0)
+
+Testing same default (no level):
+int(0)
+int(0)
+
+Testing different levels:
+int(-1)
+int(1)
+
+Testing one has level and the other does not:
+int(1)
+int(-1)
+
+Testing Object comparison fallback if one value is not a ReadConcern:
+int(1)
+int(1)
+===DONE===

--- a/tests/readConcern/readconcern-ctor-001.phpt
+++ b/tests/readConcern/readconcern-ctor-001.phpt
@@ -13,8 +13,12 @@ var_dump(new MongoDB\Driver\ReadConcern('not-yet-supported'));
 <?php exit(0); ?>
 --EXPECTF--
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
+  ["level"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
+  ["level"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
   ["level"]=>

--- a/tests/readConcern/readconcern-debug-001.phpt
+++ b/tests/readConcern/readconcern-debug-001.phpt
@@ -19,6 +19,8 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECTF--
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
+  ["level"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
   ["level"]=>

--- a/tests/readConcern/readconcern-getlevel-001.phpt
+++ b/tests/readConcern/readconcern-getlevel-001.phpt
@@ -12,6 +12,7 @@ $tests = [
 foreach ($tests as $test) {
     $rc = new MongoDB\Driver\ReadConcern($test);
     var_dump($rc->getLevel());
+    var_dump($rc->level);
 }
 
 ?>
@@ -19,6 +20,9 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 NULL
+NULL
 string(5) "local"
+string(5) "local"
+string(17) "not-yet-supported"
 string(17) "not-yet-supported"
 ===DONE===

--- a/tests/readConcern/readconcern-serialization-002.phpt
+++ b/tests/readConcern/readconcern-serialization-002.phpt
@@ -22,9 +22,13 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECTF--
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
+  ["level"]=>
+  NULL
 }
-O:26:"MongoDB\Driver\ReadConcern":0:{}
+O:26:"MongoDB\Driver\ReadConcern":1:{s:5:"level";N;}
 object(MongoDB\Driver\ReadConcern)#%d (%d) {
+  ["level"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadConcern)#%d (%d) {

--- a/tests/readConcern/readconcern-set_state-001.phpt
+++ b/tests/readConcern/readconcern-set_state-001.phpt
@@ -22,6 +22,7 @@ echo "\n\n";
 ))
 
 %r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
+%w'level' => NULL,
 ))
 
 ===DONE===

--- a/tests/readConcern/readconcern-var_export-001.phpt
+++ b/tests/readConcern/readconcern-var_export-001.phpt
@@ -19,6 +19,7 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECTF--
 %r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
+   'level' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadConcern::__set_state(array(
    'level' => 'local',

--- a/tests/readPreference/bug0146-001.phpt
+++ b/tests/readPreference/bug0146-001.phpt
@@ -58,6 +58,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["session"]=>
   NULL
@@ -96,6 +102,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(16) "primaryPreferred"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["session"]=>
   NULL
@@ -134,6 +146,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(9) "secondary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["session"]=>
   NULL
@@ -172,6 +190,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(18) "secondaryPreferred"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["session"]=>
   NULL
@@ -210,6 +234,12 @@ object(MongoDB\Driver\Cursor)#%d (%d) {
   object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "nearest"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["session"]=>
   NULL

--- a/tests/readPreference/bug0851-001.phpt
+++ b/tests/readPreference/bug0851-001.phpt
@@ -43,5 +43,9 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/readPreference/bug1598-002.phpt
+++ b/tests/readPreference/bug1598-002.phpt
@@ -8,7 +8,12 @@ PHPC-1598: ReadPreference get_gc should delegate to zend_std_get_properties
 
 /* Store an additional object reference as a public property on the
  * ReadPreference. This will leak if get_gc returns internally cached properties
- * (from our get_properties handler) instead of zend_std_get_properties. */
+ * (from our get_properties handler) instead of zend_std_get_properties.
+ *
+ * Note: since ReadPreference uses typed properties, PHP stores dynamic
+ * properties in a separate obj->properties HashTable. This HashTable is itself
+ * a GC-collectable value, so 3 cycles are collected: the stdClass, the
+ * ReadPreference object, and the dynamic properties HashTable. */
 $a = new stdClass;
 $a->rp = new MongoDB\Driver\ReadPreference('primary');
 $a->rp->a = $a;
@@ -24,5 +29,5 @@ printf("Collected cycles: %d\n", gc_collect_cycles());
 <?php exit(0); ?>
 --EXPECT--
 Collected cycles: 0
-Collected cycles: 2
+Collected cycles: 3
 ===DONE===

--- a/tests/readPreference/bug1698-001.phpt
+++ b/tests/readPreference/bug1698-001.phpt
@@ -21,7 +21,7 @@ var_dump($uriTagSets);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\ReadPreference)#%d (2) {
+object(MongoDB\Driver\ReadPreference)#%d (4) {
   ["mode"]=>
   string(9) "secondary"
   ["tags"]=>
@@ -32,6 +32,10 @@ object(MongoDB\Driver\ReadPreference)#%d (2) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 array(2) {
   ["mode"]=>
@@ -45,7 +49,7 @@ array(2) {
     }
   }
 }
-object(MongoDB\Driver\ReadPreference)#%d (2) {
+object(MongoDB\Driver\ReadPreference)#%d (4) {
   ["mode"]=>
   string(9) "secondary"
   ["tags"]=>
@@ -56,6 +60,10 @@ object(MongoDB\Driver\ReadPreference)#%d (2) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 array(1) {
   [0]=>
@@ -64,7 +72,7 @@ array(1) {
     string(2) "ny"
   }
 }
-object(MongoDB\Driver\ReadPreference)#%d (2) {
+object(MongoDB\Driver\ReadPreference)#%d (4) {
   ["mode"]=>
   string(9) "secondary"
   ["tags"]=>
@@ -75,6 +83,10 @@ object(MongoDB\Driver\ReadPreference)#%d (2) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 array(1) {
   [0]=>

--- a/tests/readPreference/readpreference-compare-001.phpt
+++ b/tests/readPreference/readpreference-compare-001.phpt
@@ -1,0 +1,112 @@
+--TEST--
+MongoDB\Driver\ReadPreference equality comparison
+--FILE--
+<?php
+
+$tests = [
+    'same mode' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY),
+        'b' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY)
+    ],
+    'same mode and tag sets' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'east']]),
+        'b' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'east']])
+    ],
+    'same mode and maxStalenessSeconds' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 120]),
+        'b' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 120])
+    ],
+    'different modes' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY),
+        'b' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY)
+    ],
+    'different tag sets' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'east']]),
+        'b' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'west']])
+    ],
+    'different maxStalenessSeconds' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 120]),
+        'b' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 180])
+    ],
+    'one has tag sets and the other does not' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, [['dc' => 'east']]),
+        'b' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY)
+    ],
+    'one has maxStalenessSeconds and the other does not' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => 120]),
+        'b' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY)
+    ],
+    'different hedges' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => ['enabled' => false]]),
+        'b' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => ['enabled' => true]])
+    ],
+    'one has hedges sets and the other does not' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => ['enabled' => true]]),
+        'b' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY)
+    ],
+    'Object comparison fallback if one value is not a ReadPreference' => [
+        'a' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY),
+        'b' => new MongoDB\BSON\Int64('1')
+    ],
+];
+
+foreach ($tests as $name => $test) {
+    echo "\nTesting $name:\n";
+    var_dump($test['a'] <=> $test['b']);
+    var_dump($test['b'] <=> $test['a']);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
+
+Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
+
+Testing same mode:
+int(0)
+int(0)
+
+Testing same mode and tag sets:
+int(0)
+int(0)
+
+Testing same mode and maxStalenessSeconds:
+int(0)
+int(0)
+
+Testing different modes:
+int(-1)
+int(1)
+
+Testing different tag sets:
+int(-1)
+int(1)
+
+Testing different maxStalenessSeconds:
+int(-1)
+int(1)
+
+Testing one has tag sets and the other does not:
+int(1)
+int(-1)
+
+Testing one has maxStalenessSeconds and the other does not:
+int(1)
+int(-1)
+
+Testing different hedges:
+int(-1)
+int(1)
+
+Testing one has hedges sets and the other does not:
+int(1)
+int(-1)
+
+Testing Object comparison fallback if one value is not a ReadPreference:
+int(1)
+int(1)
+===DONE===

--- a/tests/readPreference/readpreference-ctor-001.phpt
+++ b/tests/readPreference/readpreference-ctor-001.phpt
@@ -15,6 +15,12 @@ var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECOND
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -27,15 +33,29 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
       string(3) "one"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
 ===DONE===

--- a/tests/readPreference/readpreference-ctor-002.phpt
+++ b/tests/readPreference/readpreference-ctor-002.phpt
@@ -37,60 +37,150 @@ foreach ($data as $item) {
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }

--- a/tests/readPreference/readpreference-debug-001.phpt
+++ b/tests/readPreference/readpreference-debug-001.phpt
@@ -30,26 +30,62 @@ Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -62,6 +98,10 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
@@ -84,16 +124,28 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
   ["hedge"]=>
   object(stdClass)#%d (%d) {
     ["enabled"]=>

--- a/tests/readPreference/readpreference-getHedge-001.phpt
+++ b/tests/readPreference/readpreference-getHedge-001.phpt
@@ -15,6 +15,7 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['hedge' => $test]);
     var_dump($rp->getHedge());
+    var_dump($rp->hedge);
 }
 
 ?>
@@ -26,9 +27,16 @@ Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is 
 Deprecated: Method MongoDB\Driver\ReadPreference::getHedge() is deprecated in %s
 NULL
 
+Deprecated: main(): Property MongoDB\Driver\ReadPreference::hedge is deprecated in %s
+NULL
+
 Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
 
 Deprecated: Method MongoDB\Driver\ReadPreference::getHedge() is deprecated in %s
+object(stdClass)#%d (%d) {
+  ["enabled"]=>
+  bool(true)
+}
 object(stdClass)#%d (%d) {
   ["enabled"]=>
   bool(true)
@@ -41,10 +49,18 @@ object(stdClass)#%d (%d) {
   ["enabled"]=>
   bool(true)
 }
+object(stdClass)#%d (%d) {
+  ["enabled"]=>
+  bool(true)
+}
 
 Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
 
 Deprecated: Method MongoDB\Driver\ReadPreference::getHedge() is deprecated in %s
+object(stdClass)#%d (%d) {
+  ["foo"]=>
+  string(3) "bar"
+}
 object(stdClass)#%d (%d) {
   ["foo"]=>
   string(3) "bar"

--- a/tests/readPreference/readpreference-getMaxStalenessMS-001.phpt
+++ b/tests/readPreference/readpreference-getMaxStalenessMS-001.phpt
@@ -16,6 +16,7 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY, null, ['maxStalenessSeconds' => $test]);
     var_dump($rp->getMaxStalenessSeconds());
+    var_dump($rp->maxStalenessSeconds);
 }
 
 ?>
@@ -23,8 +24,13 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 int(-1)
+int(-1)
+int(90)
+int(90)
 int(90)
 int(90)
 int(1000)
+int(1000)
+int(2147483647)
 int(2147483647)
 ===DONE===

--- a/tests/readPreference/readpreference-getMaxStalenessMS-002.phpt
+++ b/tests/readPreference/readpreference-getMaxStalenessMS-002.phpt
@@ -16,6 +16,7 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference("secondary", null, ['maxStalenessSeconds' => $test]);
     var_dump($rp->getMaxStalenessSeconds());
+    var_dump($rp->maxStalenessSeconds);
 }
 
 ?>
@@ -23,8 +24,13 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 int(-1)
+int(-1)
+int(90)
+int(90)
 int(90)
 int(90)
 int(1000)
+int(1000)
+int(2147483647)
 int(2147483647)
 ===DONE===

--- a/tests/readPreference/readpreference-getModeString-001.phpt
+++ b/tests/readPreference/readpreference-getModeString-001.phpt
@@ -14,6 +14,7 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference($test);
     var_dump($rp->getModeString());
+    var_dump($rp->mode);
 }
 
 ?>
@@ -21,8 +22,13 @@ foreach ($tests as $test) {
 <?php exit(0); ?>
 --EXPECT--
 string(7) "primary"
+string(7) "primary"
+string(16) "primaryPreferred"
 string(16) "primaryPreferred"
 string(9) "secondary"
+string(9) "secondary"
 string(18) "secondaryPreferred"
+string(18) "secondaryPreferred"
+string(7) "nearest"
 string(7) "nearest"
 ===DONE===

--- a/tests/readPreference/readpreference-getTagSets-001.phpt
+++ b/tests/readPreference/readpreference-getTagSets-001.phpt
@@ -13,16 +13,19 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED, $test);
     var_dump($rp->getTagSets());
+    var_dump($rp->tags);
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 array(0) {
 }
+NULL
 array(0) {
 }
+NULL
 array(2) {
   [0]=>
   array(1) {
@@ -31,6 +34,16 @@ array(2) {
   }
   [1]=>
   array(0) {
+  }
+}
+array(2) {
+  [0]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "ny"
+  }
+  [1]=>
+  object(stdClass)#%d (%d) {
   }
 }
 array(3) {
@@ -48,6 +61,23 @@ array(3) {
   }
   [2]=>
   array(0) {
+  }
+}
+array(3) {
+  [0]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "ny"
+  }
+  [1]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "sf"
+    ["use"]=>
+    string(9) "reporting"
+  }
+  [2]=>
+  object(stdClass)#%d (%d) {
   }
 }
 ===DONE===

--- a/tests/readPreference/readpreference-getTagSets-002.phpt
+++ b/tests/readPreference/readpreference-getTagSets-002.phpt
@@ -13,16 +13,19 @@ $tests = [
 foreach ($tests as $test) {
     $rp = new MongoDB\Driver\ReadPreference("secondaryPreferred", $test);
     var_dump($rp->getTagSets());
+    var_dump($rp->tags);
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
---EXPECT--
+--EXPECTF--
 array(0) {
 }
+NULL
 array(0) {
 }
+NULL
 array(2) {
   [0]=>
   array(1) {
@@ -31,6 +34,16 @@ array(2) {
   }
   [1]=>
   array(0) {
+  }
+}
+array(2) {
+  [0]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "ny"
+  }
+  [1]=>
+  object(stdClass)#%d (%d) {
   }
 }
 array(3) {
@@ -48,6 +61,23 @@ array(3) {
   }
   [2]=>
   array(0) {
+  }
+}
+array(3) {
+  [0]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "ny"
+  }
+  [1]=>
+  object(stdClass)#%d (%d) {
+    ["dc"]=>
+    string(2) "sf"
+    ["use"]=>
+    string(9) "reporting"
+  }
+  [2]=>
+  object(stdClass)#%d (%d) {
   }
 }
 ===DONE===

--- a/tests/readPreference/readpreference-serialization-002.phpt
+++ b/tests/readPreference/readpreference-serialization-002.phpt
@@ -33,61 +33,133 @@ Deprecated: MongoDB\Driver\ReadPreference::__construct(): The "hedge" option is 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:7:"primary";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:7:"primary";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "primary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:16:"primaryPreferred";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:16:"primaryPreferred";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(16) "primaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:9:"secondary";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:18:"secondaryPreferred";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:18:"secondaryPreferred";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(18) "secondaryPreferred"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:7:"nearest";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:7:"nearest";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(7) "nearest"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":1:{s:4:"mode";s:9:"secondary";}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
@@ -101,8 +173,12 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":2:{s:4:"mode";s:9:"secondary";s:4:"tags";a:1:{i:0;O:8:"stdClass":1:{s:2:"dc";s:2:"ny";}}}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";a:1:{i:0;O:8:"stdClass":1:{s:2:"dc";s:2:"ny";}}s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
@@ -114,6 +190,10 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
       string(2) "ny"
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
@@ -137,8 +217,12 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":2:{s:4:"mode";s:9:"secondary";s:4:"tags";a:3:{i:0;O:8:"stdClass":1:{s:2:"dc";s:2:"ny";}i:1;O:8:"stdClass":2:{s:2:"dc";s:2:"sf";s:3:"use";s:9:"reporting";}i:2;O:8:"stdClass":0:{}}}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";a:3:{i:0;O:8:"stdClass":1:{s:2:"dc";s:2:"ny";}i:1;O:8:"stdClass":2:{s:2:"dc";s:2:"sf";s:3:"use";s:9:"reporting";}i:2;O:8:"stdClass":0:{}}s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
@@ -160,37 +244,57 @@ object(MongoDB\Driver\ReadPreference)#%d (%d) {
     object(stdClass)#%d (%d) {
     }
   }
+  ["maxStalenessSeconds"]=>
+  int(-1)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
-O:29:"MongoDB\Driver\ReadPreference":2:{s:4:"mode";s:9:"secondary";s:19:"maxStalenessSeconds";i:1000;}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";N;s:19:"maxStalenessSeconds";i:1000;s:5:"hedge";N;}
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
   ["maxStalenessSeconds"]=>
   int(1000)
+  ["hedge"]=>
+  NULL
 }
 
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
   ["hedge"]=>
   object(stdClass)#%d (%d) {
     ["enabled"]=>
     bool(true)
   }
 }
-O:29:"MongoDB\Driver\ReadPreference":2:{s:4:"mode";s:9:"secondary";s:5:"hedge";O:8:"stdClass":1:{s:7:"enabled";b:1;}}
+O:29:"MongoDB\Driver\ReadPreference":4:{s:4:"mode";s:9:"secondary";s:4:"tags";N;s:19:"maxStalenessSeconds";i:-1;s:5:"hedge";O:8:"stdClass":1:{s:7:"enabled";b:1;}}
 
 Deprecated: MongoDB\Driver\ReadPreference::__unserialize(): The "hedge" option is deprecated as of MongoDB 8.0 and will be removed in a future release in %s
 object(MongoDB\Driver\ReadPreference)#%d (%d) {
   ["mode"]=>
   string(9) "secondary"
+  ["tags"]=>
+  NULL
+  ["maxStalenessSeconds"]=>
+  int(-1)
   ["hedge"]=>
   object(stdClass)#%d (%d) {
     ["enabled"]=>

--- a/tests/readPreference/readpreference-set_state-001.phpt
+++ b/tests/readPreference/readpreference-set_state-001.phpt
@@ -28,22 +28,37 @@ foreach ($tests as $fields) {
 --EXPECTF--
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'primary',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'primaryPreferred',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondaryPreferred',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'nearest',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
@@ -55,6 +70,8 @@ foreach ($tests as $fields) {
        'dc' => 'ny',
     ),
   ),
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
@@ -74,11 +91,15 @@ foreach ($tests as $fields) {
     (object) array(
     ),
   ),
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
+   'tags' => NULL,
    'maxStalenessSeconds' => 1000,
+   'hedge' => NULL,
 ))
 
 ===DONE===

--- a/tests/readPreference/readpreference-var_export-001.phpt
+++ b/tests/readPreference/readpreference-var_export-001.phpt
@@ -27,21 +27,39 @@ foreach ($tests as $test) {
 --EXPECTF--
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'primary',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'primaryPreferred',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondaryPreferred',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'nearest',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'primary',
+   'tags' => NULL,
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
@@ -52,6 +70,8 @@ foreach ($tests as $test) {
        'dc' => 'ny',
     ),
   ),
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
@@ -70,9 +90,13 @@ foreach ($tests as $test) {
     (object) array(
     ),
   ),
+   'maxStalenessSeconds' => -1,
+   'hedge' => NULL,
 ))
 %r\\?%rMongoDB\Driver\ReadPreference::__set_state(array(
    'mode' => 'secondary',
+   'tags' => NULL,
    'maxStalenessSeconds' => 1000,
+   'hedge' => NULL,
 ))
 ===DONE===

--- a/tests/replicaset/writeresult-getserver-002.phpt
+++ b/tests/replicaset/writeresult-getserver-002.phpt
@@ -60,16 +60,20 @@ bool(false)
 int(%d)
 int(%d)
 object(MongoDB\Driver\WriteResult)#%d (%d) {
-  ["nInserted"]=>
+  ["insertedCount"]=>
   int(1)
-  ["nMatched"]=>
+  ["matchedCount"]=>
   int(0)
-  ["nModified"]=>
+  ["modifiedCount"]=>
   int(0)
-  ["nRemoved"]=>
+  ["deletedCount"]=>
   int(0)
-  ["nUpserted"]=>
+  ["upsertedCount"]=>
   int(0)
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
   ["upsertedIds"]=>
   array(0) {
   }

--- a/tests/replicaset/writeresult-getserver-002.phpt
+++ b/tests/replicaset/writeresult-getserver-002.phpt
@@ -79,9 +79,13 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcernError"]=>
   NULL
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
     ["w"]=>
     int(1)
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
+    int(0)
   }
   ["errorReplies"]=>
   array(0) {

--- a/tests/server/server-executeBulkWrite-001.phpt
+++ b/tests/server/server-executeBulkWrite-001.phpt
@@ -71,7 +71,13 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcernError"]=>
   NULL
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
+    ["w"]=>
+    NULL
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
+    int(0)
   }
   ["errorReplies"]=>
   array(0) {

--- a/tests/server/server-executeBulkWrite-001.phpt
+++ b/tests/server/server-executeBulkWrite-001.phpt
@@ -45,25 +45,23 @@ upsertedCount: 1
 deletedCount: 1
 upsertedId[3]: int(3)
 object(MongoDB\Driver\WriteResult)#%d (%d) {
-  ["nInserted"]=>
+  ["insertedCount"]=>
   int(2)
-  ["nMatched"]=>
+  ["matchedCount"]=>
   int(1)
-  ["nModified"]=>
+  ["modifiedCount"]=>
   int(1)
-  ["nRemoved"]=>
+  ["deletedCount"]=>
   int(1)
-  ["nUpserted"]=>
+  ["upsertedCount"]=>
   int(1)
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {%A
+  }
   ["upsertedIds"]=>
   array(1) {
-    [0]=>
-    array(%d) {
-      ["index"]=>
-      int(3)
-      ["_id"]=>
-      int(3)
-    }
+    [3]=>
+    int(3)
   }
   ["writeErrors"]=>
   array(0) {

--- a/tests/session/session-debug-005.phpt
+++ b/tests/session/session-debug-005.phpt
@@ -78,6 +78,12 @@ object(MongoDB\Driver\Session)#%d (%d) {
     object(MongoDB\Driver\ReadPreference)#%d (%d) {
       ["mode"]=>
       string(7) "primary"
+      ["tags"]=>
+      NULL
+      ["maxStalenessSeconds"]=>
+      int(-1)
+      ["hedge"]=>
+      NULL
     }
   }
 }

--- a/tests/session/session-debug-006.phpt
+++ b/tests/session/session-debug-006.phpt
@@ -74,9 +74,13 @@ object(MongoDB\Driver\Session)#%d (%d) {
       NULL
     }
     ["writeConcern"]=>
-    object(MongoDB\Driver\WriteConcern)#%d (%d) {
+    object(MongoDB\Driver\WriteConcern)#%d (3) {
       ["w"]=>
       string(8) "majority"
+      ["j"]=>
+      NULL
+      ["wtimeout"]=>
+      int(0)
     }
   }
 }

--- a/tests/session/session-debug-006.phpt
+++ b/tests/session/session-debug-006.phpt
@@ -66,6 +66,12 @@ object(MongoDB\Driver\Session)#%d (%d) {
     object(MongoDB\Driver\ReadPreference)#%d (%d) {
       ["mode"]=>
       string(16) "primaryPreferred"
+      ["tags"]=>
+      NULL
+      ["maxStalenessSeconds"]=>
+      int(-1)
+      ["hedge"]=>
+      NULL
     }
     ["writeConcern"]=>
     object(MongoDB\Driver\WriteConcern)#%d (%d) {

--- a/tests/session/session-getTransactionOptions-001.phpt
+++ b/tests/session/session-getTransactionOptions-001.phpt
@@ -43,18 +43,30 @@ foreach ($options as $test) {
 NULL
 array(1) {
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
 }
 array(2) {
   ["maxCommitTimeMS"]=>
   int(1)
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
 }
 array(2) {
@@ -64,23 +76,41 @@ array(2) {
     string(8) "majority"
   }
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
 }
 array(1) {
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(16) "primaryPreferred"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
 }
 array(2) {
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["writeConcern"]=>
   object(MongoDB\Driver\WriteConcern)#%d (1) {
@@ -97,9 +127,15 @@ array(4) {
     string(8) "majority"
   }
   ["readPreference"]=>
-  object(MongoDB\Driver\ReadPreference)#%d (1) {
+  object(MongoDB\Driver\ReadPreference)#%d (%d) {
     ["mode"]=>
     string(7) "primary"
+    ["tags"]=>
+    NULL
+    ["maxStalenessSeconds"]=>
+    int(-1)
+    ["hedge"]=>
+    NULL
   }
   ["writeConcern"]=>
   object(MongoDB\Driver\WriteConcern)#%d (1) {

--- a/tests/session/session-getTransactionOptions-001.phpt
+++ b/tests/session/session-getTransactionOptions-001.phpt
@@ -113,9 +113,13 @@ array(2) {
     NULL
   }
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (1) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
     ["w"]=>
     string(8) "majority"
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
+    int(0)
   }
 }
 array(4) {
@@ -138,9 +142,13 @@ array(4) {
     NULL
   }
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (1) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
     ["w"]=>
     string(8) "majority"
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
+    int(0)
   }
 }
 ===DONE===

--- a/tests/standalone/writeresult-isacknowledged-001.phpt
+++ b/tests/standalone/writeresult-isacknowledged-001.phpt
@@ -23,16 +23,19 @@ var_dump($result);
 --EXPECTF--
 WriteResult::isAcknowledged(): true
 object(MongoDB\Driver\WriteResult)#%d (%d) {
-  ["nInserted"]=>
+  ["insertedCount"]=>
   int(1)
-  ["nMatched"]=>
+  ["matchedCount"]=>
   int(0)
-  ["nModified"]=>
+  ["modifiedCount"]=>
   int(0)
-  ["nRemoved"]=>
+  ["deletedCount"]=>
   int(0)
-  ["nUpserted"]=>
+  ["upsertedCount"]=>
   int(0)
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {%A
+  }
   ["upsertedIds"]=>
   array(0) {
   }

--- a/tests/standalone/writeresult-isacknowledged-001.phpt
+++ b/tests/standalone/writeresult-isacknowledged-001.phpt
@@ -42,7 +42,13 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcernError"]=>
   NULL
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
+    ["w"]=>
+    NULL
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
+    int(0)
   }
   ["errorReplies"]=>
   array(0) {

--- a/tests/standalone/writeresult-isacknowledged-002.phpt
+++ b/tests/standalone/writeresult-isacknowledged-002.phpt
@@ -45,8 +45,12 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcernError"]=>
   NULL
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
     ["w"]=>
+    int(0)
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
     int(0)
   }
   ["errorReplies"]=>

--- a/tests/standalone/writeresult-isacknowledged-002.phpt
+++ b/tests/standalone/writeresult-isacknowledged-002.phpt
@@ -26,16 +26,19 @@ var_dump($result);
 --EXPECTF--
 WriteResult::isAcknowledged(): false
 object(MongoDB\Driver\WriteResult)#%d (%d) {
-  ["nInserted"]=>
-  int(0)
-  ["nMatched"]=>
-  int(0)
-  ["nModified"]=>
-  int(0)
-  ["nRemoved"]=>
-  int(0)
-  ["nUpserted"]=>
-  int(0)
+  ["insertedCount"]=>
+  NULL
+  ["matchedCount"]=>
+  NULL
+  ["modifiedCount"]=>
+  NULL
+  ["deletedCount"]=>
+  NULL
+  ["upsertedCount"]=>
+  NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {%A
+  }
   ["upsertedIds"]=>
   array(0) {
   }

--- a/tests/standalone/writeresult-isacknowledged-003.phpt
+++ b/tests/standalone/writeresult-isacknowledged-003.phpt
@@ -23,16 +23,19 @@ var_dump($result);
 --EXPECTF--
 WriteResult::isAcknowledged(): false
 object(MongoDB\Driver\WriteResult)#%d (%d) {
-  ["nInserted"]=>
+  ["insertedCount"]=>
   NULL
-  ["nMatched"]=>
+  ["matchedCount"]=>
   NULL
-  ["nModified"]=>
+  ["modifiedCount"]=>
   NULL
-  ["nRemoved"]=>
+  ["deletedCount"]=>
   NULL
-  ["nUpserted"]=>
+  ["upsertedCount"]=>
   NULL
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {%A
+  }
   ["upsertedIds"]=>
   array(0) {
   }

--- a/tests/standalone/writeresult-isacknowledged-003.phpt
+++ b/tests/standalone/writeresult-isacknowledged-003.phpt
@@ -42,8 +42,12 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcernError"]=>
   NULL
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
     ["w"]=>
+    int(0)
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
     int(0)
   }
   ["errorReplies"]=>

--- a/tests/writeConcern/bug1598-002.phpt
+++ b/tests/writeConcern/bug1598-002.phpt
@@ -27,5 +27,5 @@ printf("Collected cycles: %d\n", gc_collect_cycles());
 <?php exit(0); ?>
 --EXPECT--
 Collected cycles: 0
-Collected cycles: 2
+Collected cycles: 3
 ===DONE===

--- a/tests/writeConcern/writeconcern-compare-001.phpt
+++ b/tests/writeConcern/writeconcern-compare-001.phpt
@@ -1,0 +1,107 @@
+--TEST--
+MongoDB\Driver\WriteConcern equality comparison
+--FILE--
+<?php
+
+$tests = [
+    'same w (string)' => [
+        'a' => new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY),
+        'b' => new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY),
+    ],
+    'same w (int)' => [
+        'a' => new MongoDB\Driver\WriteConcern(1),
+        'b' => new MongoDB\Driver\WriteConcern(1),
+    ],
+    'same default (no w)' => [
+        'a' => new MongoDB\Driver\WriteConcern(-2),
+        'b' => new MongoDB\Driver\WriteConcern(-2),
+    ],
+    'same w and j' => [
+        'a' => new MongoDB\Driver\WriteConcern(1, 0, true),
+        'b' => new MongoDB\Driver\WriteConcern(1, 0, true),
+    ],
+    'same w and wtimeout' => [
+        'a' => new MongoDB\Driver\WriteConcern(1, 1000),
+        'b' => new MongoDB\Driver\WriteConcern(1, 1000),
+    ],
+    'different w (int)' => [
+        'a' => new MongoDB\Driver\WriteConcern(1),
+        'b' => new MongoDB\Driver\WriteConcern(2),
+    ],
+    'different w (string)' => [
+        'a' => new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY),
+        'b' => new MongoDB\Driver\WriteConcern('tag'),
+    ],
+    'one has w and the other does not' => [
+        'a' => new MongoDB\Driver\WriteConcern(1),
+        'b' => new MongoDB\Driver\WriteConcern(-2),
+    ],
+    'different j' => [
+        'a' => new MongoDB\Driver\WriteConcern(1, 0, false),
+        'b' => new MongoDB\Driver\WriteConcern(1, 0, true),
+    ],
+    'different wtimeout' => [
+        'a' => new MongoDB\Driver\WriteConcern(1, 500),
+        'b' => new MongoDB\Driver\WriteConcern(1, 1000),
+    ],
+    'Object comparison fallback if one value is not a WriteConcern' => [
+        'a' => new MongoDB\Driver\WriteConcern(1),
+        'b' => new MongoDB\BSON\Int64('1'),
+    ],
+];
+
+foreach ($tests as $name => $test) {
+    echo "\nTesting $name:\n";
+    var_dump($test['a'] <=> $test['b']);
+    var_dump($test['b'] <=> $test['a']);
+}
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+
+Testing same w (string):
+int(0)
+int(0)
+
+Testing same w (int):
+int(0)
+int(0)
+
+Testing same default (no w):
+int(0)
+int(0)
+
+Testing same w and j:
+int(0)
+int(0)
+
+Testing same w and wtimeout:
+int(0)
+int(0)
+
+Testing different w (int):
+int(-1)
+int(1)
+
+Testing different w (string):
+int(-1)
+int(1)
+
+Testing one has w and the other does not:
+int(1)
+int(-1)
+
+Testing different j:
+int(-1)
+int(1)
+
+Testing different wtimeout:
+int(-1)
+int(1)
+
+Testing Object comparison fallback if one value is not a WriteConcern:
+int(1)
+int(1)
+===DONE===

--- a/tests/writeConcern/writeconcern-ctor-001.phpt
+++ b/tests/writeConcern/writeconcern-ctor-001.phpt
@@ -20,37 +20,55 @@ var_dump(new MongoDB\Driver\WriteConcern("string", 6000, null));
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(2)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(2)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(2000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(7) "tagname"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(6) "string"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(3000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(6) "string"
   ["j"]=>
@@ -58,7 +76,7 @@ object(MongoDB\Driver\WriteConcern)#%d (%d) {
   ["wtimeout"]=>
   int(4000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(6) "string"
   ["j"]=>
@@ -66,9 +84,11 @@ object(MongoDB\Driver\WriteConcern)#%d (%d) {
   ["wtimeout"]=>
   int(5000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(6) "string"
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(6000)
 }

--- a/tests/writeConcern/writeconcern-ctor-002.phpt
+++ b/tests/writeConcern/writeconcern-ctor-002.phpt
@@ -11,9 +11,11 @@ var_dump(new MongoDB\Driver\WriteConcern(1, 2147483648));
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(2147483648)
 }

--- a/tests/writeConcern/writeconcern-debug-001.phpt
+++ b/tests/writeConcern/writeconcern-debug-001.phpt
@@ -14,6 +14,8 @@ var_dump(new MongoDB\Driver\WriteConcern(-2, 1000, true));
 <?php exit(0); ?>
 --EXPECTF--
 object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  ["w"]=>
+  NULL
   ["j"]=>
   bool(true)
   ["wtimeout"]=>

--- a/tests/writeConcern/writeconcern-debug-002.phpt
+++ b/tests/writeConcern/writeconcern-debug-002.phpt
@@ -11,11 +11,15 @@ var_dump(new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY, 
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(3) "tag"
   ["j"]=>
@@ -23,7 +27,7 @@ object(MongoDB\Driver\WriteConcern)#%d (%d) {
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
   ["j"]=>

--- a/tests/writeConcern/writeconcern-debug-003.phpt
+++ b/tests/writeConcern/writeconcern-debug-003.phpt
@@ -30,49 +30,87 @@ foreach ($tests as $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
-  int(-1)
-}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
   int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(-1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(0)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(3) "tag"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
   ["j"]=>
   bool(false)
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
   ["j"]=>
@@ -80,18 +118,28 @@ object(MongoDB\Driver\WriteConcern)#%d (%d) {
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
   ["j"]=>
   bool(true)
+  ["wtimeout"]=>
+  int(0)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(2)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
-  %rint\(2147483648\)|string\(10\) "2147483648"%r
+  %rint\(2147483648\)|int\(2147483647\)%r
 }
 ===DONE===

--- a/tests/writeConcern/writeconcern-getjournal-001.phpt
+++ b/tests/writeConcern/writeconcern-getjournal-001.phpt
@@ -14,20 +14,28 @@ $tests = array(
 foreach ($tests as $test) {
     $wc = new MongoDB\Driver\WriteConcern(1, 0, $test);
     var_dump($wc->getJournal());
+    var_dump($wc->j);
 }
 
 // Test with default value
 $wc = new MongoDB\Driver\WriteConcern(1, 0);
 var_dump($wc->getJournal());
+var_dump($wc->j);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
 bool(true)
-bool(false)
 bool(true)
 bool(false)
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+NULL
+NULL
 NULL
 NULL
 ===DONE===

--- a/tests/writeConcern/writeconcern-getw-001.phpt
+++ b/tests/writeConcern/writeconcern-getw-001.phpt
@@ -18,6 +18,7 @@ $tests = array(
 foreach ($tests as $test) {
     $wc = new MongoDB\Driver\WriteConcern($test);
     var_dump($wc->getW());
+    var_dump($wc->w);
 }
 
 ?>
@@ -26,11 +27,20 @@ foreach ($tests as $test) {
 --EXPECT--
 string(8) "majority"
 string(8) "majority"
+string(8) "majority"
+string(8) "majority"
+NULL
 NULL
 int(-1)
+int(-1)
+int(0)
 int(0)
 int(1)
+int(1)
+int(2)
 int(2)
 string(3) "tag"
+string(3) "tag"
+string(1) "2"
 string(1) "2"
 ===DONE===

--- a/tests/writeConcern/writeconcern-getwtimeout-001.phpt
+++ b/tests/writeConcern/writeconcern-getwtimeout-001.phpt
@@ -11,17 +11,22 @@ $tests = array(
 foreach ($tests as $test) {
     $wc = new MongoDB\Driver\WriteConcern(1, $test);
     var_dump($wc->getWtimeout());
+    var_dump($wc->wtimeout);
 }
 
 // Test with default value
 $wc = new MongoDB\Driver\WriteConcern(1);
 var_dump($wc->getWtimeout());
+var_dump($wc->wtimeout);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
 int(0)
+int(0)
 int(1)
+int(1)
+int(0)
 int(0)
 ===DONE===

--- a/tests/writeConcern/writeconcern-serialization-002.phpt
+++ b/tests/writeConcern/writeconcern-serialization-002.phpt
@@ -35,111 +35,187 @@ foreach ($tests as $test) {
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
-}
-O:27:"MongoDB\Driver\WriteConcern":1:{s:1:"w";s:8:"majority";}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
-  string(8) "majority"
-}
-
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-}
-O:27:"MongoDB\Driver\WriteConcern":0:{}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-}
-
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
-  int(-1)
-}
-O:27:"MongoDB\Driver\WriteConcern":1:{s:1:"w";i:-1;}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
-  int(-1)
-}
-
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
-  ["w"]=>
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
   int(0)
 }
-O:27:"MongoDB\Driver\WriteConcern":1:{s:1:"w";i:0;}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";s:8:"majority";s:1:"j";N;s:8:"wtimeout";i:0;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
+  string(8) "majority"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
   int(0)
 }
 
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
-  int(1)
+  NULL
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-O:27:"MongoDB\Driver\WriteConcern":1:{s:1:"w";i:1;}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";N;s:1:"j";N;s:8:"wtimeout";i:0;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
-  int(1)
+  NULL
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
 
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(-1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";i:-1;s:1:"j";N;s:8:"wtimeout";i:0;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(-1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(0)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";i:0;s:1:"j";N;s:8:"wtimeout";i:0;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(0)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";i:1;s:1:"j";N;s:8:"wtimeout";i:0;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
+}
+
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-O:27:"MongoDB\Driver\WriteConcern":1:{s:1:"w";s:8:"majority";}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";s:8:"majority";s:1:"j";N;s:8:"wtimeout";i:0;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(8) "majority"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
 
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(3) "tag"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-O:27:"MongoDB\Driver\WriteConcern":1:{s:1:"w";s:3:"tag";}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";s:3:"tag";s:1:"j";N;s:8:"wtimeout";i:0;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   string(3) "tag"
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
 
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
-O:27:"MongoDB\Driver\WriteConcern":1:{s:1:"w";i:1;}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";i:1;s:1:"j";N;s:8:"wtimeout";i:0;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
+  ["wtimeout"]=>
+  int(0)
 }
 
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
   ["j"]=>
   bool(false)
+  ["wtimeout"]=>
+  int(0)
 }
-O:27:"MongoDB\Driver\WriteConcern":2:{s:1:"w";i:1;s:1:"j";b:0;}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";i:1;s:1:"j";b:0;s:8:"wtimeout";i:0;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
   ["j"]=>
   bool(false)
+  ["wtimeout"]=>
+  int(0)
 }
 
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-O:27:"MongoDB\Driver\WriteConcern":2:{s:1:"w";i:1;s:8:"wtimeout";i:1000;}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";i:1;s:1:"j";N;s:8:"wtimeout";i:1000;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
 
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
   ["j"]=>
@@ -148,7 +224,7 @@ object(MongoDB\Driver\WriteConcern)#%d (%d) {
   int(1000)
 }
 O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";i:1;s:1:"j";b:1;s:8:"wtimeout";i:1000;}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(1)
   ["j"]=>
@@ -157,38 +233,58 @@ object(MongoDB\Driver\WriteConcern)#%d (%d) {
   int(1000)
 }
 
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
   ["j"]=>
   bool(true)
+  ["wtimeout"]=>
+  int(0)
 }
-O:27:"MongoDB\Driver\WriteConcern":1:{s:1:"j";b:1;}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";N;s:1:"j";b:1;s:8:"wtimeout";i:0;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
   ["j"]=>
   bool(true)
+  ["wtimeout"]=>
+  int(0)
 }
 
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
-O:27:"MongoDB\Driver\WriteConcern":1:{s:8:"wtimeout";i:1000;}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";N;s:1:"j";N;s:8:"wtimeout";i:1000;}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
+  ["w"]=>
+  NULL
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
   int(1000)
 }
 
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(2)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
-  %rint\(2147483648\)|string\(10\) "2147483648"%r
+  %rint\(2147483648\)|int\(2147483647\)%r
 }
-O:27:"MongoDB\Driver\WriteConcern":2:{s:1:"w";i:2;s:8:"wtimeout";s:10:"2147483648";}
-object(MongoDB\Driver\WriteConcern)#%d (%d) {
+O:27:"MongoDB\Driver\WriteConcern":3:{s:1:"w";i:2;s:1:"j";N;s:8:"wtimeout";%ri:2147483648;|i:2147483647;%r}
+object(MongoDB\Driver\WriteConcern)#%d (3) {
   ["w"]=>
   int(2)
+  ["j"]=>
+  NULL
   ["wtimeout"]=>
-  %rint\(2147483648\)|string\(10\) "2147483648"%r
+  %rint\(2147483648\)|int\(2147483647\)%r
 }
 
 ===DONE===

--- a/tests/writeConcern/writeconcern-set_state-001.phpt
+++ b/tests/writeConcern/writeconcern-set_state-001.phpt
@@ -31,38 +31,55 @@ foreach ($tests as $fields) {
 --EXPECTF--
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 'majority',
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
+   'w' => NULL,
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => -1,
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 0,
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 1,
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 'majority',
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 'tag',
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 1,
    'j' => false,
+   'wtimeout' => 0,
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 1,
+   'j' => NULL,
    'wtimeout' => 1000,
 ))
 
@@ -73,15 +90,21 @@ foreach ($tests as $fields) {
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
+   'w' => NULL,
    'j' => true,
+   'wtimeout' => 0,
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
+   'w' => NULL,
+   'j' => NULL,
    'wtimeout' => 1000,
 ))
 
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
-   'wtimeout' => %r2147483648|'2147483648'%r,
+   'w' => NULL,
+   'j' => NULL,
+   'wtimeout' => %r2147483648|2147483647%r,
 ))
 
 ===DONE===

--- a/tests/writeConcern/writeconcern-var_export-001.phpt
+++ b/tests/writeConcern/writeconcern-var_export-001.phpt
@@ -32,33 +32,52 @@ foreach ($tests as $test) {
 --EXPECTF--
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 'majority',
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
+   'w' => NULL,
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => -1,
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 0,
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 1,
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 'majority',
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 'tag',
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 1,
+   'j' => NULL,
+   'wtimeout' => 0,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 1,
    'j' => false,
+   'wtimeout' => 0,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 1,
+   'j' => NULL,
    'wtimeout' => 1000,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
@@ -67,13 +86,18 @@ foreach ($tests as $test) {
    'wtimeout' => 1000,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
+   'w' => NULL,
    'j' => true,
+   'wtimeout' => 0,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
+   'w' => NULL,
+   'j' => NULL,
    'wtimeout' => 1000,
 ))
 %r\\?%rMongoDB\Driver\WriteConcern::__set_state(array(
    'w' => 2,
-   'wtimeout' => %r2147483648|'2147483648'%r,
+   'j' => NULL,
+   'wtimeout' => %r2147483648|2147483647%r,
 ))
 ===DONE===

--- a/tests/writeResult/writeresult-debug-001.phpt
+++ b/tests/writeResult/writeresult-debug-001.phpt
@@ -65,7 +65,13 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
   ["writeConcernError"]=>
   NULL
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
+    ["w"]=>
+    NULL
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
+    int(0)
   }
   ["errorReplies"]=>
   array(0) {

--- a/tests/writeResult/writeresult-debug-001.phpt
+++ b/tests/writeResult/writeresult-debug-001.phpt
@@ -26,37 +26,31 @@ var_dump($result);
 <?php exit(0); ?>
 --EXPECTF--
 object(MongoDB\Driver\WriteResult)#%d (%d) {
-  ["nInserted"]=>
+  ["insertedCount"]=>
   int(1)
-  ["nMatched"]=>
+  ["matchedCount"]=>
   int(1)
-  ["nModified"]=>
+  ["modifiedCount"]=>
   int(1)
-  ["nRemoved"]=>
+  ["deletedCount"]=>
   int(1)
-  ["nUpserted"]=>
+  ["upsertedCount"]=>
   int(2)
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
   ["upsertedIds"]=>
   array(2) {
-    [0]=>
-    array(2) {
-      ["index"]=>
-      int(2)
-      ["_id"]=>
-      object(MongoDB\BSON\ObjectId)#%d (%d) {
-        ["oid"]=>
-        string(24) "%x"
-      }
+    [2]=>
+    object(MongoDB\BSON\ObjectId)#%d (%d) {
+      ["oid"]=>
+      string(24) "%x"
     }
-    [1]=>
-    array(2) {
-      ["index"]=>
-      int(3)
-      ["_id"]=>
-      object(MongoDB\BSON\ObjectId)#%d (%d) {
-        ["oid"]=>
-        string(24) "%x"
-      }
+    [3]=>
+    object(MongoDB\BSON\ObjectId)#%d (%d) {
+      ["oid"]=>
+      string(24) "%x"
     }
   }
   ["writeErrors"]=>

--- a/tests/writeResult/writeresult-debug-002.phpt
+++ b/tests/writeResult/writeresult-debug-002.phpt
@@ -111,9 +111,13 @@ object(MongoDB\Driver\WriteResult)#%d (%d) {
     %a
   }
   ["writeConcern"]=>
-  object(MongoDB\Driver\WriteConcern)#%d (%d) {
+  object(MongoDB\Driver\WriteConcern)#%d (3) {
     ["w"]=>
     int(30)
+    ["j"]=>
+    NULL
+    ["wtimeout"]=>
+    int(0)
   }
   ["errorReplies"]=>
   array(0) {

--- a/tests/writeResult/writeresult-debug-002.phpt
+++ b/tests/writeResult/writeresult-debug-002.phpt
@@ -32,37 +32,31 @@ try {
 <?php exit(0); ?>
 --EXPECTF--
 object(MongoDB\Driver\WriteResult)#%d (%d) {
-  ["nInserted"]=>
+  ["insertedCount"]=>
   int(3)
-  ["nMatched"]=>
+  ["matchedCount"]=>
   int(0)
-  ["nModified"]=>
+  ["modifiedCount"]=>
   int(0)
-  ["nRemoved"]=>
+  ["deletedCount"]=>
   int(0)
-  ["nUpserted"]=>
+  ["upsertedCount"]=>
   int(2)
+  ["server"]=>
+  object(MongoDB\Driver\Server)#%d (%d) {
+    %a
+  }
   ["upsertedIds"]=>
   array(2) {
     [0]=>
-    array(2) {
-      ["index"]=>
-      int(0)
-      ["_id"]=>
-      object(MongoDB\BSON\ObjectId)#%d (%d) {
-        ["oid"]=>
-        string(24) "%x"
-      }
+    object(MongoDB\BSON\ObjectId)#%d (%d) {
+      ["oid"]=>
+      string(24) "%x"
     }
     [1]=>
-    array(2) {
-      ["index"]=>
-      int(1)
-      ["_id"]=>
-      object(MongoDB\BSON\ObjectId)#%d (%d) {
-        ["oid"]=>
-        string(24) "%x"
-      }
+    object(MongoDB\BSON\ObjectId)#%d (%d) {
+      ["oid"]=>
+      string(24) "%x"
     }
   }
   ["writeErrors"]=>

--- a/tests/writeResult/writeresult-getErrorReplies-001.phpt
+++ b/tests/writeResult/writeresult-getErrorReplies-001.phpt
@@ -19,22 +19,28 @@ configureTargetedFailPoint(
     ['errorCode' => 8, 'failCommands' => ['insert']]
 );
 
+function dumpErrors(array $errors): void
+{
+    var_dump(count($errors));
+    var_dump($errors[0]->code);
+}
+
 $errors = [];
 try {
     $bulk = new MongoDB\Driver\BulkWrite;
     $bulk->insert(['_id' => 1, 'x' => 'bar']);
     $server->executeBulkWrite(NS, $bulk);
 } catch (MongoDB\Driver\Exception\BulkWriteException $e) {
-    $errors = $e->getWriteResult()->getErrorReplies();
+    dumpErrors($e->getWriteResult()->getErrorReplies());
+    dumpErrors($e->getWriteResult()->errorReplies);
 }
-
-var_dump(count($errors));
-var_dump($errors[0]->code);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
+int(1)
+int(8)
 int(1)
 int(8)
 ===DONE===

--- a/tests/writeResult/writeresult-getdeletedcount-001.phpt
+++ b/tests/writeResult/writeresult-getdeletedcount-001.phpt
@@ -20,10 +20,12 @@ $bulk->delete(['x' => 1]);
 $result = $manager->executeBulkWrite(NS, $bulk);
 
 var_dump($result->getDeletedCount());
+var_dump($result->deletedCount);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
+int(1)
 int(1)
 ===DONE===

--- a/tests/writeResult/writeresult-getdeletedcount-002.phpt
+++ b/tests/writeResult/writeresult-getdeletedcount-002.phpt
@@ -22,6 +22,7 @@ $result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\D
 echo throws(function() use ($result) {
     $result->getDeletedCount();
 }, MongoDB\Driver\Exception\LogicException::class), "\n";
+var_dump($result->deletedCount);
 
 ?>
 ===DONE===
@@ -29,4 +30,5 @@ echo throws(function() use ($result) {
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\LogicException
 MongoDB\Driver\WriteResult::getDeletedCount() should not be called for an unacknowledged write result
+NULL
 ===DONE===

--- a/tests/writeResult/writeresult-getinsertedcount-001.phpt
+++ b/tests/writeResult/writeresult-getinsertedcount-001.phpt
@@ -20,10 +20,12 @@ $bulk->delete(['x' => 1]);
 $result = $manager->executeBulkWrite(NS, $bulk);
 
 var_dump($result->getInsertedCount());
+var_dump($result->insertedCount);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
+int(1)
 int(1)
 ===DONE===

--- a/tests/writeResult/writeresult-getinsertedcount-002.phpt
+++ b/tests/writeResult/writeresult-getinsertedcount-002.phpt
@@ -23,10 +23,13 @@ echo throws(function() use ($result) {
     $result->getInsertedCount();
 }, MongoDB\Driver\Exception\LogicException::class), "\n";
 
+var_dump($result->insertedCount);
+
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\LogicException
 MongoDB\Driver\WriteResult::getInsertedCount() should not be called for an unacknowledged write result
+NULL
 ===DONE===

--- a/tests/writeResult/writeresult-getmatchedcount-001.phpt
+++ b/tests/writeResult/writeresult-getmatchedcount-001.phpt
@@ -20,10 +20,12 @@ $bulk->delete(['x' => 1]);
 $result = $manager->executeBulkWrite(NS, $bulk);
 
 var_dump($result->getMatchedCount());
+var_dump($result->matchedCount);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
+int(1)
 int(1)
 ===DONE===

--- a/tests/writeResult/writeresult-getmatchedcount-002.phpt
+++ b/tests/writeResult/writeresult-getmatchedcount-002.phpt
@@ -23,10 +23,13 @@ echo throws(function() use ($result) {
     $result->getMatchedCount();
 }, MongoDB\Driver\Exception\LogicException::class), "\n";
 
+var_dump($result->matchedCount);
+
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\LogicException
 MongoDB\Driver\WriteResult::getMatchedCount() should not be called for an unacknowledged write result
+NULL
 ===DONE===

--- a/tests/writeResult/writeresult-getmodifiedcount-001.phpt
+++ b/tests/writeResult/writeresult-getmodifiedcount-001.phpt
@@ -20,10 +20,12 @@ $bulk->delete(['x' => 1]);
 $result = $manager->executeBulkWrite(NS, $bulk);
 
 var_dump($result->getModifiedCount());
+var_dump($result->modifiedCount);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
+int(1)
 int(1)
 ===DONE===

--- a/tests/writeResult/writeresult-getmodifiedcount-002.phpt
+++ b/tests/writeResult/writeresult-getmodifiedcount-002.phpt
@@ -23,10 +23,13 @@ echo throws(function() use ($result) {
     $result->getModifiedCount();
 }, MongoDB\Driver\Exception\LogicException::class), "\n";
 
+var_dump($result->modifiedCount);
+
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\LogicException
 MongoDB\Driver\WriteResult::getModifiedCount() should not be called for an unacknowledged write result
+NULL
 ===DONE===

--- a/tests/writeResult/writeresult-getserver-001.phpt
+++ b/tests/writeResult/writeresult-getserver-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MongoDB\Driver\WriteResult::getUpsertedIds()
+MongoDB\Driver\WriteResult::getServer()
 --SKIPIF--
 <?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
 <?php skip_if_not_live(); ?>
@@ -17,10 +17,12 @@ $bulk->insert(['x' => 1]);
 $result = $server->executeBulkWrite(NS, $bulk);
 
 var_dump($result->getServer() == $server);
+var_dump($result->server == $server);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
+bool(true)
 bool(true)
 ===DONE===

--- a/tests/writeResult/writeresult-getupsertedcount-001.phpt
+++ b/tests/writeResult/writeresult-getupsertedcount-001.phpt
@@ -20,10 +20,12 @@ $bulk->delete(['x' => 1]);
 $result = $manager->executeBulkWrite(NS, $bulk);
 
 var_dump($result->getUpsertedCount());
+var_dump($result->upsertedCount);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
+int(2)
 int(2)
 ===DONE===

--- a/tests/writeResult/writeresult-getupsertedcount-002.phpt
+++ b/tests/writeResult/writeresult-getupsertedcount-002.phpt
@@ -23,10 +23,13 @@ echo throws(function() use ($result) {
     $result->getUpsertedCount();
 }, MongoDB\Driver\Exception\LogicException::class), "\n";
 
+var_dump($result->upsertedCount);
+
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
 OK: Got MongoDB\Driver\Exception\LogicException
 MongoDB\Driver\WriteResult::getUpsertedCount() should not be called for an unacknowledged write result
+NULL
 ===DONE===

--- a/tests/writeResult/writeresult-getupsertedids-001.phpt
+++ b/tests/writeResult/writeresult-getupsertedids-001.phpt
@@ -20,11 +20,24 @@ $bulk->delete(['x' => 1]);
 $result = $manager->executeBulkWrite(NS, $bulk);
 
 var_dump($result->getUpsertedIds());
+var_dump($result->upsertedIds);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+array(2) {
+  [2]=>
+  object(MongoDB\BSON\ObjectId)#%d (%d) {
+    ["oid"]=>
+    string(24) "%x"
+  }
+  [3]=>
+  object(MongoDB\BSON\ObjectId)#%d (%d) {
+    ["oid"]=>
+    string(24) "%x"
+  }
+}
 array(2) {
   [2]=>
   object(MongoDB\BSON\ObjectId)#%d (%d) {

--- a/tests/writeResult/writeresult-getupsertedids-002.phpt
+++ b/tests/writeResult/writeresult-getupsertedids-002.phpt
@@ -39,11 +39,69 @@ foreach ($tests as $value) {
 $result = $manager->executeBulkWrite(NS, $bulk);
 
 var_dump($result->getUpsertedIds());
+var_dump($result->upsertedIds);
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+array(14) {
+  [0]=>
+  NULL
+  [1]=>
+  bool(true)
+  [2]=>
+  int(1)
+  [3]=>
+  float(4.125)
+  [4]=>
+  string(3) "foo"
+  [5]=>
+  object(stdClass)#%d (%d) {
+  }
+  [6]=>
+  object(MongoDB\BSON\Binary)#%d (%d) {
+    ["data"]=>
+    string(4) "Zm9v"
+    ["type"]=>
+    int(0)
+  }
+  [7]=>
+  object(MongoDB\BSON\Decimal128)#%d (%d) {
+    ["dec"]=>
+    string(9) "1234.5678"
+  }
+  [8]=>
+  object(MongoDB\BSON\Javascript)#%d (%d) {
+    ["code"]=>
+    string(12) "function(){}"
+    ["scope"]=>
+    NULL
+  }
+  [9]=>
+  object(MongoDB\BSON\MaxKey)#%d (%d) {
+  }
+  [10]=>
+  object(MongoDB\BSON\MinKey)#%d (%d) {
+  }
+  [11]=>
+  object(MongoDB\BSON\ObjectId)#%d (%d) {
+    ["oid"]=>
+    string(24) "586c18d86118fd6c9012dec1"
+  }
+  [12]=>
+  object(MongoDB\BSON\Timestamp)#%d (%d) {
+    ["increment"]=>
+    string(4) "1234"
+    ["timestamp"]=>
+    string(4) "5678"
+  }
+  [13]=>
+  object(MongoDB\BSON\UTCDateTime)#%d (%d) {
+    ["milliseconds"]=>
+    string(13) "1483479256924"
+  }
+}
 array(14) {
   [0]=>
   NULL

--- a/tests/writeResult/writeresult-getwriteconcernerror-001.phpt
+++ b/tests/writeResult/writeresult-getwriteconcernerror-001.phpt
@@ -18,12 +18,21 @@ try {
     $result = $manager->executeBulkWrite(NS, $bulk, ['writeConcern' => new MongoDB\Driver\WriteConcern(12)]);
 } catch (MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteConcernError());
+    var_dump($e->getWriteResult()->writeConcernError);
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+object(MongoDB\Driver\WriteConcernError)#%d (%d) {
+  ["message"]=>
+  string(29) "Not enough data-bearing nodes"
+  ["code"]=>
+  int(100)
+  ["info"]=>
+  %a
+}
 object(MongoDB\Driver\WriteConcernError)#%d (%d) {
   ["message"]=>
   string(29) "Not enough data-bearing nodes"

--- a/tests/writeResult/writeresult-getwriteconcernerror-002.phpt
+++ b/tests/writeResult/writeresult-getwriteconcernerror-002.phpt
@@ -27,6 +27,7 @@ $bulk->insert(['write' => 1]);
 $result = $manager->executeBulkWrite(NS, $bulk);
 
 var_dump($result->getWriteConcernError());
+var_dump($result->writeConcernError);
 
 configureFailPoint($manager, 'failCommand', 'off');
 
@@ -34,6 +35,14 @@ configureFailPoint($manager, 'failCommand', 'off');
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+object(MongoDB\Driver\WriteConcernError)#%d (%d) {
+  ["message"]=>
+  string(0) ""
+  ["code"]=>
+  int(91)
+  ["info"]=>
+  NULL
+}
 object(MongoDB\Driver\WriteConcernError)#%d (%d) {
   ["message"]=>
   string(0) ""

--- a/tests/writeResult/writeresult-getwriteerrors-001.phpt
+++ b/tests/writeResult/writeresult-getwriteerrors-001.phpt
@@ -22,12 +22,26 @@ try {
     $result = $manager->executeBulkWrite(NS, $bulk);
 } catch (MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteErrors());
+    var_dump($e->getWriteResult()->writeErrors);
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+array(1) {
+  [0]=>
+  object(MongoDB\Driver\WriteError)#%d (%d) {
+    ["message"]=>
+    string(%d) "%SE11000 duplicate key error %s: phongo.writeResult_writeresult_getwriteerrors_001%sdup key: { %S: 2 }"
+    ["code"]=>
+    int(11000)
+    ["index"]=>
+    int(2)
+    ["info"]=>
+    NULL
+  }
+}
 array(1) {
   [0]=>
   object(MongoDB\Driver\WriteError)#%d (%d) {

--- a/tests/writeResult/writeresult-getwriteerrors-002.phpt
+++ b/tests/writeResult/writeresult-getwriteerrors-002.phpt
@@ -22,12 +22,37 @@ try {
     $result = $manager->executeBulkWrite(NS, $bulk);
 } catch (MongoDB\Driver\Exception\BulkWriteException $e) {
     var_dump($e->getWriteResult()->getWriteErrors());
+    var_dump($e->getWriteResult()->writeErrors);
 }
 
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+array(2) {
+  [0]=>
+  object(MongoDB\Driver\WriteError)#%d (%d) {
+    ["message"]=>
+    string(%d) "%SE11000 duplicate key error %s: phongo.writeResult_writeresult_getwriteerrors_002%sdup key: { %S: 2 }"
+    ["code"]=>
+    int(11000)
+    ["index"]=>
+    int(2)
+    ["info"]=>
+    NULL
+  }
+  [1]=>
+  object(MongoDB\Driver\WriteError)#%d (%d) {
+    ["message"]=>
+    string(%d) "%SE11000 duplicate key error %s: phongo.writeResult_writeresult_getwriteerrors_002%sdup key: { %S: 4 }"
+    ["code"]=>
+    int(11000)
+    ["index"]=>
+    int(5)
+    ["info"]=>
+    NULL
+  }
+}
 array(2) {
   [0]=>
   object(MongoDB\Driver\WriteError)#%d (%d) {


### PR DESCRIPTION
PHPC-2699; continuation of #1973

This PR adds public, read-only properties to the stub files for the following classes:

- `MongoDB\Driver\ReadConcern`
- `MongoDB\Driver\ReadPreference`
- `MongoDB\Driver\WriteConcern`
- `MongoDB\Driver\WriteError`
- `MongoDB\Driver\WriteResult`
- `MongoDB\Driver\Exception\CommandException` (make existing property `public readonly`)
- `MongoDB\Driver\Exception\BulkWriteException` (make existing property `public readonly`)
- `MongoDB\Driver\Monitoring\CommandFailedEvent`
- `MongoDB\Driver\Monitoring\CommandStartedEvent`
- `MongoDB\Driver\Monitoring\CommandSucceededEvent`
- `MongoDB\Driver\Monitoring\ServerChangedEvent`
- `MongoDB\Driver\Monitoring\ServerClosedEvent`
- `MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent`
- `MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent`
- `MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent`
- `MongoDB\Driver\Monitoring\ServerOpeningEvent`
- `MongoDB\Driver\Monitoring\TopologyChangedEvent`
- `MongoDB\Driver\Monitoring\TopologyClosedEvent`
- `MongoDB\Driver\Monitoring\TopologyOpeningEvent`

This allows us to rely on PHP's default handling for several things:
- The `__serialize` implementation falls away for classes that implement it, as our property table now contains serialisable properties
- The `get_debug_info` handler falls away as it exposes properties by default
- By extension, the `get_properties_hash` function in these classes falls away; `bsonSerialize` implementations instead use the standard property table
- No `get_properties_for` handler needs to be implemented (makes PHPC-1622 obsolete for these classes)
- For `ReadConcern`, `ReadPreference`, and `WriteConcern`, we no longer need to implement a `compare` handler to make them comparable as there's now a property table to compare (this makes PHPC-2234 obsolete)

I strongly recommend a review of individual commits.

This PR opens avenues for further simplification. For example, the various event classes copy data from the libmongoc event object into the internal structure, and also store them in the property table as `zval`. By making the getters return the values of the property, we could do away with the internal structure for all these objects and only store data in the `zval`.

In future, we can also deprecate the various getters for removal in 3.0. I've left this out of this PR as the changes are already quite verbose due to the occasional change in debug output.

Other classes, such as BSON objects and "functional" objects like `MongoDB\Driver\Server` or `MongoDB\Driver\Cursor`, will be handled at a separate time.