### PR TITLE
Generate legacy arginfo for older PHP versions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -60,7 +60,7 @@ PHP method signatures are defined in `*.stub.php` files alongside each class's `
 ./build/gen_stub.php
 ```
 
-This requires `phpize` to have been run with **PHP 8.2** to use all features. Commit both the stub and the generated arginfo file.
+This requires `phpize` to have been run with the latest stable PHP version to use all features. Commit both the stub and the generated arginfo file.
 
 ## Architecture
 

--- a/.github/workflows/arginfo-files.yml
+++ b/.github/workflows/arginfo-files.yml
@@ -11,7 +11,7 @@ on:
       - "feature/*"
 
 env:
-  PHP_VERSION: "8.2"
+  PHP_VERSION: "8.5"
 
 jobs:
   check-arginfo:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,14 @@ $ php --ri mongodb
 ## Generating arginfo from stub files
 
 Arginfo structures are generated from stub files using the `gen_stub.php`
-file. Note that this requires `phpize` to be run for **PHP 8.2** to make use
-of all features. After changing a stub file, run `./build/gen_stub.php`
-to regenerate the corresponding arginfo files and commit the results.
+file. After changing a stub file, run `./build/gen_stub.php` to regenerate the
+corresponding arginfo files and commit the results.
+
+The `gen_stub.php` file is added to the `build` directory when calling `phpize`. 
+Arginfo structures are generated with the latest version of PHP. The 
+`@generate-legacy-arginfo` directive ensures that the generated files are 
+compatible with the indicated version of PHP. When bumping the minimum PHP 
+requirement, this directive needs to be updated accordingly. 
 
 ## Generating function maps for static analysis tools
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,11 @@ Arginfo structures are generated from stub files using the `gen_stub.php`
 file. After changing a stub file, run `./build/gen_stub.php` to regenerate the
 corresponding arginfo files and commit the results.
 
-The `gen_stub.php` file is added to the `build` directory when calling `phpize`. 
-Arginfo structures are generated with the latest version of PHP. The 
-`@generate-legacy-arginfo` directive ensures that the generated files are 
-compatible with the indicated version of PHP. When bumping the minimum PHP 
-requirement, this directive needs to be updated accordingly. 
+The `gen_stub.php` file is added to the `build` directory when calling `phpize`.
+Arginfo structures are generated with the latest version of PHP. The
+`@generate-legacy-arginfo` directive ensures that the generated files are
+compatible with the indicated version of PHP. When bumping the minimum PHP
+requirement, this directive needs to be updated accordingly.
 
 ## Generating function maps for static analysis tools
 

--- a/src/BSON/Binary.stub.php
+++ b/src/BSON/Binary.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/BinaryInterface.stub.php
+++ b/src/BSON/BinaryInterface.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/BinaryInterface_arginfo.h
+++ b/src/BSON/BinaryInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 48817588d8bad80ae873bb654842960e058e81a2 */
+ * Stub hash: 6bfe5c53bac9804fdb1498594a81962cf1b6c6c7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_BinaryInterface_getData, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -10,12 +10,22 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_MongoDB_BSON_BinaryInterface___toString arginfo_class_MongoDB_BSON_BinaryInterface_getData
 
 
-
-
 static const zend_function_entry class_MongoDB_BSON_BinaryInterface_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_BinaryInterface, getData, arginfo_class_MongoDB_BSON_BinaryInterface_getData, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_BinaryInterface, getType, arginfo_class_MongoDB_BSON_BinaryInterface_getType, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_BinaryInterface, __toString, arginfo_class_MongoDB_BSON_BinaryInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getData", NULL, arginfo_class_MongoDB_BSON_BinaryInterface_getData, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getData", NULL, arginfo_class_MongoDB_BSON_BinaryInterface_getData, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getType", NULL, arginfo_class_MongoDB_BSON_BinaryInterface_getType, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getType", NULL, arginfo_class_MongoDB_BSON_BinaryInterface_getType, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_BinaryInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_BinaryInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/Binary_arginfo.h
+++ b/src/BSON/Binary_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3c433c48b47c68051a55617ddbb9ed0f50c21484 */
+ * Stub hash: 897b6b28554999a55d29f4fa299a210c608b400e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Binary___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
@@ -38,7 +38,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Binary_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_Binary, __construct);
 static ZEND_METHOD(MongoDB_BSON_Binary, fromVector);
 static ZEND_METHOD(MongoDB_BSON_Binary, getData);
@@ -50,7 +49,6 @@ static ZEND_METHOD(MongoDB_BSON_Binary, __toString);
 static ZEND_METHOD(MongoDB_BSON_Binary, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Binary, __serialize);
 static ZEND_METHOD(MongoDB_BSON_Binary, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_Binary_methods[] = {
 	ZEND_ME(MongoDB_BSON_Binary, __construct, arginfo_class_MongoDB_BSON_Binary___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -72,8 +70,12 @@ static zend_class_entry *register_class_MongoDB_BSON_Binary(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Binary", class_MongoDB_BSON_Binary_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 4, class_entry_MongoDB_BSON_BinaryInterface, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	zval const_TYPE_GENERIC_value;

--- a/src/BSON/DBPointer.stub.php
+++ b/src/BSON/DBPointer.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/DBPointer_arginfo.h
+++ b/src/BSON/DBPointer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3462cf9349062679b50671a9c388a2a1b2930070 */
+ * Stub hash: d47b4fcf2b42ddd4e11d899123e6354403466a4b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_DBPointer___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -21,14 +21,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_DBPointer_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_DBPointer, __construct);
 static ZEND_METHOD(MongoDB_BSON_DBPointer, __set_state);
 static ZEND_METHOD(MongoDB_BSON_DBPointer, __toString);
 static ZEND_METHOD(MongoDB_BSON_DBPointer, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_DBPointer, __serialize);
 static ZEND_METHOD(MongoDB_BSON_DBPointer, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_DBPointer_methods[] = {
 	ZEND_ME(MongoDB_BSON_DBPointer, __construct, arginfo_class_MongoDB_BSON_DBPointer___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -45,8 +43,12 @@ static zend_class_entry *register_class_MongoDB_BSON_DBPointer(zend_class_entry 
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "DBPointer", class_MongoDB_BSON_DBPointer_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 3, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/Decimal128.stub.php
+++ b/src/BSON/Decimal128.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Decimal128Interface.stub.php
+++ b/src/BSON/Decimal128Interface.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Decimal128Interface_arginfo.h
+++ b/src/BSON/Decimal128Interface_arginfo.h
@@ -1,14 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 629d35b8a42f119cefc5563eb015a1e0403b6ac7 */
+ * Stub hash: fd63ec36126fe9b35fb30affbcd4a0861b5c85f8 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128Interface___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_BSON_Decimal128Interface_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_Decimal128Interface, __toString, arginfo_class_MongoDB_BSON_Decimal128Interface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_Decimal128Interface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_Decimal128Interface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/Decimal128_arginfo.h
+++ b/src/BSON/Decimal128_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 93e233be4ba07472af49fe8b8d3278ec30c570a9 */
+ * Stub hash: c547ea884b494f5e317844066b582294843dd903 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
@@ -22,14 +22,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Decimal128_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_Decimal128, __construct);
 static ZEND_METHOD(MongoDB_BSON_Decimal128, __toString);
 static ZEND_METHOD(MongoDB_BSON_Decimal128, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Decimal128, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Decimal128, __serialize);
 static ZEND_METHOD(MongoDB_BSON_Decimal128, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_Decimal128_methods[] = {
 	ZEND_ME(MongoDB_BSON_Decimal128, __construct, arginfo_class_MongoDB_BSON_Decimal128___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -46,8 +44,12 @@ static zend_class_entry *register_class_MongoDB_BSON_Decimal128(zend_class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Decimal128", class_MongoDB_BSON_Decimal128_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 4, class_entry_MongoDB_BSON_Decimal128Interface, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/Document.stub.php
+++ b/src/BSON/Document.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Document_arginfo.h
+++ b/src/BSON/Document_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 13d114590a7c0bc86da4dbb1383d17c296edcb40 */
+ * Stub hash: 0855bcff12d1a521f0a433754675b7e1e316523c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Document___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -66,7 +66,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Document___serialize, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_Document, __construct);
 static ZEND_METHOD(MongoDB_BSON_Document, fromBSON);
 static ZEND_METHOD(MongoDB_BSON_Document, fromJSON);
@@ -85,7 +84,6 @@ static ZEND_METHOD(MongoDB_BSON_Document, __toString);
 static ZEND_METHOD(MongoDB_BSON_Document, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Document, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Document, __serialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_Document_methods[] = {
 	ZEND_ME(MongoDB_BSON_Document, __construct, arginfo_class_MongoDB_BSON_Document___construct, ZEND_ACC_PRIVATE)
@@ -114,8 +112,12 @@ static zend_class_entry *register_class_MongoDB_BSON_Document(zend_class_entry *
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Document", class_MongoDB_BSON_Document_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_ArrayAccess, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/Int64.stub.php
+++ b/src/BSON/Int64.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Int64_arginfo.h
+++ b/src/BSON/Int64_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ecb9f0dd09b4af79334ef03ac2a5e04f111ab7b3 */
+ * Stub hash: e86cafa03de91adfee42f656658188da9cc9b973 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Int64___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_MASK(0, value, MAY_BE_LONG|MAY_BE_STRING, NULL)
@@ -22,14 +22,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Int64_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_Int64, __construct);
 static ZEND_METHOD(MongoDB_BSON_Int64, __toString);
 static ZEND_METHOD(MongoDB_BSON_Int64, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Int64, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Int64, __serialize);
 static ZEND_METHOD(MongoDB_BSON_Int64, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_Int64_methods[] = {
 	ZEND_ME(MongoDB_BSON_Int64, __construct, arginfo_class_MongoDB_BSON_Int64___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -46,8 +44,12 @@ static zend_class_entry *register_class_MongoDB_BSON_Int64(zend_class_entry *cla
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Int64", class_MongoDB_BSON_Int64_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 3, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/Iterator.stub.php
+++ b/src/BSON/Iterator.stub.php
@@ -2,7 +2,7 @@
 
 /**
   * @generate-class-entries static
-  * @generate-function-entries static
+  * @generate-legacy-arginfo 80100
   */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Iterator_arginfo.h
+++ b/src/BSON/Iterator_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b1cb9bc973c616b9ec005232e95368bf1b233480 */
+ * Stub hash: 316ef74b784437b102af498e22dae771b85866d9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Iterator___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -18,14 +18,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Iterator_valid, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_Iterator, __construct);
 static ZEND_METHOD(MongoDB_BSON_Iterator, current);
 static ZEND_METHOD(MongoDB_BSON_Iterator, key);
 static ZEND_METHOD(MongoDB_BSON_Iterator, next);
 static ZEND_METHOD(MongoDB_BSON_Iterator, rewind);
 static ZEND_METHOD(MongoDB_BSON_Iterator, valid);
-
 
 static const zend_function_entry class_MongoDB_BSON_Iterator_methods[] = {
 	ZEND_ME(MongoDB_BSON_Iterator, __construct, arginfo_class_MongoDB_BSON_Iterator___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -42,8 +40,12 @@ static zend_class_entry *register_class_MongoDB_BSON_Iterator(zend_class_entry *
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Iterator", class_MongoDB_BSON_Iterator_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	return class_entry;

--- a/src/BSON/Javascript.stub.php
+++ b/src/BSON/Javascript.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/JavascriptInterface.stub.php
+++ b/src/BSON/JavascriptInterface.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/JavascriptInterface_arginfo.h
+++ b/src/BSON/JavascriptInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d2335273fc900e95ba3ce8731fa241792beeec88 */
+ * Stub hash: 58512a88fdb87ca50ced15fb3509ec1bbdfd137d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_JavascriptInterface_getCode, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -10,12 +10,22 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_MongoDB_BSON_JavascriptInterface___toString arginfo_class_MongoDB_BSON_JavascriptInterface_getCode
 
 
-
-
 static const zend_function_entry class_MongoDB_BSON_JavascriptInterface_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_JavascriptInterface, getCode, arginfo_class_MongoDB_BSON_JavascriptInterface_getCode, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_JavascriptInterface, getScope, arginfo_class_MongoDB_BSON_JavascriptInterface_getScope, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_JavascriptInterface, __toString, arginfo_class_MongoDB_BSON_JavascriptInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getCode", NULL, arginfo_class_MongoDB_BSON_JavascriptInterface_getCode, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getCode", NULL, arginfo_class_MongoDB_BSON_JavascriptInterface_getCode, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getScope", NULL, arginfo_class_MongoDB_BSON_JavascriptInterface_getScope, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getScope", NULL, arginfo_class_MongoDB_BSON_JavascriptInterface_getScope, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_JavascriptInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_JavascriptInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/Javascript_arginfo.h
+++ b/src/BSON/Javascript_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 017421710f18d98547b7f987309bcd932a076245 */
+ * Stub hash: 5bf645c9a3fc1bccb4d6a6cfa8e5f3e4956a9835 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Javascript___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, code, IS_STRING, 0)
@@ -28,7 +28,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Javascript_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_Javascript, __construct);
 static ZEND_METHOD(MongoDB_BSON_Javascript, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Javascript, getCode);
@@ -37,7 +36,6 @@ static ZEND_METHOD(MongoDB_BSON_Javascript, __toString);
 static ZEND_METHOD(MongoDB_BSON_Javascript, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Javascript, __serialize);
 static ZEND_METHOD(MongoDB_BSON_Javascript, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_Javascript_methods[] = {
 	ZEND_ME(MongoDB_BSON_Javascript, __construct, arginfo_class_MongoDB_BSON_Javascript___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -56,8 +54,12 @@ static zend_class_entry *register_class_MongoDB_BSON_Javascript(zend_class_entry
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Javascript", class_MongoDB_BSON_Javascript_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 4, class_entry_MongoDB_BSON_JavascriptInterface, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/MaxKey.stub.php
+++ b/src/BSON/MaxKey.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/MaxKeyInterface.stub.php
+++ b/src/BSON/MaxKeyInterface.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/MaxKeyInterface_arginfo.h
+++ b/src/BSON/MaxKeyInterface_arginfo.h
@@ -1,18 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6c27815fcc33b0b03365b6b24d4145d8621cf13d */
-
-
-
-
-static const zend_function_entry class_MongoDB_BSON_MaxKeyInterface_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: e7e08a9c8203cc7ea8c5669442dbe0bc0607eee6 */
 
 static zend_class_entry *register_class_MongoDB_BSON_MaxKeyInterface(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "MaxKeyInterface", class_MongoDB_BSON_MaxKeyInterface_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "MaxKeyInterface", NULL);
 	class_entry = zend_register_internal_interface(&ce);
 
 	return class_entry;

--- a/src/BSON/MaxKey_arginfo.h
+++ b/src/BSON/MaxKey_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: df810b4d4876637e555a0e129e940acc5177b892 */
+ * Stub hash: a62a947a0884e0f9709e923cd22d203b61781c87 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_MaxKey___set_state, 0, 1, MongoDB\\BSON\\MaxKey, 0)
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)
@@ -15,12 +15,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_MaxKey_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_MaxKey, __set_state);
 static ZEND_METHOD(MongoDB_BSON_MaxKey, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_MaxKey, __serialize);
 static ZEND_METHOD(MongoDB_BSON_MaxKey, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_MaxKey_methods[] = {
 	ZEND_ME(MongoDB_BSON_MaxKey, __set_state, arginfo_class_MongoDB_BSON_MaxKey___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
@@ -35,8 +33,12 @@ static zend_class_entry *register_class_MongoDB_BSON_MaxKey(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "MaxKey", class_MongoDB_BSON_MaxKey_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 3, class_entry_MongoDB_BSON_MaxKeyInterface, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type);
 
 	return class_entry;

--- a/src/BSON/MinKey.stub.php
+++ b/src/BSON/MinKey.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/MinKeyInterface.stub.php
+++ b/src/BSON/MinKeyInterface.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/MinKeyInterface_arginfo.h
+++ b/src/BSON/MinKeyInterface_arginfo.h
@@ -1,18 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c9b23e875d9dc9ebb0ed3391d88cb2458ed96407 */
-
-
-
-
-static const zend_function_entry class_MongoDB_BSON_MinKeyInterface_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: 598f048ec627ac0df4af6941b0e598772908c7cb */
 
 static zend_class_entry *register_class_MongoDB_BSON_MinKeyInterface(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "MinKeyInterface", class_MongoDB_BSON_MinKeyInterface_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "MinKeyInterface", NULL);
 	class_entry = zend_register_internal_interface(&ce);
 
 	return class_entry;

--- a/src/BSON/MinKey_arginfo.h
+++ b/src/BSON/MinKey_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 75a01ebbfa05e7a9b38aa1bd1a0bef3e0a06637e */
+ * Stub hash: 8f783511e88c42df9c57abac6738d31937d65928 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_MinKey___set_state, 0, 1, MongoDB\\BSON\\MinKey, 0)
 	ZEND_ARG_TYPE_INFO(0, properties, IS_ARRAY, 0)
@@ -15,12 +15,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_MinKey_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_MinKey, __set_state);
 static ZEND_METHOD(MongoDB_BSON_MinKey, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_MinKey, __serialize);
 static ZEND_METHOD(MongoDB_BSON_MinKey, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_MinKey_methods[] = {
 	ZEND_ME(MongoDB_BSON_MinKey, __set_state, arginfo_class_MongoDB_BSON_MinKey___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
@@ -35,8 +33,12 @@ static zend_class_entry *register_class_MongoDB_BSON_MinKey(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "MinKey", class_MongoDB_BSON_MinKey_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 3, class_entry_MongoDB_BSON_MinKeyInterface, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type);
 
 	return class_entry;

--- a/src/BSON/ObjectId.stub.php
+++ b/src/BSON/ObjectId.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/ObjectIdInterface.stub.php
+++ b/src/BSON/ObjectIdInterface.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/ObjectIdInterface_arginfo.h
+++ b/src/BSON/ObjectIdInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 918396361a59962098b767437a61efe5fa2ab259 */
+ * Stub hash: f82341700fba9fcf48096873075b17a810e5f448 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectIdInterface_getTimestamp, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -8,11 +8,17 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectIdInter
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_BSON_ObjectIdInterface_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_ObjectIdInterface, getTimestamp, arginfo_class_MongoDB_BSON_ObjectIdInterface_getTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_ObjectIdInterface, __toString, arginfo_class_MongoDB_BSON_ObjectIdInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getTimestamp", NULL, arginfo_class_MongoDB_BSON_ObjectIdInterface_getTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getTimestamp", NULL, arginfo_class_MongoDB_BSON_ObjectIdInterface_getTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_ObjectIdInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_ObjectIdInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/ObjectId_arginfo.h
+++ b/src/BSON/ObjectId_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: beb5fbef79a5e5c826c086ffbf912748dd15f19b */
+ * Stub hash: 6498d9a4685323f610d5673621b43cb5362bd49d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_ObjectId___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, id, IS_STRING, 1, "null")
@@ -25,7 +25,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_ObjectId_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_ObjectId, __construct);
 static ZEND_METHOD(MongoDB_BSON_ObjectId, getTimestamp);
 static ZEND_METHOD(MongoDB_BSON_ObjectId, __toString);
@@ -33,7 +32,6 @@ static ZEND_METHOD(MongoDB_BSON_ObjectId, __set_state);
 static ZEND_METHOD(MongoDB_BSON_ObjectId, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_ObjectId, __serialize);
 static ZEND_METHOD(MongoDB_BSON_ObjectId, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_ObjectId_methods[] = {
 	ZEND_ME(MongoDB_BSON_ObjectId, __construct, arginfo_class_MongoDB_BSON_ObjectId___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -51,8 +49,12 @@ static zend_class_entry *register_class_MongoDB_BSON_ObjectId(zend_class_entry *
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "ObjectId", class_MongoDB_BSON_ObjectId_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 4, class_entry_MongoDB_BSON_ObjectIdInterface, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/PackedArray.stub.php
+++ b/src/BSON/PackedArray.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/PackedArray_arginfo.h
+++ b/src/BSON/PackedArray_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 497915f5aa3a10fc5e4bf222c82cdcb5c891a1bd */
+ * Stub hash: b104bf91975f87a360e8ee756f948bf83bffae50 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -62,7 +62,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_PackedArray___serialize, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __construct);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, fromJSON);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, fromPHP);
@@ -80,7 +79,6 @@ static ZEND_METHOD(MongoDB_BSON_PackedArray, __toString);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __set_state);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_PackedArray, __serialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_PackedArray_methods[] = {
 	ZEND_ME(MongoDB_BSON_PackedArray, __construct, arginfo_class_MongoDB_BSON_PackedArray___construct, ZEND_ACC_PRIVATE)
@@ -108,8 +106,12 @@ static zend_class_entry *register_class_MongoDB_BSON_PackedArray(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "PackedArray", class_MongoDB_BSON_PackedArray_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_ArrayAccess, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/Persistable.stub.php
+++ b/src/BSON/Persistable.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Persistable_arginfo.h
+++ b/src/BSON/Persistable_arginfo.h
@@ -1,14 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8a5634034ae5939cd0c182b80243b246e8bd8558 */
+ * Stub hash: 0f9f27e9007f9bf08fe83bdaa3896f333f03af6b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Persistable_bsonSerialize, 0, 0, stdClass|MongoDB\\BSON\\Document, MAY_BE_ARRAY)
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_BSON_Persistable_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_Persistable, bsonSerialize, arginfo_class_MongoDB_BSON_Persistable_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("bsonSerialize", NULL, arginfo_class_MongoDB_BSON_Persistable_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("bsonSerialize", NULL, arginfo_class_MongoDB_BSON_Persistable_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/Regex.stub.php
+++ b/src/BSON/Regex.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/RegexInterface.stub.php
+++ b/src/BSON/RegexInterface.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/RegexInterface_arginfo.h
+++ b/src/BSON/RegexInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3d2702dde50173adc1d9b3c69257814256f26173 */
+ * Stub hash: 0207382679445e7ccb3f0eed665dc2820472df41 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_RegexInterface_getPattern, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -9,12 +9,22 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_MongoDB_BSON_RegexInterface___toString arginfo_class_MongoDB_BSON_RegexInterface_getPattern
 
 
-
-
 static const zend_function_entry class_MongoDB_BSON_RegexInterface_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_RegexInterface, getPattern, arginfo_class_MongoDB_BSON_RegexInterface_getPattern, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_RegexInterface, getFlags, arginfo_class_MongoDB_BSON_RegexInterface_getFlags, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_RegexInterface, __toString, arginfo_class_MongoDB_BSON_RegexInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getPattern", NULL, arginfo_class_MongoDB_BSON_RegexInterface_getPattern, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getPattern", NULL, arginfo_class_MongoDB_BSON_RegexInterface_getPattern, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getFlags", NULL, arginfo_class_MongoDB_BSON_RegexInterface_getFlags, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getFlags", NULL, arginfo_class_MongoDB_BSON_RegexInterface_getFlags, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_RegexInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_RegexInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/Regex_arginfo.h
+++ b/src/BSON/Regex_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5fb63bbe527f9b0cadf1898ac21e97bbba8dbb6c */
+ * Stub hash: fc23b5f166d4e4ffe43ffe15b4b4b16dcfdba2b9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Regex___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
@@ -27,7 +27,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Regex_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_Regex, __construct);
 static ZEND_METHOD(MongoDB_BSON_Regex, getPattern);
 static ZEND_METHOD(MongoDB_BSON_Regex, getFlags);
@@ -36,7 +35,6 @@ static ZEND_METHOD(MongoDB_BSON_Regex, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Regex, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Regex, __serialize);
 static ZEND_METHOD(MongoDB_BSON_Regex, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_Regex_methods[] = {
 	ZEND_ME(MongoDB_BSON_Regex, __construct, arginfo_class_MongoDB_BSON_Regex___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -55,8 +53,12 @@ static zend_class_entry *register_class_MongoDB_BSON_Regex(zend_class_entry *cla
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Regex", class_MongoDB_BSON_Regex_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 4, class_entry_MongoDB_BSON_RegexInterface, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/Serializable.stub.php
+++ b/src/BSON/Serializable.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Serializable_arginfo.h
+++ b/src/BSON/Serializable_arginfo.h
@@ -1,14 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0d23d26a86f14abf19f9fb44b350a134534df5ac */
+ * Stub hash: 21b68b053b081dce111f72a9db8f4e64a2b57113 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, 0, 0, stdClass|MongoDB\\BSON\\Document|MongoDB\\BSON\\PackedArray, MAY_BE_ARRAY)
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_BSON_Serializable_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_Serializable, bsonSerialize, arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("bsonSerialize", NULL, arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("bsonSerialize", NULL, arginfo_class_MongoDB_BSON_Serializable_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/Symbol.stub.php
+++ b/src/BSON/Symbol.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Symbol_arginfo.h
+++ b/src/BSON/Symbol_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9bd846827a2c2fb7fd6c0cb853a3fec5756073e8 */
+ * Stub hash: 0942ac0771228198f4d4247d5825e0d865fe2098 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Symbol___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -21,14 +21,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Symbol_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_Symbol, __construct);
 static ZEND_METHOD(MongoDB_BSON_Symbol, __toString);
 static ZEND_METHOD(MongoDB_BSON_Symbol, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Symbol, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Symbol, __serialize);
 static ZEND_METHOD(MongoDB_BSON_Symbol, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_Symbol_methods[] = {
 	ZEND_ME(MongoDB_BSON_Symbol, __construct, arginfo_class_MongoDB_BSON_Symbol___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -45,8 +43,12 @@ static zend_class_entry *register_class_MongoDB_BSON_Symbol(zend_class_entry *cl
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Symbol", class_MongoDB_BSON_Symbol_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 3, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/Timestamp.stub.php
+++ b/src/BSON/Timestamp.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/TimestampInterface.stub.php
+++ b/src/BSON/TimestampInterface.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/TimestampInterface_arginfo.h
+++ b/src/BSON/TimestampInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6943cf9694dde756ed5ad2b7220c1c39e6157165 */
+ * Stub hash: 5ebfb13003e6b82254b7154f492222e0610f0894 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_TimestampInterface_getTimestamp, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -10,12 +10,22 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_TimestampInte
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_BSON_TimestampInterface_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_TimestampInterface, getTimestamp, arginfo_class_MongoDB_BSON_TimestampInterface_getTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_TimestampInterface, getIncrement, arginfo_class_MongoDB_BSON_TimestampInterface_getIncrement, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_TimestampInterface, __toString, arginfo_class_MongoDB_BSON_TimestampInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getTimestamp", NULL, arginfo_class_MongoDB_BSON_TimestampInterface_getTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getTimestamp", NULL, arginfo_class_MongoDB_BSON_TimestampInterface_getTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getIncrement", NULL, arginfo_class_MongoDB_BSON_TimestampInterface_getIncrement, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getIncrement", NULL, arginfo_class_MongoDB_BSON_TimestampInterface_getIncrement, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_TimestampInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_TimestampInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/Timestamp_arginfo.h
+++ b/src/BSON/Timestamp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0b768cfa7860b1bde5cbc32742528dd5754b9a85 */
+ * Stub hash: 5b6c8488c5502a6d0fc472449f49de60560ec15e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Timestamp___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_MASK(0, increment, MAY_BE_LONG|MAY_BE_STRING, NULL)
@@ -28,7 +28,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Timestamp_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_Timestamp, __construct);
 static ZEND_METHOD(MongoDB_BSON_Timestamp, getTimestamp);
 static ZEND_METHOD(MongoDB_BSON_Timestamp, getIncrement);
@@ -37,7 +36,6 @@ static ZEND_METHOD(MongoDB_BSON_Timestamp, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Timestamp, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Timestamp, __serialize);
 static ZEND_METHOD(MongoDB_BSON_Timestamp, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_Timestamp_methods[] = {
 	ZEND_ME(MongoDB_BSON_Timestamp, __construct, arginfo_class_MongoDB_BSON_Timestamp___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -56,8 +54,12 @@ static zend_class_entry *register_class_MongoDB_BSON_Timestamp(zend_class_entry 
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Timestamp", class_MongoDB_BSON_Timestamp_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 4, class_entry_MongoDB_BSON_TimestampInterface, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/Type.stub.php
+++ b/src/BSON/Type.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Type_arginfo.h
+++ b/src/BSON/Type_arginfo.h
@@ -1,18 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ece602b4c841263e650ab50fa949a83ad265db69 */
-
-
-
-
-static const zend_function_entry class_MongoDB_BSON_Type_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: 7c297c1f6a9454b4e7a509b278f2776e31d8dbfa */
 
 static zend_class_entry *register_class_MongoDB_BSON_Type(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Type", class_MongoDB_BSON_Type_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Type", NULL);
 	class_entry = zend_register_internal_interface(&ce);
 
 	return class_entry;

--- a/src/BSON/UTCDateTime.stub.php
+++ b/src/BSON/UTCDateTime.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/UTCDateTimeInterface.stub.php
+++ b/src/BSON/UTCDateTimeInterface.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/UTCDateTimeInterface_arginfo.h
+++ b/src/BSON/UTCDateTimeInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9dfbe17b754382e121289ef990984d39b18117ca */
+ * Stub hash: f4cd2c12699a833caf1cb1d769d564479052180e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTime, 0, 0, DateTime, 0)
 ZEND_END_ARG_INFO()
@@ -11,12 +11,22 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTimeIn
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_BSON_UTCDateTimeInterface_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_UTCDateTimeInterface, toDateTime, arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTime, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_UTCDateTimeInterface, toDateTimeImmutable, arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTimeImmutable, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_UTCDateTimeInterface, __toString, arginfo_class_MongoDB_BSON_UTCDateTimeInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("toDateTime", NULL, arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTime, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("toDateTime", NULL, arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTime, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("toDateTimeImmutable", NULL, arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTimeImmutable, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("toDateTimeImmutable", NULL, arginfo_class_MongoDB_BSON_UTCDateTimeInterface_toDateTimeImmutable, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_UTCDateTimeInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("__toString", NULL, arginfo_class_MongoDB_BSON_UTCDateTimeInterface___toString, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/UTCDateTime_arginfo.h
+++ b/src/BSON/UTCDateTime_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b5033645ba31d4b4e5040548ea979cef5e3e8adb */
+ * Stub hash: 05b6082994907fb78762b1c327450617a00a0830 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTime___construct, 0, 0, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, milliseconds, DateTimeInterface|MongoDB\\BSON\\Int64, MAY_BE_LONG|MAY_BE_NULL, "null")
@@ -28,7 +28,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_UTCDateTime_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, __construct);
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, toDateTime);
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, toDateTimeImmutable);
@@ -37,7 +36,6 @@ static ZEND_METHOD(MongoDB_BSON_UTCDateTime, __set_state);
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, __serialize);
 static ZEND_METHOD(MongoDB_BSON_UTCDateTime, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_UTCDateTime_methods[] = {
 	ZEND_ME(MongoDB_BSON_UTCDateTime, __construct, arginfo_class_MongoDB_BSON_UTCDateTime___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -56,8 +54,12 @@ static zend_class_entry *register_class_MongoDB_BSON_UTCDateTime(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "UTCDateTime", class_MongoDB_BSON_UTCDateTime_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 4, class_entry_MongoDB_BSON_UTCDateTimeInterface, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/Undefined.stub.php
+++ b/src/BSON/Undefined.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Undefined_arginfo.h
+++ b/src/BSON/Undefined_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4f9631736bdc048203268e88e70cc395b383aee4 */
+ * Stub hash: a3f2e651402ca9aa948ec9462d793db58dc964da */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_BSON_Undefined___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -21,14 +21,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Undefined_jsonSerialize, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_BSON_Undefined, __construct);
 static ZEND_METHOD(MongoDB_BSON_Undefined, __toString);
 static ZEND_METHOD(MongoDB_BSON_Undefined, __set_state);
 static ZEND_METHOD(MongoDB_BSON_Undefined, __unserialize);
 static ZEND_METHOD(MongoDB_BSON_Undefined, __serialize);
 static ZEND_METHOD(MongoDB_BSON_Undefined, jsonSerialize);
-
 
 static const zend_function_entry class_MongoDB_BSON_Undefined_methods[] = {
 	ZEND_ME(MongoDB_BSON_Undefined, __construct, arginfo_class_MongoDB_BSON_Undefined___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -45,8 +43,12 @@ static zend_class_entry *register_class_MongoDB_BSON_Undefined(zend_class_entry 
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\BSON", "Undefined", class_MongoDB_BSON_Undefined_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 3, class_entry_JsonSerializable, class_entry_MongoDB_BSON_Type, class_entry_Stringable);
 
 	return class_entry;

--- a/src/BSON/Unserializable.stub.php
+++ b/src/BSON/Unserializable.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/Unserializable_arginfo.h
+++ b/src/BSON/Unserializable_arginfo.h
@@ -1,15 +1,17 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b9746862d533c46cd8977bde20093fe92d8f4440 */
+ * Stub hash: 56ea9546c171aa438abb57626f0129fe473339fb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_BSON_Unserializable_bsonUnserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_BSON_Unserializable_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_BSON_Unserializable, bsonUnserialize, arginfo_class_MongoDB_BSON_Unserializable_bsonUnserialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("bsonUnserialize", NULL, arginfo_class_MongoDB_BSON_Unserializable_bsonUnserialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("bsonUnserialize", NULL, arginfo_class_MongoDB_BSON_Unserializable_bsonUnserialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/BSON/VectorType.stub.php
+++ b/src/BSON/VectorType.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\BSON;

--- a/src/BSON/VectorType_arginfo.h
+++ b/src/BSON/VectorType_arginfo.h
@@ -1,16 +1,9 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9fc1377046ca92a6a50cfac11fabc50b4d30d708 */
-
-
-
-
-static const zend_function_entry class_MongoDB_BSON_VectorType_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: f6db546bc317d0d1ab8e7a80ecaf92a058f49875 */
 
 static zend_class_entry *register_class_MongoDB_BSON_VectorType(void)
 {
-	zend_class_entry *class_entry = zend_register_internal_enum("MongoDB\\BSON\\VectorType", IS_UNDEF, class_MongoDB_BSON_VectorType_methods);
+	zend_class_entry *class_entry = zend_register_internal_enum("MongoDB\\BSON\\VectorType", IS_UNDEF, NULL);
 
 	zend_enum_add_case_cstr(class_entry, "Float32", NULL);
 

--- a/src/MongoDB/BulkWrite.stub.php
+++ b/src/MongoDB/BulkWrite.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/BulkWriteCommand.stub.php
+++ b/src/MongoDB/BulkWriteCommand.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/BulkWriteCommandResult.stub.php
+++ b/src/MongoDB/BulkWriteCommandResult.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/BulkWriteCommandResult_arginfo.h
+++ b/src/MongoDB/BulkWriteCommandResult_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 042b10edec437daefeda4f0fc883dd25e240439f */
+ * Stub hash: c3b36fa7e01da6c3e30280afc23e71b81ef39c36 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_BulkWriteCommandResult___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -25,7 +25,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_BulkWriteCommandResult_isAcknowledged, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommandResult, __construct);
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommandResult, getInsertedCount);
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommandResult, getMatchedCount);
@@ -36,7 +35,6 @@ static ZEND_METHOD(MongoDB_Driver_BulkWriteCommandResult, getInsertResults);
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommandResult, getUpdateResults);
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommandResult, getDeleteResults);
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommandResult, isAcknowledged);
-
 
 static const zend_function_entry class_MongoDB_Driver_BulkWriteCommandResult_methods[] = {
 	ZEND_ME(MongoDB_Driver_BulkWriteCommandResult, __construct, arginfo_class_MongoDB_Driver_BulkWriteCommandResult___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -57,8 +55,12 @@ static zend_class_entry *register_class_MongoDB_Driver_BulkWriteCommandResult(vo
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "BulkWriteCommandResult", class_MongoDB_Driver_BulkWriteCommandResult_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/BulkWriteCommand_arginfo.h
+++ b/src/MongoDB/BulkWriteCommand_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2af15e87d1d8095137d315218e688221ac2b5983 */
+ * Stub hash: 8c202ca492791b5f182d4a1e61f6152a10a6d0fe */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_BulkWriteCommand___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -37,7 +37,6 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_BulkWriteCommand_updateMany arginfo_class_MongoDB_Driver_BulkWriteCommand_updateOne
 
-
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommand, __construct);
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommand, count);
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommand, deleteOne);
@@ -46,7 +45,6 @@ static ZEND_METHOD(MongoDB_Driver_BulkWriteCommand, insertOne);
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommand, replaceOne);
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommand, updateOne);
 static ZEND_METHOD(MongoDB_Driver_BulkWriteCommand, updateMany);
-
 
 static const zend_function_entry class_MongoDB_Driver_BulkWriteCommand_methods[] = {
 	ZEND_ME(MongoDB_Driver_BulkWriteCommand, __construct, arginfo_class_MongoDB_Driver_BulkWriteCommand___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -65,8 +63,12 @@ static zend_class_entry *register_class_MongoDB_Driver_BulkWriteCommand(zend_cla
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "BulkWriteCommand", class_MongoDB_Driver_BulkWriteCommand_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 	zend_class_implements(class_entry, 1, class_entry_Countable);
 
 	return class_entry;

--- a/src/MongoDB/BulkWrite_arginfo.h
+++ b/src/MongoDB/BulkWrite_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1e91ce9db35aa0f3b77c3042099b02ac0fb381a9 */
+ * Stub hash: b7ffabc15b61c0824fda1f95035668477c3ea8a2 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_BulkWrite___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -23,13 +23,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_BulkWrite_u
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, updateOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_BulkWrite, __construct);
 static ZEND_METHOD(MongoDB_Driver_BulkWrite, count);
 static ZEND_METHOD(MongoDB_Driver_BulkWrite, delete);
 static ZEND_METHOD(MongoDB_Driver_BulkWrite, insert);
 static ZEND_METHOD(MongoDB_Driver_BulkWrite, update);
-
 
 static const zend_function_entry class_MongoDB_Driver_BulkWrite_methods[] = {
 	ZEND_ME(MongoDB_Driver_BulkWrite, __construct, arginfo_class_MongoDB_Driver_BulkWrite___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -45,8 +43,12 @@ static zend_class_entry *register_class_MongoDB_Driver_BulkWrite(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "BulkWrite", class_MongoDB_Driver_BulkWrite_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 	zend_class_implements(class_entry, 1, class_entry_Countable);
 
 	return class_entry;

--- a/src/MongoDB/ClientEncryption.stub.php
+++ b/src/MongoDB/ClientEncryption.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/ClientEncryption_arginfo.h
+++ b/src/MongoDB/ClientEncryption_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ea16be50be5151fdd45b9e1bc37856d94990725e */
+ * Stub hash: 1b2aa1b90af91216b8f9261143058edf9a2a81ca */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ClientEncryption___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 0)
@@ -51,7 +51,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ClientEncry
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_ClientEncryption, __construct);
 static ZEND_METHOD(MongoDB_Driver_ClientEncryption, addKeyAltName);
 static ZEND_METHOD(MongoDB_Driver_ClientEncryption, createDataKey);
@@ -64,7 +63,6 @@ static ZEND_METHOD(MongoDB_Driver_ClientEncryption, getKeyByAltName);
 static ZEND_METHOD(MongoDB_Driver_ClientEncryption, getKeys);
 static ZEND_METHOD(MongoDB_Driver_ClientEncryption, removeKeyAltName);
 static ZEND_METHOD(MongoDB_Driver_ClientEncryption, rewrapManyDataKey);
-
 
 static const zend_function_entry class_MongoDB_Driver_ClientEncryption_methods[] = {
 	ZEND_ME(MongoDB_Driver_ClientEncryption, __construct, arginfo_class_MongoDB_Driver_ClientEncryption___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -87,8 +85,12 @@ static zend_class_entry *register_class_MongoDB_Driver_ClientEncryption(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "ClientEncryption", class_MongoDB_Driver_ClientEncryption_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 	zval const_AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC_value;
 	zend_string *const_AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC_value_str = zend_string_init(MONGOC_AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC, strlen(MONGOC_AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC), 1);

--- a/src/MongoDB/Command.stub.php
+++ b/src/MongoDB/Command.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/Command_arginfo.h
+++ b/src/MongoDB/Command_arginfo.h
@@ -1,14 +1,12 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e613d505cab7a354e0e6b1e0395933169891021f */
+ * Stub hash: e779e5022eadeccbd0d2dfb14ce2cf157bb253d8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Command___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_MASK(0, document, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, commandOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Command, __construct);
-
 
 static const zend_function_entry class_MongoDB_Driver_Command_methods[] = {
 	ZEND_ME(MongoDB_Driver_Command, __construct, arginfo_class_MongoDB_Driver_Command___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -20,8 +18,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Command(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "Command", class_MongoDB_Driver_Command_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Cursor.stub.php
+++ b/src/MongoDB/Cursor.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/CursorInterface.stub.php
+++ b/src/MongoDB/CursorInterface.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/CursorInterface_arginfo.h
+++ b/src/MongoDB/CursorInterface_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3e304bb86abaff66e9714a02e3a20ec994b444ed */
+ * Stub hash: a679a82c3245e125935b03359a1d8007dbd22b24 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_MongoDB_Driver_CursorInterface_current, 0, 0, MAY_BE_ARRAY|MAY_BE_OBJECT|MAY_BE_NULL)
 ZEND_END_ARG_INFO()
@@ -24,16 +24,42 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_CursorInter
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_Driver_CursorInterface_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, current, arginfo_class_MongoDB_Driver_CursorInterface_current, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, getId, arginfo_class_MongoDB_Driver_CursorInterface_getId, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, getServer, arginfo_class_MongoDB_Driver_CursorInterface_getServer, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, isDead, arginfo_class_MongoDB_Driver_CursorInterface_isDead, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, key, arginfo_class_MongoDB_Driver_CursorInterface_key, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, setTypeMap, arginfo_class_MongoDB_Driver_CursorInterface_setTypeMap, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_CursorInterface, toArray, arginfo_class_MongoDB_Driver_CursorInterface_toArray, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("current", NULL, arginfo_class_MongoDB_Driver_CursorInterface_current, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("current", NULL, arginfo_class_MongoDB_Driver_CursorInterface_current, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getId", NULL, arginfo_class_MongoDB_Driver_CursorInterface_getId, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getId", NULL, arginfo_class_MongoDB_Driver_CursorInterface_getId, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("getServer", NULL, arginfo_class_MongoDB_Driver_CursorInterface_getServer, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("getServer", NULL, arginfo_class_MongoDB_Driver_CursorInterface_getServer, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("isDead", NULL, arginfo_class_MongoDB_Driver_CursorInterface_isDead, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("isDead", NULL, arginfo_class_MongoDB_Driver_CursorInterface_isDead, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("key", NULL, arginfo_class_MongoDB_Driver_CursorInterface_key, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("key", NULL, arginfo_class_MongoDB_Driver_CursorInterface_key, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("setTypeMap", NULL, arginfo_class_MongoDB_Driver_CursorInterface_setTypeMap, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("setTypeMap", NULL, arginfo_class_MongoDB_Driver_CursorInterface_setTypeMap, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("toArray", NULL, arginfo_class_MongoDB_Driver_CursorInterface_toArray, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("toArray", NULL, arginfo_class_MongoDB_Driver_CursorInterface_toArray, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/MongoDB/Cursor_arginfo.h
+++ b/src/MongoDB/Cursor_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e598fccd4b9b82f6da64f43855fa7a302ac86ae8 */
+ * Stub hash: 78a1878cbe0b4ba92c8daa4385876643b6c191e7 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Cursor___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -33,7 +33,6 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_Cursor_valid arginfo_class_MongoDB_Driver_Cursor_isDead
 
-
 static ZEND_METHOD(MongoDB_Driver_Cursor, __construct);
 static ZEND_METHOD(MongoDB_Driver_Cursor, current);
 static ZEND_METHOD(MongoDB_Driver_Cursor, getId);
@@ -45,7 +44,6 @@ static ZEND_METHOD(MongoDB_Driver_Cursor, rewind);
 static ZEND_METHOD(MongoDB_Driver_Cursor, setTypeMap);
 static ZEND_METHOD(MongoDB_Driver_Cursor, toArray);
 static ZEND_METHOD(MongoDB_Driver_Cursor, valid);
-
 
 static const zend_function_entry class_MongoDB_Driver_Cursor_methods[] = {
 	ZEND_ME(MongoDB_Driver_Cursor, __construct, arginfo_class_MongoDB_Driver_Cursor___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -67,8 +65,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Cursor(zend_class_entry *
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "Cursor", class_MongoDB_Driver_Cursor_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 	zend_class_implements(class_entry, 1, class_entry_MongoDB_Driver_CursorInterface);
 
 	return class_entry;

--- a/src/MongoDB/Exception/AuthenticationException.stub.php
+++ b/src/MongoDB/Exception/AuthenticationException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/AuthenticationException_arginfo.h
+++ b/src/MongoDB/Exception/AuthenticationException_arginfo.h
@@ -1,19 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dfb57a5b65b8a075b239be872177213a182faf60 */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Exception_AuthenticationException_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: 63d10707da7b749576ce02f6e565957f94fd7a37 */
 
 static zend_class_entry *register_class_MongoDB_Driver_Exception_AuthenticationException(zend_class_entry *class_entry_MongoDB_Driver_Exception_ConnectionException)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "AuthenticationException", class_MongoDB_Driver_Exception_AuthenticationException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "AuthenticationException", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_MongoDB_Driver_Exception_ConnectionException, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_ConnectionException);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Exception/BulkWriteCommandException.stub.php
+++ b/src/MongoDB/Exception/BulkWriteCommandException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/BulkWriteCommandException_arginfo.h
+++ b/src/MongoDB/Exception/BulkWriteCommandException_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 16a2478ef423f897f914ad7b2ed3dbbdc4036e60 */
+ * Stub hash: 8e4d85c10a3ec545f3ca38591d74195d4732eac5 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Exception_BulkWriteCommandException_getErrorReply, 0, 0, MongoDB\\BSON\\Document, 1)
 ZEND_END_ARG_INFO()
@@ -12,12 +12,10 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_Exception_BulkWriteCommandException_getWriteConcernErrors arginfo_class_MongoDB_Driver_Exception_BulkWriteCommandException_getWriteErrors
 
-
 static ZEND_METHOD(MongoDB_Driver_Exception_BulkWriteCommandException, getErrorReply);
 static ZEND_METHOD(MongoDB_Driver_Exception_BulkWriteCommandException, getPartialResult);
 static ZEND_METHOD(MongoDB_Driver_Exception_BulkWriteCommandException, getWriteErrors);
 static ZEND_METHOD(MongoDB_Driver_Exception_BulkWriteCommandException, getWriteConcernErrors);
-
 
 static const zend_function_entry class_MongoDB_Driver_Exception_BulkWriteCommandException_methods[] = {
 	ZEND_ME(MongoDB_Driver_Exception_BulkWriteCommandException, getErrorReply, arginfo_class_MongoDB_Driver_Exception_BulkWriteCommandException_getErrorReply, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -32,20 +30,24 @@ static zend_class_entry *register_class_MongoDB_Driver_Exception_BulkWriteComman
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "BulkWriteCommandException", class_MongoDB_Driver_Exception_BulkWriteCommandException_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_MongoDB_Driver_Exception_ServerException, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_ServerException);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 
-	zend_string *property_errorReply_class_MongoDB_BSON_Document = zend_string_init("MongoDB\\BSON\\Document", sizeof("MongoDB\\BSON\\Document")-1, 1);
 	zval property_errorReply_default_value;
 	ZVAL_NULL(&property_errorReply_default_value);
 	zend_string *property_errorReply_name = zend_string_init("errorReply", sizeof("errorReply") - 1, 1);
+	zend_string *property_errorReply_class_MongoDB_BSON_Document = zend_string_init("MongoDB\\BSON\\Document", sizeof("MongoDB\\BSON\\Document")-1, 1);
 	zend_declare_typed_property(class_entry, property_errorReply_name, &property_errorReply_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_errorReply_class_MongoDB_BSON_Document, 0, MAY_BE_NULL));
 	zend_string_release(property_errorReply_name);
 
-	zend_string *property_partialResult_class_MongoDB_Driver_BulkWriteCommandResult = zend_string_init("MongoDB\\Driver\\BulkWriteCommandResult", sizeof("MongoDB\\Driver\\BulkWriteCommandResult")-1, 1);
 	zval property_partialResult_default_value;
 	ZVAL_NULL(&property_partialResult_default_value);
 	zend_string *property_partialResult_name = zend_string_init("partialResult", sizeof("partialResult") - 1, 1);
+	zend_string *property_partialResult_class_MongoDB_Driver_BulkWriteCommandResult = zend_string_init("MongoDB\\Driver\\BulkWriteCommandResult", sizeof("MongoDB\\Driver\\BulkWriteCommandResult")-1, 1);
 	zend_declare_typed_property(class_entry, property_partialResult_name, &property_partialResult_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_partialResult_class_MongoDB_Driver_BulkWriteCommandResult, 0, MAY_BE_NULL));
 	zend_string_release(property_partialResult_name);
 

--- a/src/MongoDB/Exception/BulkWriteException.stub.php
+++ b/src/MongoDB/Exception/BulkWriteException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/BulkWriteException_arginfo.h
+++ b/src/MongoDB/Exception/BulkWriteException_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 66b1cbab461cd3955a2487923a2f1b08dc6a55bf */
+ * Stub hash: ef1bf3a5b851c5e1e6c80ffb3daad587913f639f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Exception_BulkWriteException_getWriteResult, 0, 0, MongoDB\\Driver\\WriteResult, 0)
 ZEND_END_ARG_INFO()
@@ -23,9 +23,10 @@ static zend_class_entry *register_class_MongoDB_Driver_Exception_BulkWriteExcept
 #endif
 
 	zval property_writeResult_default_value;
-	ZVAL_NULL(&property_writeResult_default_value);
+	ZVAL_UNDEF(&property_writeResult_default_value);
 	zend_string *property_writeResult_name = zend_string_init("writeResult", sizeof("writeResult") - 1, 1);
-	zend_declare_typed_property(class_entry, property_writeResult_name, &property_writeResult_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
+	zend_string *property_writeResult_class_MongoDB_Driver_WriteResult = zend_string_init("MongoDB\\Driver\\WriteResult", sizeof("MongoDB\\Driver\\WriteResult")-1, 1);
+	zend_declare_typed_property(class_entry, property_writeResult_name, &property_writeResult_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_writeResult_class_MongoDB_Driver_WriteResult, 0, 0));
 	zend_string_release(property_writeResult_name);
 
 	return class_entry;

--- a/src/MongoDB/Exception/BulkWriteException_arginfo.h
+++ b/src/MongoDB/Exception/BulkWriteException_arginfo.h
@@ -1,12 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3f5cb39269196e24c33e5f9393b2e5e25fc771c3 */
+ * Stub hash: 66b1cbab461cd3955a2487923a2f1b08dc6a55bf */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Exception_BulkWriteException_getWriteResult, 0, 0, MongoDB\\Driver\\WriteResult, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Exception_BulkWriteException, getWriteResult);
-
 
 static const zend_function_entry class_MongoDB_Driver_Exception_BulkWriteException_methods[] = {
 	ZEND_ME(MongoDB_Driver_Exception_BulkWriteException, getWriteResult, arginfo_class_MongoDB_Driver_Exception_BulkWriteException_getWriteResult, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -18,13 +16,16 @@ static zend_class_entry *register_class_MongoDB_Driver_Exception_BulkWriteExcept
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "BulkWriteException", class_MongoDB_Driver_Exception_BulkWriteException_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_MongoDB_Driver_Exception_ServerException, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_ServerException);
+#endif
 
-	zend_string *property_writeResult_class_MongoDB_Driver_WriteResult = zend_string_init("MongoDB\\Driver\\WriteResult", sizeof("MongoDB\\Driver\\WriteResult")-1, 1);
 	zval property_writeResult_default_value;
-	ZVAL_UNDEF(&property_writeResult_default_value);
+	ZVAL_NULL(&property_writeResult_default_value);
 	zend_string *property_writeResult_name = zend_string_init("writeResult", sizeof("writeResult") - 1, 1);
-	zend_declare_typed_property(class_entry, property_writeResult_name, &property_writeResult_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_writeResult_class_MongoDB_Driver_WriteResult, 0, 0));
+	zend_declare_typed_property(class_entry, property_writeResult_name, &property_writeResult_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release(property_writeResult_name);
 
 	return class_entry;

--- a/src/MongoDB/Exception/CommandException.stub.php
+++ b/src/MongoDB/Exception/CommandException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/CommandException_arginfo.h
+++ b/src/MongoDB/Exception/CommandException_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 40be27bab918f1c80863dc38526c2b236e8fb328 */
+ * Stub hash: 5c92211a99c6771f13c7ae6e37f01bd387bc6f2a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Exception_CommandException_getResultDocument, 0, 0, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
@@ -23,9 +23,9 @@ static zend_class_entry *register_class_MongoDB_Driver_Exception_CommandExceptio
 #endif
 
 	zval property_resultDocument_default_value;
-	ZVAL_NULL(&property_resultDocument_default_value);
+	ZVAL_UNDEF(&property_resultDocument_default_value);
 	zend_string *property_resultDocument_name = zend_string_init("resultDocument", sizeof("resultDocument") - 1, 1);
-	zend_declare_typed_property(class_entry, property_resultDocument_name, &property_resultDocument_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
+	zend_declare_typed_property(class_entry, property_resultDocument_name, &property_resultDocument_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
 	zend_string_release(property_resultDocument_name);
 
 	return class_entry;

--- a/src/MongoDB/Exception/CommandException_arginfo.h
+++ b/src/MongoDB/Exception/CommandException_arginfo.h
@@ -1,12 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a34c85582624ddbc462e429ba71d3309c4bcb4a3 */
+ * Stub hash: 40be27bab918f1c80863dc38526c2b236e8fb328 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Exception_CommandException_getResultDocument, 0, 0, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Exception_CommandException, getResultDocument);
-
 
 static const zend_function_entry class_MongoDB_Driver_Exception_CommandException_methods[] = {
 	ZEND_ME(MongoDB_Driver_Exception_CommandException, getResultDocument, arginfo_class_MongoDB_Driver_Exception_CommandException_getResultDocument, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -18,12 +16,16 @@ static zend_class_entry *register_class_MongoDB_Driver_Exception_CommandExceptio
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "CommandException", class_MongoDB_Driver_Exception_CommandException_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_MongoDB_Driver_Exception_ServerException, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_ServerException);
+#endif
 
 	zval property_resultDocument_default_value;
-	ZVAL_UNDEF(&property_resultDocument_default_value);
+	ZVAL_NULL(&property_resultDocument_default_value);
 	zend_string *property_resultDocument_name = zend_string_init("resultDocument", sizeof("resultDocument") - 1, 1);
-	zend_declare_typed_property(class_entry, property_resultDocument_name, &property_resultDocument_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
+	zend_declare_typed_property(class_entry, property_resultDocument_name, &property_resultDocument_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release(property_resultDocument_name);
 
 	return class_entry;

--- a/src/MongoDB/Exception/ConnectionException.stub.php
+++ b/src/MongoDB/Exception/ConnectionException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/ConnectionException_arginfo.h
+++ b/src/MongoDB/Exception/ConnectionException_arginfo.h
@@ -1,19 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 722ab9f3f73ccb6493c68e6ce4ac888f1aec8955 */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Exception_ConnectionException_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: bc5696aa261289787b61d29dcdbd0ae8b782c40b */
 
 static zend_class_entry *register_class_MongoDB_Driver_Exception_ConnectionException(zend_class_entry *class_entry_MongoDB_Driver_Exception_RuntimeException)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ConnectionException", class_MongoDB_Driver_Exception_ConnectionException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ConnectionException", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_MongoDB_Driver_Exception_RuntimeException, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_RuntimeException);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Exception/ConnectionTimeoutException.stub.php
+++ b/src/MongoDB/Exception/ConnectionTimeoutException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/ConnectionTimeoutException_arginfo.h
+++ b/src/MongoDB/Exception/ConnectionTimeoutException_arginfo.h
@@ -1,20 +1,17 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 60470413296405ec96e76e4331835d8a27dd5ade */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Exception_ConnectionTimeoutException_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: 57a9674abe9a302a39515e475f5af803fa3a03d6 */
 
 static zend_class_entry *register_class_MongoDB_Driver_Exception_ConnectionTimeoutException(zend_class_entry *class_entry_MongoDB_Driver_Exception_ConnectionException)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ConnectionTimeoutException", class_MongoDB_Driver_Exception_ConnectionTimeoutException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ConnectionTimeoutException", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_MongoDB_Driver_Exception_ConnectionException, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_ConnectionException);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Exception/EncryptionException.stub.php
+++ b/src/MongoDB/Exception/EncryptionException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/EncryptionException_arginfo.h
+++ b/src/MongoDB/Exception/EncryptionException_arginfo.h
@@ -1,19 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 432323bdeb13c6e1ce5e0201f0957290f412d26d */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Exception_EncryptionException_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: 27f5cb800d4f6d5bc710a48c3831622d2bc1e83d */
 
 static zend_class_entry *register_class_MongoDB_Driver_Exception_EncryptionException(zend_class_entry *class_entry_MongoDB_Driver_Exception_RuntimeException)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "EncryptionException", class_MongoDB_Driver_Exception_EncryptionException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "EncryptionException", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_MongoDB_Driver_Exception_RuntimeException, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_RuntimeException);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Exception/Exception.stub.php
+++ b/src/MongoDB/Exception/Exception.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/Exception_arginfo.h
+++ b/src/MongoDB/Exception/Exception_arginfo.h
@@ -1,18 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0e426c19c65154d51a01669619579b7ab2b7f60c */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Exception_Exception_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: 20977240e2f1eb527ecb609d61137353a1a5973a */
 
 static zend_class_entry *register_class_MongoDB_Driver_Exception_Exception(zend_class_entry *class_entry_Throwable)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "Exception", class_MongoDB_Driver_Exception_Exception_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "Exception", NULL);
 	class_entry = zend_register_internal_interface(&ce);
 	zend_class_implements(class_entry, 1, class_entry_Throwable);
 

--- a/src/MongoDB/Exception/ExecutionTimeoutException.stub.php
+++ b/src/MongoDB/Exception/ExecutionTimeoutException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/ExecutionTimeoutException_arginfo.h
+++ b/src/MongoDB/Exception/ExecutionTimeoutException_arginfo.h
@@ -1,20 +1,17 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e152c0d8d8a6b9d5cd6f43479fb32972ecd585d5 */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Exception_ExecutionTimeoutException_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: 1a4f91d780a89d2a50c5239070589470e76e768b */
 
 static zend_class_entry *register_class_MongoDB_Driver_Exception_ExecutionTimeoutException(zend_class_entry *class_entry_MongoDB_Driver_Exception_ServerException)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ExecutionTimeoutException", class_MongoDB_Driver_Exception_ExecutionTimeoutException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ExecutionTimeoutException", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_MongoDB_Driver_Exception_ServerException, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_ServerException);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Exception/InvalidArgumentException.stub.php
+++ b/src/MongoDB/Exception/InvalidArgumentException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/InvalidArgumentException_arginfo.h
+++ b/src/MongoDB/Exception/InvalidArgumentException_arginfo.h
@@ -1,19 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 275625c4d5dfb49b5608867b883711c5a4dc2057 */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Exception_InvalidArgumentException_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: 83e36c8ba8811dea91d9fde0e5673916c8027b66 */
 
 static zend_class_entry *register_class_MongoDB_Driver_Exception_InvalidArgumentException(zend_class_entry *class_entry_InvalidArgumentException, zend_class_entry *class_entry_MongoDB_Driver_Exception_Exception)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "InvalidArgumentException", class_MongoDB_Driver_Exception_InvalidArgumentException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "InvalidArgumentException", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_InvalidArgumentException, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_InvalidArgumentException);
+#endif
 	zend_class_implements(class_entry, 1, class_entry_MongoDB_Driver_Exception_Exception);
 
 	return class_entry;

--- a/src/MongoDB/Exception/LogicException.stub.php
+++ b/src/MongoDB/Exception/LogicException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/LogicException_arginfo.h
+++ b/src/MongoDB/Exception/LogicException_arginfo.h
@@ -1,19 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e3bbd956f358c9c22d22617be4d56c4018bd0441 */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Exception_LogicException_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: 5ab852c50a988ce0fe2f9f32f5fb2e4b838ab3f9 */
 
 static zend_class_entry *register_class_MongoDB_Driver_Exception_LogicException(zend_class_entry *class_entry_LogicException, zend_class_entry *class_entry_MongoDB_Driver_Exception_Exception)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "LogicException", class_MongoDB_Driver_Exception_LogicException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "LogicException", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_LogicException, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_LogicException);
+#endif
 	zend_class_implements(class_entry, 1, class_entry_MongoDB_Driver_Exception_Exception);
 
 	return class_entry;

--- a/src/MongoDB/Exception/RuntimeException.stub.php
+++ b/src/MongoDB/Exception/RuntimeException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/RuntimeException_arginfo.h
+++ b/src/MongoDB/Exception/RuntimeException_arginfo.h
@@ -1,13 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c895df47a65fcadec95e6f0d4e3f98a0dae827d6 */
+ * Stub hash: d1165a1dc3d202bd1f29d0b5ffdc336e4faf65d6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Exception_RuntimeException_hasErrorLabel, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, errorLabel, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Exception_RuntimeException, hasErrorLabel);
-
 
 static const zend_function_entry class_MongoDB_Driver_Exception_RuntimeException_methods[] = {
 	ZEND_ME(MongoDB_Driver_Exception_RuntimeException, hasErrorLabel, arginfo_class_MongoDB_Driver_Exception_RuntimeException_hasErrorLabel, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -19,13 +17,17 @@ static zend_class_entry *register_class_MongoDB_Driver_Exception_RuntimeExceptio
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "RuntimeException", class_MongoDB_Driver_Exception_RuntimeException_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_RuntimeException, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_RuntimeException);
+#endif
 	zend_class_implements(class_entry, 1, class_entry_MongoDB_Driver_Exception_Exception);
 
 	zval property_errorLabels_default_value;
 	ZVAL_NULL(&property_errorLabels_default_value);
 	zend_string *property_errorLabels_name = zend_string_init("errorLabels", sizeof("errorLabels") - 1, 1);
-	zend_declare_property_ex(class_entry, property_errorLabels_name, &property_errorLabels_default_value, ZEND_ACC_PROTECTED, NULL);
+	zend_declare_typed_property(class_entry, property_errorLabels_name, &property_errorLabels_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_NONE(0));
 	zend_string_release(property_errorLabels_name);
 
 	return class_entry;

--- a/src/MongoDB/Exception/ServerException.stub.php
+++ b/src/MongoDB/Exception/ServerException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/ServerException_arginfo.h
+++ b/src/MongoDB/Exception/ServerException_arginfo.h
@@ -1,19 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 62d8bf646599c54ba5a204b38042f80578435322 */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Exception_ServerException_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: 19490ac980b38cd2a6c25c93baf7e1ac0467961f */
 
 static zend_class_entry *register_class_MongoDB_Driver_Exception_ServerException(zend_class_entry *class_entry_MongoDB_Driver_Exception_RuntimeException)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ServerException", class_MongoDB_Driver_Exception_ServerException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "ServerException", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_MongoDB_Driver_Exception_RuntimeException, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_MongoDB_Driver_Exception_RuntimeException);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Exception/UnexpectedValueException.stub.php
+++ b/src/MongoDB/Exception/UnexpectedValueException.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Exception;

--- a/src/MongoDB/Exception/UnexpectedValueException_arginfo.h
+++ b/src/MongoDB/Exception/UnexpectedValueException_arginfo.h
@@ -1,19 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 463206b30ddfa600327f4ba731476ab4196939de */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Exception_UnexpectedValueException_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: f2934f2b5cb4d9407b5bbbf59698a7411c908863 */
 
 static zend_class_entry *register_class_MongoDB_Driver_Exception_UnexpectedValueException(zend_class_entry *class_entry_UnexpectedValueException, zend_class_entry *class_entry_MongoDB_Driver_Exception_Exception)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "UnexpectedValueException", class_MongoDB_Driver_Exception_UnexpectedValueException_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Exception", "UnexpectedValueException", NULL);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, class_entry_UnexpectedValueException, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_UnexpectedValueException);
+#endif
 	zend_class_implements(class_entry, 1, class_entry_MongoDB_Driver_Exception_Exception);
 
 	return class_entry;

--- a/src/MongoDB/Manager.stub.php
+++ b/src/MongoDB/Manager.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/Manager_arginfo.h
+++ b/src/MongoDB/Manager_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 94e08d9aa9d6b2f361f14207a86881c54ee3ff67 */
+ * Stub hash: 1fee3e4e276420cfc5b18ab7d6e076be94779105 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Manager___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uri, IS_STRING, 1, "null")
@@ -69,7 +69,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Manager_star
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Manager, __construct);
 static ZEND_METHOD(MongoDB_Driver_Manager, addSubscriber);
 static ZEND_METHOD(MongoDB_Driver_Manager, createClientEncryption);
@@ -88,7 +87,6 @@ static ZEND_METHOD(MongoDB_Driver_Manager, getWriteConcern);
 static ZEND_METHOD(MongoDB_Driver_Manager, removeSubscriber);
 static ZEND_METHOD(MongoDB_Driver_Manager, selectServer);
 static ZEND_METHOD(MongoDB_Driver_Manager, startSession);
-
 
 static const zend_function_entry class_MongoDB_Driver_Manager_methods[] = {
 	ZEND_ME(MongoDB_Driver_Manager, __construct, arginfo_class_MongoDB_Driver_Manager___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -117,8 +115,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Manager(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "Manager", class_MongoDB_Driver_Manager_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/CommandFailedEvent.stub.php
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/CommandFailedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandFailedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9a242bf0efd045145ad51f4fbeab587a59c8dd78 */
+ * Stub hash: 95a1f5035792c201d11fdd1b2948f29cc15b1e69 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -32,7 +32,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent_getServerConnectionId, 0, 0, IS_LONG, 1)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getCommandName);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getDatabaseName);
@@ -45,7 +44,6 @@ static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getReply);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getRequestId);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getServiceId);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getServerConnectionId);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_CommandFailedEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_CommandFailedEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -68,76 +66,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandFailedE
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "CommandFailedEvent", class_MongoDB_Driver_Monitoring_CommandFailedEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_host_default_value;
-	ZVAL_UNDEF(&property_host_default_value);
-	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
-	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_host_name);
-
-	zval property_port_default_value;
-	ZVAL_UNDEF(&property_port_default_value);
-	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
-	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_port_name);
-
-	zval property_commandName_default_value;
-	ZVAL_UNDEF(&property_commandName_default_value);
-	zend_string *property_commandName_name = zend_string_init("commandName", sizeof("commandName") - 1, 1);
-	zend_declare_typed_property(class_entry, property_commandName_name, &property_commandName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_commandName_name);
-
-	zval property_databaseName_default_value;
-	ZVAL_UNDEF(&property_databaseName_default_value);
-	zend_string *property_databaseName_name = zend_string_init("databaseName", sizeof("databaseName") - 1, 1);
-	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_databaseName_name);
-
-	zval property_durationMicros_default_value;
-	ZVAL_UNDEF(&property_durationMicros_default_value);
-	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
-	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_durationMicros_name);
-
-	zend_string *property_error_class_Exception = zend_string_init("Exception", sizeof("Exception")-1, 1);
-	zval property_error_default_value;
-	ZVAL_UNDEF(&property_error_default_value);
-	zend_string *property_error_name = zend_string_init("error", sizeof("error") - 1, 1);
-	zend_declare_typed_property(class_entry, property_error_name, &property_error_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_error_class_Exception, 0, 0));
-	zend_string_release(property_error_name);
-
-	zval property_reply_default_value;
-	ZVAL_UNDEF(&property_reply_default_value);
-	zend_string *property_reply_name = zend_string_init("reply", sizeof("reply") - 1, 1);
-	zend_declare_typed_property(class_entry, property_reply_name, &property_reply_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
-	zend_string_release(property_reply_name);
-
-	zval property_operationId_default_value;
-	ZVAL_UNDEF(&property_operationId_default_value);
-	zend_string *property_operationId_name = zend_string_init("operationId", sizeof("operationId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_operationId_name, &property_operationId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_operationId_name);
-
-	zval property_requestId_default_value;
-	ZVAL_UNDEF(&property_requestId_default_value);
-	zend_string *property_requestId_name = zend_string_init("requestId", sizeof("requestId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_requestId_name, &property_requestId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_requestId_name);
-
-	zend_string *property_serviceId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
-	zval property_serviceId_default_value;
-	ZVAL_UNDEF(&property_serviceId_default_value);
-	zend_string *property_serviceId_name = zend_string_init("serviceId", sizeof("serviceId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_serviceId_name, &property_serviceId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_serviceId_class_MongoDB_BSON_ObjectId, 0, MAY_BE_NULL));
-	zend_string_release(property_serviceId_name);
-
-	zval property_serverConnectionId_default_value;
-	ZVAL_UNDEF(&property_serverConnectionId_default_value);
-	zend_string *property_serverConnectionId_name = zend_string_init("serverConnectionId", sizeof("serverConnectionId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_serverConnectionId_name, &property_serverConnectionId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
-	zend_string_release(property_serverConnectionId_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/CommandFailedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandFailedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 95a1f5035792c201d11fdd1b2948f29cc15b1e69 */
+ * Stub hash: 290fcb84655aea3822ce90394e198c1055ab75a9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -72,6 +72,70 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandFailedE
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_HOST), &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PORT), &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zval property_commandName_default_value;
+	ZVAL_UNDEF(&property_commandName_default_value);
+	zend_string *property_commandName_name = zend_string_init("commandName", sizeof("commandName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_commandName_name, &property_commandName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_commandName_name);
+
+	zval property_databaseName_default_value;
+	ZVAL_UNDEF(&property_databaseName_default_value);
+	zend_string *property_databaseName_name = zend_string_init("databaseName", sizeof("databaseName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_databaseName_name);
+
+	zval property_durationMicros_default_value;
+	ZVAL_UNDEF(&property_durationMicros_default_value);
+	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
+	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_durationMicros_name);
+
+	zval property_error_default_value;
+	ZVAL_UNDEF(&property_error_default_value);
+	zend_string *property_error_name = zend_string_init("error", sizeof("error") - 1, 1);
+	zend_string *property_error_class_Exception = zend_string_init("Exception", sizeof("Exception")-1, 1);
+	zend_declare_typed_property(class_entry, property_error_name, &property_error_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_error_class_Exception, 0, 0));
+	zend_string_release(property_error_name);
+
+	zval property_reply_default_value;
+	ZVAL_UNDEF(&property_reply_default_value);
+	zend_string *property_reply_name = zend_string_init("reply", sizeof("reply") - 1, 1);
+	zend_declare_typed_property(class_entry, property_reply_name, &property_reply_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
+	zend_string_release(property_reply_name);
+
+	zval property_operationId_default_value;
+	ZVAL_UNDEF(&property_operationId_default_value);
+	zend_string *property_operationId_name = zend_string_init("operationId", sizeof("operationId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_operationId_name, &property_operationId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_operationId_name);
+
+	zval property_requestId_default_value;
+	ZVAL_UNDEF(&property_requestId_default_value);
+	zend_string *property_requestId_name = zend_string_init("requestId", sizeof("requestId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_requestId_name, &property_requestId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_requestId_name);
+
+	zval property_serviceId_default_value;
+	ZVAL_UNDEF(&property_serviceId_default_value);
+	zend_string *property_serviceId_name = zend_string_init("serviceId", sizeof("serviceId") - 1, 1);
+	zend_string *property_serviceId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zend_declare_typed_property(class_entry, property_serviceId_name, &property_serviceId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_serviceId_class_MongoDB_BSON_ObjectId, 0, MAY_BE_NULL));
+	zend_string_release(property_serviceId_name);
+
+	zval property_serverConnectionId_default_value;
+	ZVAL_UNDEF(&property_serverConnectionId_default_value);
+	zend_string *property_serverConnectionId_name = zend_string_init("serverConnectionId", sizeof("serverConnectionId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_serverConnectionId_name, &property_serverConnectionId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_serverConnectionId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/CommandStartedEvent.stub.php
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/CommandStartedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandStartedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4201347a0af241aed07d3a2a638af34a7cc17425 */
+ * Stub hash: 58431fd556ea4b06fa2f4b1e7c3a2ae7c75e7a47 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandStartedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -27,7 +27,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandStartedEvent_getServerConnectionId, 0, 0, IS_LONG, 1)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getCommand);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getCommandName);
@@ -38,7 +37,6 @@ static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getPort);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getRequestId);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getServiceId);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getServerConnectionId);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_CommandStartedEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_CommandStartedEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_CommandStartedEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -59,63 +57,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandStarted
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "CommandStartedEvent", class_MongoDB_Driver_Monitoring_CommandStartedEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_host_default_value;
-	ZVAL_UNDEF(&property_host_default_value);
-	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
-	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_host_name);
-
-	zval property_port_default_value;
-	ZVAL_UNDEF(&property_port_default_value);
-	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
-	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_port_name);
-
-	zval property_commandName_default_value;
-	ZVAL_UNDEF(&property_commandName_default_value);
-	zend_string *property_commandName_name = zend_string_init("commandName", sizeof("commandName") - 1, 1);
-	zend_declare_typed_property(class_entry, property_commandName_name, &property_commandName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_commandName_name);
-
-	zval property_databaseName_default_value;
-	ZVAL_UNDEF(&property_databaseName_default_value);
-	zend_string *property_databaseName_name = zend_string_init("databaseName", sizeof("databaseName") - 1, 1);
-	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_databaseName_name);
-
-	zval property_command_default_value;
-	ZVAL_UNDEF(&property_command_default_value);
-	zend_string *property_command_name = zend_string_init("command", sizeof("command") - 1, 1);
-	zend_declare_typed_property(class_entry, property_command_name, &property_command_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
-	zend_string_release(property_command_name);
-
-	zval property_operationId_default_value;
-	ZVAL_UNDEF(&property_operationId_default_value);
-	zend_string *property_operationId_name = zend_string_init("operationId", sizeof("operationId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_operationId_name, &property_operationId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_operationId_name);
-
-	zval property_requestId_default_value;
-	ZVAL_UNDEF(&property_requestId_default_value);
-	zend_string *property_requestId_name = zend_string_init("requestId", sizeof("requestId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_requestId_name, &property_requestId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_requestId_name);
-
-	zend_string *property_serviceId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
-	zval property_serviceId_default_value;
-	ZVAL_UNDEF(&property_serviceId_default_value);
-	zend_string *property_serviceId_name = zend_string_init("serviceId", sizeof("serviceId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_serviceId_name, &property_serviceId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_serviceId_class_MongoDB_BSON_ObjectId, 0, MAY_BE_NULL));
-	zend_string_release(property_serviceId_name);
-
-	zval property_serverConnectionId_default_value;
-	ZVAL_UNDEF(&property_serverConnectionId_default_value);
-	zend_string *property_serverConnectionId_name = zend_string_init("serverConnectionId", sizeof("serverConnectionId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_serverConnectionId_name, &property_serverConnectionId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
-	zend_string_release(property_serverConnectionId_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/CommandStartedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandStartedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 58431fd556ea4b06fa2f4b1e7c3a2ae7c75e7a47 */
+ * Stub hash: e250ffaa013fd197fb3946669d1f186da158606d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandStartedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -63,6 +63,57 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandStarted
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_HOST), &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PORT), &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zval property_commandName_default_value;
+	ZVAL_UNDEF(&property_commandName_default_value);
+	zend_string *property_commandName_name = zend_string_init("commandName", sizeof("commandName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_commandName_name, &property_commandName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_commandName_name);
+
+	zval property_databaseName_default_value;
+	ZVAL_UNDEF(&property_databaseName_default_value);
+	zend_string *property_databaseName_name = zend_string_init("databaseName", sizeof("databaseName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_databaseName_name);
+
+	zval property_command_default_value;
+	ZVAL_UNDEF(&property_command_default_value);
+	zend_string *property_command_name = zend_string_init("command", sizeof("command") - 1, 1);
+	zend_declare_typed_property(class_entry, property_command_name, &property_command_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
+	zend_string_release(property_command_name);
+
+	zval property_operationId_default_value;
+	ZVAL_UNDEF(&property_operationId_default_value);
+	zend_string *property_operationId_name = zend_string_init("operationId", sizeof("operationId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_operationId_name, &property_operationId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_operationId_name);
+
+	zval property_requestId_default_value;
+	ZVAL_UNDEF(&property_requestId_default_value);
+	zend_string *property_requestId_name = zend_string_init("requestId", sizeof("requestId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_requestId_name, &property_requestId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_requestId_name);
+
+	zval property_serviceId_default_value;
+	ZVAL_UNDEF(&property_serviceId_default_value);
+	zend_string *property_serviceId_name = zend_string_init("serviceId", sizeof("serviceId") - 1, 1);
+	zend_string *property_serviceId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zend_declare_typed_property(class_entry, property_serviceId_name, &property_serviceId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_serviceId_class_MongoDB_BSON_ObjectId, 0, MAY_BE_NULL));
+	zend_string_release(property_serviceId_name);
+
+	zval property_serverConnectionId_default_value;
+	ZVAL_UNDEF(&property_serverConnectionId_default_value);
+	zend_string *property_serverConnectionId_name = zend_string_init("serverConnectionId", sizeof("serverConnectionId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_serverConnectionId_name, &property_serverConnectionId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_serverConnectionId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/CommandSubscriber.stub.php
+++ b/src/MongoDB/Monitoring/CommandSubscriber.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/CommandSubscriber_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandSubscriber_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9733d9c7cb3460bd7fb85be93cc5c9fbe70e3762 */
+ * Stub hash: 3207fb6b6a5b00471d08add24c41e062d7d2b43e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandStarted, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\CommandStartedEvent, 0)
@@ -14,12 +14,22 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_Driver_Monitoring_CommandSubscriber_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_CommandSubscriber, commandStarted, arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandStarted, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_CommandSubscriber, commandSucceeded, arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandSucceeded, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_CommandSubscriber, commandFailed, arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandFailed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("commandStarted", NULL, arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandStarted, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("commandStarted", NULL, arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandStarted, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("commandSucceeded", NULL, arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandSucceeded, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("commandSucceeded", NULL, arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandSucceeded, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("commandFailed", NULL, arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandFailed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("commandFailed", NULL, arginfo_class_MongoDB_Driver_Monitoring_CommandSubscriber_commandFailed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.stub.php
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/CommandSucceededEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 386a11d24c8964c5305ebda6b7070709fe745d83 */
+ * Stub hash: 153383f0dae4ebcbaece5b307b623f6903fec00b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSucceededEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -67,6 +67,63 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandSucceed
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_HOST), &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PORT), &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zval property_commandName_default_value;
+	ZVAL_UNDEF(&property_commandName_default_value);
+	zend_string *property_commandName_name = zend_string_init("commandName", sizeof("commandName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_commandName_name, &property_commandName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_commandName_name);
+
+	zval property_databaseName_default_value;
+	ZVAL_UNDEF(&property_databaseName_default_value);
+	zend_string *property_databaseName_name = zend_string_init("databaseName", sizeof("databaseName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_databaseName_name);
+
+	zval property_durationMicros_default_value;
+	ZVAL_UNDEF(&property_durationMicros_default_value);
+	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
+	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_durationMicros_name);
+
+	zval property_reply_default_value;
+	ZVAL_UNDEF(&property_reply_default_value);
+	zend_string *property_reply_name = zend_string_init("reply", sizeof("reply") - 1, 1);
+	zend_declare_typed_property(class_entry, property_reply_name, &property_reply_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
+	zend_string_release(property_reply_name);
+
+	zval property_operationId_default_value;
+	ZVAL_UNDEF(&property_operationId_default_value);
+	zend_string *property_operationId_name = zend_string_init("operationId", sizeof("operationId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_operationId_name, &property_operationId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_operationId_name);
+
+	zval property_requestId_default_value;
+	ZVAL_UNDEF(&property_requestId_default_value);
+	zend_string *property_requestId_name = zend_string_init("requestId", sizeof("requestId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_requestId_name, &property_requestId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_requestId_name);
+
+	zval property_serviceId_default_value;
+	ZVAL_UNDEF(&property_serviceId_default_value);
+	zend_string *property_serviceId_name = zend_string_init("serviceId", sizeof("serviceId") - 1, 1);
+	zend_string *property_serviceId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zend_declare_typed_property(class_entry, property_serviceId_name, &property_serviceId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_serviceId_class_MongoDB_BSON_ObjectId, 0, MAY_BE_NULL));
+	zend_string_release(property_serviceId_name);
+
+	zval property_serverConnectionId_default_value;
+	ZVAL_UNDEF(&property_serverConnectionId_default_value);
+	zend_string *property_serverConnectionId_name = zend_string_init("serverConnectionId", sizeof("serverConnectionId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_serverConnectionId_name, &property_serverConnectionId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_serverConnectionId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/CommandSucceededEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 97e5abaecaa34efe4cddf058cd701ec5c2890b96 */
+ * Stub hash: 386a11d24c8964c5305ebda6b7070709fe745d83 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSucceededEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -29,7 +29,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSucceededEvent_getServerConnectionId, 0, 0, IS_LONG, 1)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getCommandName);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getDatabaseName);
@@ -41,7 +40,6 @@ static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getReply);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getRequestId);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getServiceId);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getServerConnectionId);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_CommandSucceededEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_CommandSucceededEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_CommandSucceededEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -63,69 +61,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandSucceed
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "CommandSucceededEvent", class_MongoDB_Driver_Monitoring_CommandSucceededEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_host_default_value;
-	ZVAL_UNDEF(&property_host_default_value);
-	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
-	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_host_name);
-
-	zval property_port_default_value;
-	ZVAL_UNDEF(&property_port_default_value);
-	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
-	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_port_name);
-
-	zval property_commandName_default_value;
-	ZVAL_UNDEF(&property_commandName_default_value);
-	zend_string *property_commandName_name = zend_string_init("commandName", sizeof("commandName") - 1, 1);
-	zend_declare_typed_property(class_entry, property_commandName_name, &property_commandName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_commandName_name);
-
-	zval property_databaseName_default_value;
-	ZVAL_UNDEF(&property_databaseName_default_value);
-	zend_string *property_databaseName_name = zend_string_init("databaseName", sizeof("databaseName") - 1, 1);
-	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_databaseName_name);
-
-	zval property_durationMicros_default_value;
-	ZVAL_UNDEF(&property_durationMicros_default_value);
-	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
-	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_durationMicros_name);
-
-	zval property_reply_default_value;
-	ZVAL_UNDEF(&property_reply_default_value);
-	zend_string *property_reply_name = zend_string_init("reply", sizeof("reply") - 1, 1);
-	zend_declare_typed_property(class_entry, property_reply_name, &property_reply_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
-	zend_string_release(property_reply_name);
-
-	zval property_operationId_default_value;
-	ZVAL_UNDEF(&property_operationId_default_value);
-	zend_string *property_operationId_name = zend_string_init("operationId", sizeof("operationId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_operationId_name, &property_operationId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_operationId_name);
-
-	zval property_requestId_default_value;
-	ZVAL_UNDEF(&property_requestId_default_value);
-	zend_string *property_requestId_name = zend_string_init("requestId", sizeof("requestId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_requestId_name, &property_requestId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_requestId_name);
-
-	zend_string *property_serviceId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
-	zval property_serviceId_default_value;
-	ZVAL_UNDEF(&property_serviceId_default_value);
-	zend_string *property_serviceId_name = zend_string_init("serviceId", sizeof("serviceId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_serviceId_name, &property_serviceId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_serviceId_class_MongoDB_BSON_ObjectId, 0, MAY_BE_NULL));
-	zend_string_release(property_serviceId_name);
-
-	zval property_serverConnectionId_default_value;
-	ZVAL_UNDEF(&property_serverConnectionId_default_value);
-	zend_string *property_serverConnectionId_name = zend_string_init("serverConnectionId", sizeof("serverConnectionId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_serverConnectionId_name, &property_serverConnectionId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
-	zend_string_release(property_serverConnectionId_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/LogSubscriber.stub.php
+++ b/src/MongoDB/Monitoring/LogSubscriber.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/LogSubscriber_arginfo.h
+++ b/src/MongoDB/Monitoring/LogSubscriber_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4920ad21bd26ea586d4322d49bf44c9c3530e494 */
+ * Stub hash: 0a17415d9367b2a9db97fdfb381375c07db7523b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_LogSubscriber_log, 0, 3, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, level, IS_LONG, 0)
@@ -8,10 +8,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_Driver_Monitoring_LogSubscriber_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_LogSubscriber, log, arginfo_class_MongoDB_Driver_Monitoring_LogSubscriber_log, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("log", NULL, arginfo_class_MongoDB_Driver_Monitoring_LogSubscriber_log, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("log", NULL, arginfo_class_MongoDB_Driver_Monitoring_LogSubscriber_log, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/MongoDB/Monitoring/SDAMSubscriber.stub.php
+++ b/src/MongoDB/Monitoring/SDAMSubscriber.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/SDAMSubscriber_arginfo.h
+++ b/src/MongoDB/Monitoring/SDAMSubscriber_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4288cbc04c5e6f432f960e0964ee7022c4a94ac5 */
+ * Stub hash: b7d58477d2ac5f63bdfb04801eb6517aff5dd8df */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverChanged, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, event, MongoDB\\Driver\\Monitoring\\ServerChangedEvent, 0)
@@ -38,18 +38,52 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_
 ZEND_END_ARG_INFO()
 
 
-
-
 static const zend_function_entry class_MongoDB_Driver_Monitoring_SDAMSubscriber_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_SDAMSubscriber, serverChanged, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverChanged, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_SDAMSubscriber, serverClosed, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverClosed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_SDAMSubscriber, serverOpening, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverOpening, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_SDAMSubscriber, serverHeartbeatFailed, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatFailed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_SDAMSubscriber, serverHeartbeatStarted, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatStarted, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_SDAMSubscriber, serverHeartbeatSucceeded, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatSucceeded, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_SDAMSubscriber, topologyChanged, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyChanged, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_SDAMSubscriber, topologyClosed, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyClosed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
-	ZEND_ABSTRACT_ME_WITH_FLAGS(MongoDB_Driver_Monitoring_SDAMSubscriber, topologyOpening, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyOpening, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("serverChanged", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverChanged, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("serverChanged", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverChanged, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("serverClosed", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverClosed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("serverClosed", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverClosed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("serverOpening", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverOpening, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("serverOpening", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverOpening, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("serverHeartbeatFailed", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatFailed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("serverHeartbeatFailed", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatFailed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("serverHeartbeatStarted", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatStarted, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("serverHeartbeatStarted", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatStarted, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("serverHeartbeatSucceeded", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatSucceeded, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("serverHeartbeatSucceeded", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_serverHeartbeatSucceeded, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("topologyChanged", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyChanged, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("topologyChanged", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyChanged, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("topologyClosed", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyClosed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("topologyClosed", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyClosed, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY("topologyOpening", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyOpening, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY("topologyOpening", NULL, arginfo_class_MongoDB_Driver_Monitoring_SDAMSubscriber_topologyOpening, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+#endif
 	ZEND_FE_END
 };
 

--- a/src/MongoDB/Monitoring/ServerChangedEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerChangedEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/ServerChangedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerChangedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 01bc1644f31f6d23462d3b58403f74917f0fcd1d */
+ * Stub hash: 978047b8c3560beeb59e80be3d9c132e3b9d2c93 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerChangedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -46,6 +46,35 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerChangedE
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_HOST), &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PORT), &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
+
+	zval property_newDescription_default_value;
+	ZVAL_UNDEF(&property_newDescription_default_value);
+	zend_string *property_newDescription_name = zend_string_init("newDescription", sizeof("newDescription") - 1, 1);
+	zend_string *property_newDescription_class_MongoDB_Driver_ServerDescription = zend_string_init("MongoDB\\Driver\\ServerDescription", sizeof("MongoDB\\Driver\\ServerDescription")-1, 1);
+	zend_declare_typed_property(class_entry, property_newDescription_name, &property_newDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_newDescription_class_MongoDB_Driver_ServerDescription, 0, 0));
+	zend_string_release(property_newDescription_name);
+
+	zval property_previousDescription_default_value;
+	ZVAL_UNDEF(&property_previousDescription_default_value);
+	zend_string *property_previousDescription_name = zend_string_init("previousDescription", sizeof("previousDescription") - 1, 1);
+	zend_string *property_previousDescription_class_MongoDB_Driver_ServerDescription = zend_string_init("MongoDB\\Driver\\ServerDescription", sizeof("MongoDB\\Driver\\ServerDescription")-1, 1);
+	zend_declare_typed_property(class_entry, property_previousDescription_name, &property_previousDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousDescription_class_MongoDB_Driver_ServerDescription, 0, 0));
+	zend_string_release(property_previousDescription_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerChangedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerChangedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3433024518babbd96607749cfd0380ddb21cc5ce */
+ * Stub hash: 01bc1644f31f6d23462d3b58403f74917f0fcd1d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerChangedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -18,14 +18,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerChangedEvent_getTopologyId, 0, 0, MongoDB\\BSON\\ObjectId, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerChangedEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerChangedEvent, getPort);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerChangedEvent, getHost);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerChangedEvent, getNewDescription);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerChangedEvent, getPreviousDescription);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerChangedEvent, getTopologyId);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_ServerChangedEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_ServerChangedEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_ServerChangedEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -42,41 +40,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerChangedE
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerChangedEvent", class_MongoDB_Driver_Monitoring_ServerChangedEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_host_default_value;
-	ZVAL_UNDEF(&property_host_default_value);
-	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
-	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_host_name);
-
-	zval property_port_default_value;
-	ZVAL_UNDEF(&property_port_default_value);
-	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
-	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_port_name);
-
-	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
-	zval property_topologyId_default_value;
-	ZVAL_UNDEF(&property_topologyId_default_value);
-	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
-	zend_string_release(property_topologyId_name);
-
-	zend_string *property_newDescription_class_MongoDB_Driver_ServerDescription = zend_string_init("MongoDB\\Driver\\ServerDescription", sizeof("MongoDB\\Driver\\ServerDescription")-1, 1);
-	zval property_newDescription_default_value;
-	ZVAL_UNDEF(&property_newDescription_default_value);
-	zend_string *property_newDescription_name = zend_string_init("newDescription", sizeof("newDescription") - 1, 1);
-	zend_declare_typed_property(class_entry, property_newDescription_name, &property_newDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_newDescription_class_MongoDB_Driver_ServerDescription, 0, 0));
-	zend_string_release(property_newDescription_name);
-
-	zend_string *property_previousDescription_class_MongoDB_Driver_ServerDescription = zend_string_init("MongoDB\\Driver\\ServerDescription", sizeof("MongoDB\\Driver\\ServerDescription")-1, 1);
-	zval property_previousDescription_default_value;
-	ZVAL_UNDEF(&property_previousDescription_default_value);
-	zend_string *property_previousDescription_name = zend_string_init("previousDescription", sizeof("previousDescription") - 1, 1);
-	zend_declare_typed_property(class_entry, property_previousDescription_name, &property_previousDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousDescription_class_MongoDB_Driver_ServerDescription, 0, 0));
-	zend_string_release(property_previousDescription_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerClosedEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerClosedEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/ServerClosedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerClosedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b535803b25b7a24ba4bd1814c52078b6d2c3acf4 */
+ * Stub hash: 69a93e4cabab41afbe70c84632dfc5c8b519b837 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerClosedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -37,6 +37,21 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerClosedEv
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_HOST), &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PORT), &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerClosedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerClosedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a2c6e5876d344618d543ff0e4c76794d9f82624c */
+ * Stub hash: b535803b25b7a24ba4bd1814c52078b6d2c3acf4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerClosedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -13,12 +13,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerClosedEvent_getTopologyId, 0, 0, MongoDB\\BSON\\ObjectId, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, getPort);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, getHost);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, getTopologyId);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_ServerClosedEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_ServerClosedEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_ServerClosedEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -33,27 +31,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerClosedEv
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerClosedEvent", class_MongoDB_Driver_Monitoring_ServerClosedEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_host_default_value;
-	ZVAL_UNDEF(&property_host_default_value);
-	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
-	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_host_name);
-
-	zval property_port_default_value;
-	ZVAL_UNDEF(&property_port_default_value);
-	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
-	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_port_name);
-
-	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
-	zval property_topologyId_default_value;
-	ZVAL_UNDEF(&property_topologyId_default_value);
-	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
-	zend_string_release(property_topologyId_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b78a5918928c8b54c49f380978e527c15db14bca */
+ * Stub hash: 045d65928d893251f62b44df99536dab6f0c7bec */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -18,14 +18,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent_isAwaited, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getDurationMicros);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getError);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getPort);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getHost);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, isAwaited);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -42,39 +40,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerHeartbeatFailedEvent", class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_host_default_value;
-	ZVAL_UNDEF(&property_host_default_value);
-	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
-	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_host_name);
-
-	zval property_port_default_value;
-	ZVAL_UNDEF(&property_port_default_value);
-	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
-	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_port_name);
-
-	zval property_awaited_default_value;
-	ZVAL_UNDEF(&property_awaited_default_value);
-	zend_string *property_awaited_name = zend_string_init("awaited", sizeof("awaited") - 1, 1);
-	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
-	zend_string_release(property_awaited_name);
-
-	zval property_durationMicros_default_value;
-	ZVAL_UNDEF(&property_durationMicros_default_value);
-	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
-	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_durationMicros_name);
-
-	zend_string *property_error_class_Exception = zend_string_init("Exception", sizeof("Exception")-1, 1);
-	zval property_error_default_value;
-	ZVAL_UNDEF(&property_error_default_value);
-	zend_string *property_error_name = zend_string_init("error", sizeof("error") - 1, 1);
-	zend_declare_typed_property(class_entry, property_error_name, &property_error_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_error_class_Exception, 0, 0));
-	zend_string_release(property_error_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 045d65928d893251f62b44df99536dab6f0c7bec */
+ * Stub hash: abff51dfbb54b9d9a61c38bf71853c20df352171 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -46,6 +46,33 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_HOST), &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PORT), &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zval property_awaited_default_value;
+	ZVAL_UNDEF(&property_awaited_default_value);
+	zend_string *property_awaited_name = zend_string_init("awaited", sizeof("awaited") - 1, 1);
+	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_awaited_name);
+
+	zval property_durationMicros_default_value;
+	ZVAL_UNDEF(&property_durationMicros_default_value);
+	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
+	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_durationMicros_name);
+
+	zval property_error_default_value;
+	ZVAL_UNDEF(&property_error_default_value);
+	zend_string *property_error_name = zend_string_init("error", sizeof("error") - 1, 1);
+	zend_string *property_error_class_Exception = zend_string_init("Exception", sizeof("Exception")-1, 1);
+	zend_declare_typed_property(class_entry, property_error_name, &property_error_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_error_class_Exception, 0, 0));
+	zend_string_release(property_error_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e60621aae01cd3f4198aa03b8d5f851f76b71d24 */
+ * Stub hash: b12f4bd39fb4ec5dcb13e603b9fbfba629d32094 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -37,6 +37,20 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_HOST), &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PORT), &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zval property_awaited_default_value;
+	ZVAL_UNDEF(&property_awaited_default_value);
+	zend_string *property_awaited_name = zend_string_init("awaited", sizeof("awaited") - 1, 1);
+	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_awaited_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9a0f4bf9a1ac308158f596c4c6010a094bca3e7e */
+ * Stub hash: e60621aae01cd3f4198aa03b8d5f851f76b71d24 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -13,12 +13,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent_isAwaited, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, getPort);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, getHost);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, isAwaited);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -33,26 +31,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerHeartbeatStartedEvent", class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_host_default_value;
-	ZVAL_UNDEF(&property_host_default_value);
-	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
-	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_host_name);
-
-	zval property_port_default_value;
-	ZVAL_UNDEF(&property_port_default_value);
-	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
-	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_port_name);
-
-	zval property_awaited_default_value;
-	ZVAL_UNDEF(&property_awaited_default_value);
-	zend_string *property_awaited_name = zend_string_init("awaited", sizeof("awaited") - 1, 1);
-	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
-	zend_string_release(property_awaited_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 92a37524aa7fdab043eabba7407db7d44ebcd472 */
+ * Stub hash: 18ac02cd0290e843cdc39f3f711ceb07ac5a4082 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -18,14 +18,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent_isAwaited, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getDurationMicros);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getReply);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getPort);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getHost);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, isAwaited);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -42,38 +40,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerHeartbeatSucceededEvent", class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_host_default_value;
-	ZVAL_UNDEF(&property_host_default_value);
-	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
-	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_host_name);
-
-	zval property_port_default_value;
-	ZVAL_UNDEF(&property_port_default_value);
-	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
-	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_port_name);
-
-	zval property_awaited_default_value;
-	ZVAL_UNDEF(&property_awaited_default_value);
-	zend_string *property_awaited_name = zend_string_init("awaited", sizeof("awaited") - 1, 1);
-	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
-	zend_string_release(property_awaited_name);
-
-	zval property_durationMicros_default_value;
-	ZVAL_UNDEF(&property_durationMicros_default_value);
-	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
-	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_durationMicros_name);
-
-	zval property_reply_default_value;
-	ZVAL_UNDEF(&property_reply_default_value);
-	zend_string *property_reply_name = zend_string_init("reply", sizeof("reply") - 1, 1);
-	zend_declare_typed_property(class_entry, property_reply_name, &property_reply_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
-	zend_string_release(property_reply_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 18ac02cd0290e843cdc39f3f711ceb07ac5a4082 */
+ * Stub hash: fe93a333a39554b9660c2eeb47852755dbea7e97 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -46,6 +46,32 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_HOST), &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PORT), &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zval property_awaited_default_value;
+	ZVAL_UNDEF(&property_awaited_default_value);
+	zend_string *property_awaited_name = zend_string_init("awaited", sizeof("awaited") - 1, 1);
+	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_awaited_name);
+
+	zval property_durationMicros_default_value;
+	ZVAL_UNDEF(&property_durationMicros_default_value);
+	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
+	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_durationMicros_name);
+
+	zval property_reply_default_value;
+	ZVAL_UNDEF(&property_reply_default_value);
+	zend_string *property_reply_name = zend_string_init("reply", sizeof("reply") - 1, 1);
+	zend_declare_typed_property(class_entry, property_reply_name, &property_reply_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT));
+	zend_string_release(property_reply_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerOpeningEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerOpeningEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/ServerOpeningEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerOpeningEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 12860341bce31afd29060045a5ffcef80fc14d92 */
+ * Stub hash: e05cac5a6840d453e7c00175763fc8d1b659054f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerOpeningEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -37,6 +37,21 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerOpeningE
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_host_default_value;
+	ZVAL_UNDEF(&property_host_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_HOST), &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zval property_port_default_value;
+	ZVAL_UNDEF(&property_port_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PORT), &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/ServerOpeningEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerOpeningEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d7f6e4ad2b7b44634cbcbc665db33bf6e0d4de4c */
+ * Stub hash: 12860341bce31afd29060045a5ffcef80fc14d92 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerOpeningEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -13,12 +13,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerOpeningEvent_getTopologyId, 0, 0, MongoDB\\BSON\\ObjectId, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, getPort);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, getHost);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, getTopologyId);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_ServerOpeningEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_ServerOpeningEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_ServerOpeningEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -33,27 +31,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerOpeningE
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "ServerOpeningEvent", class_MongoDB_Driver_Monitoring_ServerOpeningEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_host_default_value;
-	ZVAL_UNDEF(&property_host_default_value);
-	zend_string *property_host_name = zend_string_init("host", sizeof("host") - 1, 1);
-	zend_declare_typed_property(class_entry, property_host_name, &property_host_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_host_name);
-
-	zval property_port_default_value;
-	ZVAL_UNDEF(&property_port_default_value);
-	zend_string *property_port_name = zend_string_init("port", sizeof("port") - 1, 1);
-	zend_declare_typed_property(class_entry, property_port_name, &property_port_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_port_name);
-
-	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
-	zval property_topologyId_default_value;
-	ZVAL_UNDEF(&property_topologyId_default_value);
-	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
-	zend_string_release(property_topologyId_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/Subscriber.stub.php
+++ b/src/MongoDB/Monitoring/Subscriber.stub.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @generate-class-entries static
- * @generate-function-entries
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/Subscriber_arginfo.h
+++ b/src/MongoDB/Monitoring/Subscriber_arginfo.h
@@ -1,18 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f2e7d8f61aa5359716d9c2186c24ba68db5e96b4 */
-
-
-
-
-static const zend_function_entry class_MongoDB_Driver_Monitoring_Subscriber_methods[] = {
-	ZEND_FE_END
-};
+ * Stub hash: a86f5de0f86037e928a37f1b6c38593ce005b202 */
 
 static zend_class_entry *register_class_MongoDB_Driver_Monitoring_Subscriber(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "Subscriber", class_MongoDB_Driver_Monitoring_Subscriber_methods);
+	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "Subscriber", NULL);
 	class_entry = zend_register_internal_interface(&ce);
 
 	return class_entry;

--- a/src/MongoDB/Monitoring/TopologyChangedEvent.stub.php
+++ b/src/MongoDB/Monitoring/TopologyChangedEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/TopologyChangedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/TopologyChangedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bc706887153f946683941d01b12945ea8cd69e91 */
+ * Stub hash: 8b0d2964ff45fa98324e48dd31ffacc0f9152540 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyChangedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -12,12 +12,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyChangedEvent_getTopologyId, 0, 0, MongoDB\\BSON\\ObjectId, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_TopologyChangedEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_TopologyChangedEvent, getNewDescription);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_TopologyChangedEvent, getPreviousDescription);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_TopologyChangedEvent, getTopologyId);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_TopologyChangedEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_TopologyChangedEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_TopologyChangedEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -32,29 +30,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_TopologyChange
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "TopologyChangedEvent", class_MongoDB_Driver_Monitoring_TopologyChangedEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
-	zval property_topologyId_default_value;
-	ZVAL_UNDEF(&property_topologyId_default_value);
-	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
-	zend_string_release(property_topologyId_name);
-
-	zend_string *property_newDescription_class_MongoDB_Driver_TopologyDescription = zend_string_init("MongoDB\\Driver\\TopologyDescription", sizeof("MongoDB\\Driver\\TopologyDescription")-1, 1);
-	zval property_newDescription_default_value;
-	ZVAL_UNDEF(&property_newDescription_default_value);
-	zend_string *property_newDescription_name = zend_string_init("newDescription", sizeof("newDescription") - 1, 1);
-	zend_declare_typed_property(class_entry, property_newDescription_name, &property_newDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_newDescription_class_MongoDB_Driver_TopologyDescription, 0, 0));
-	zend_string_release(property_newDescription_name);
-
-	zend_string *property_previousDescription_class_MongoDB_Driver_TopologyDescription = zend_string_init("MongoDB\\Driver\\TopologyDescription", sizeof("MongoDB\\Driver\\TopologyDescription")-1, 1);
-	zval property_previousDescription_default_value;
-	ZVAL_UNDEF(&property_previousDescription_default_value);
-	zend_string *property_previousDescription_name = zend_string_init("previousDescription", sizeof("previousDescription") - 1, 1);
-	zend_declare_typed_property(class_entry, property_previousDescription_name, &property_previousDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousDescription_class_MongoDB_Driver_TopologyDescription, 0, 0));
-	zend_string_release(property_previousDescription_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/TopologyChangedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/TopologyChangedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8b0d2964ff45fa98324e48dd31ffacc0f9152540 */
+ * Stub hash: a9523c4af372004f40da12f771319b381726336e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyChangedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -36,6 +36,27 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_TopologyChange
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
+
+	zval property_newDescription_default_value;
+	ZVAL_UNDEF(&property_newDescription_default_value);
+	zend_string *property_newDescription_name = zend_string_init("newDescription", sizeof("newDescription") - 1, 1);
+	zend_string *property_newDescription_class_MongoDB_Driver_TopologyDescription = zend_string_init("MongoDB\\Driver\\TopologyDescription", sizeof("MongoDB\\Driver\\TopologyDescription")-1, 1);
+	zend_declare_typed_property(class_entry, property_newDescription_name, &property_newDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_newDescription_class_MongoDB_Driver_TopologyDescription, 0, 0));
+	zend_string_release(property_newDescription_name);
+
+	zval property_previousDescription_default_value;
+	ZVAL_UNDEF(&property_previousDescription_default_value);
+	zend_string *property_previousDescription_name = zend_string_init("previousDescription", sizeof("previousDescription") - 1, 1);
+	zend_string *property_previousDescription_class_MongoDB_Driver_TopologyDescription = zend_string_init("MongoDB\\Driver\\TopologyDescription", sizeof("MongoDB\\Driver\\TopologyDescription")-1, 1);
+	zend_declare_typed_property(class_entry, property_previousDescription_name, &property_previousDescription_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousDescription_class_MongoDB_Driver_TopologyDescription, 0, 0));
+	zend_string_release(property_previousDescription_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/TopologyClosedEvent.stub.php
+++ b/src/MongoDB/Monitoring/TopologyClosedEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/TopologyClosedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/TopologyClosedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a212dff68399555d5f716d953fed029552aaadd8 */
+ * Stub hash: 3ab90b4e8bbb8fe5d0b2248e40b102ab029ac6f1 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyClosedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -27,6 +27,13 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_TopologyClosed
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/TopologyClosedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/TopologyClosedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 644621167d1bf91bd04be273dc5ba0824477a10d */
+ * Stub hash: a212dff68399555d5f716d953fed029552aaadd8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyClosedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -7,10 +7,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyClosedEvent_getTopologyId, 0, 0, MongoDB\\BSON\\ObjectId, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_TopologyClosedEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_TopologyClosedEvent, getTopologyId);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_TopologyClosedEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_TopologyClosedEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_TopologyClosedEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -23,15 +21,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_TopologyClosed
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "TopologyClosedEvent", class_MongoDB_Driver_Monitoring_TopologyClosedEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
-	zval property_topologyId_default_value;
-	ZVAL_UNDEF(&property_topologyId_default_value);
-	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
-	zend_string_release(property_topologyId_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/TopologyOpeningEvent.stub.php
+++ b/src/MongoDB/Monitoring/TopologyOpeningEvent.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver\Monitoring;

--- a/src/MongoDB/Monitoring/TopologyOpeningEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/TopologyOpeningEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 832dbab9078319fadef89119e5dca9e2423225c7 */
+ * Stub hash: 10d60d037a0fa78818daacad26b91791a6c54784 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyOpeningEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -27,6 +27,13 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_TopologyOpenin
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_topologyId_default_value;
+	ZVAL_UNDEF(&property_topologyId_default_value);
+	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
+	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
+	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
+	zend_string_release(property_topologyId_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Monitoring/TopologyOpeningEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/TopologyOpeningEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a56da9b725311ccba7aa401f90604709af7ae2f9 */
+ * Stub hash: 832dbab9078319fadef89119e5dca9e2423225c7 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyOpeningEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -7,10 +7,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_TopologyOpeningEvent_getTopologyId, 0, 0, MongoDB\\BSON\\ObjectId, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Monitoring_TopologyOpeningEvent, __construct);
 static ZEND_METHOD(MongoDB_Driver_Monitoring_TopologyOpeningEvent, getTopologyId);
-
 
 static const zend_function_entry class_MongoDB_Driver_Monitoring_TopologyOpeningEvent_methods[] = {
 	ZEND_ME(MongoDB_Driver_Monitoring_TopologyOpeningEvent, __construct, arginfo_class_MongoDB_Driver_Monitoring_TopologyOpeningEvent___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -23,15 +21,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_TopologyOpenin
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver\\Monitoring", "TopologyOpeningEvent", class_MongoDB_Driver_Monitoring_TopologyOpeningEvent_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zend_string *property_topologyId_class_MongoDB_BSON_ObjectId = zend_string_init("MongoDB\\BSON\\ObjectId", sizeof("MongoDB\\BSON\\ObjectId")-1, 1);
-	zval property_topologyId_default_value;
-	ZVAL_UNDEF(&property_topologyId_default_value);
-	zend_string *property_topologyId_name = zend_string_init("topologyId", sizeof("topologyId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_topologyId_name, &property_topologyId_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_topologyId_class_MongoDB_BSON_ObjectId, 0, 0));
-	zend_string_release(property_topologyId_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/Query.stub.php
+++ b/src/MongoDB/Query.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/Query_arginfo.h
+++ b/src/MongoDB/Query_arginfo.h
@@ -1,14 +1,12 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 819affbb75a46cb68d88b46e0c7137590408b010 */
+ * Stub hash: 7d990858002d8ef19dd1d6e081bd94e7baf9787b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Query___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_MASK(0, filter, MAY_BE_ARRAY|MAY_BE_OBJECT, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, queryOptions, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Query, __construct);
-
 
 static const zend_function_entry class_MongoDB_Driver_Query_methods[] = {
 	ZEND_ME(MongoDB_Driver_Query, __construct, arginfo_class_MongoDB_Driver_Query___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -20,8 +18,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Query(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "Query", class_MongoDB_Driver_Query_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/ReadConcern.stub.php
+++ b/src/MongoDB/ReadConcern.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/ReadConcern_arginfo.h
+++ b/src/MongoDB/ReadConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a437d629a8e46cf88b346d03aa63d0eeba930459 */
+ * Stub hash: dc2dbca018378c16253293bee52c6931e427c118 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, level, IS_STRING, 1, "null")
@@ -22,16 +22,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern___serialize, 0, 0, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
-
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __construct);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, getLevel);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, isDefault);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __set_state);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __unserialize);
-static ZEND_METHOD(MongoDB_Driver_ReadConcern, __serialize);
 
 static const zend_function_entry class_MongoDB_Driver_ReadConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_ReadConcern, __construct, arginfo_class_MongoDB_Driver_ReadConcern___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -40,7 +36,6 @@ static const zend_function_entry class_MongoDB_Driver_ReadConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_ReadConcern, __set_state, arginfo_class_MongoDB_Driver_ReadConcern___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadConcern, bsonSerialize, arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadConcern, __unserialize, arginfo_class_MongoDB_Driver_ReadConcern___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	ZEND_ME(MongoDB_Driver_ReadConcern, __serialize, arginfo_class_MongoDB_Driver_ReadConcern___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -91,6 +86,12 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadConcern(zend_class_en
 	zend_string *const_SNAPSHOT_name = zend_string_init_interned("SNAPSHOT", sizeof("SNAPSHOT") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SNAPSHOT_name, &const_SNAPSHOT_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_SNAPSHOT_name);
+
+	zval property_level_default_value;
+	ZVAL_UNDEF(&property_level_default_value);
+	zend_string *property_level_name = zend_string_init("level", sizeof("level") - 1, 1);
+	zend_declare_typed_property(class_entry, property_level_name, &property_level_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_level_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/ReadConcern_arginfo.h
+++ b/src/MongoDB/ReadConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 814c09622ce8f209f6573cbb3d4945bc377824e7 */
+ * Stub hash: a437d629a8e46cf88b346d03aa63d0eeba930459 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, level, IS_STRING, 1, "null")
@@ -22,6 +22,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadConcern___serialize, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
 
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __construct);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, getLevel);
@@ -29,7 +31,7 @@ static ZEND_METHOD(MongoDB_Driver_ReadConcern, isDefault);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __set_state);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ReadConcern, __unserialize);
-
+static ZEND_METHOD(MongoDB_Driver_ReadConcern, __serialize);
 
 static const zend_function_entry class_MongoDB_Driver_ReadConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_ReadConcern, __construct, arginfo_class_MongoDB_Driver_ReadConcern___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -38,6 +40,7 @@ static const zend_function_entry class_MongoDB_Driver_ReadConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_ReadConcern, __set_state, arginfo_class_MongoDB_Driver_ReadConcern___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadConcern, bsonSerialize, arginfo_class_MongoDB_Driver_ReadConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadConcern, __unserialize, arginfo_class_MongoDB_Driver_ReadConcern___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	ZEND_ME(MongoDB_Driver_ReadConcern, __serialize, arginfo_class_MongoDB_Driver_ReadConcern___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -46,8 +49,12 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadConcern(zend_class_en
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "ReadConcern", class_MongoDB_Driver_ReadConcern_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 1, class_entry_MongoDB_BSON_Serializable);
 
 	zval const_LINEARIZABLE_value;
@@ -84,12 +91,6 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadConcern(zend_class_en
 	zend_string *const_SNAPSHOT_name = zend_string_init_interned("SNAPSHOT", sizeof("SNAPSHOT") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SNAPSHOT_name, &const_SNAPSHOT_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_SNAPSHOT_name);
-
-	zval property_level_default_value;
-	ZVAL_UNDEF(&property_level_default_value);
-	zend_string *property_level_name = zend_string_init("level", sizeof("level") - 1, 1);
-	zend_declare_typed_property(class_entry, property_level_name, &property_level_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_level_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/ReadPreference.stub.php
+++ b/src/MongoDB/ReadPreference.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/ReadPreference_arginfo.h
+++ b/src/MongoDB/ReadPreference_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 86acc6ab8c7a94f4a72a8cd98167d8037cf59c1d */
+ * Stub hash: c96f44c362fe158f620b96b7ce44be7a048daf1d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_STRING, 0)
@@ -30,8 +30,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadPrefere
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_MongoDB_Driver_ReadPreference___serialize arginfo_class_MongoDB_Driver_ReadPreference_getTagSets
-
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __construct);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, getHedge);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, getMaxStalenessSeconds);
@@ -40,7 +38,6 @@ static ZEND_METHOD(MongoDB_Driver_ReadPreference, getTagSets);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __set_state);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __unserialize);
-static ZEND_METHOD(MongoDB_Driver_ReadPreference, __serialize);
 
 static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] = {
 	ZEND_ME(MongoDB_Driver_ReadPreference, __construct, arginfo_class_MongoDB_Driver_ReadPreference___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -51,7 +48,6 @@ static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] =
 	ZEND_ME(MongoDB_Driver_ReadPreference, __set_state, arginfo_class_MongoDB_Driver_ReadPreference___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, bsonSerialize, arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, __unserialize, arginfo_class_MongoDB_Driver_ReadPreference___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	ZEND_ME(MongoDB_Driver_ReadPreference, __serialize, arginfo_class_MongoDB_Driver_ReadPreference___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -114,6 +110,30 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadPreference(zend_class
 	zend_string *const_SMALLEST_MAX_STALENESS_SECONDS_name = zend_string_init_interned("SMALLEST_MAX_STALENESS_SECONDS", sizeof("SMALLEST_MAX_STALENESS_SECONDS") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SMALLEST_MAX_STALENESS_SECONDS_name, &const_SMALLEST_MAX_STALENESS_SECONDS_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_SMALLEST_MAX_STALENESS_SECONDS_name);
+
+	zval property_mode_default_value;
+	ZVAL_UNDEF(&property_mode_default_value);
+	zend_string *property_mode_name = zend_string_init("mode", sizeof("mode") - 1, 1);
+	zend_declare_typed_property(class_entry, property_mode_name, &property_mode_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_mode_name);
+
+	zval property_tags_default_value;
+	ZVAL_UNDEF(&property_tags_default_value);
+	zend_string *property_tags_name = zend_string_init("tags", sizeof("tags") - 1, 1);
+	zend_declare_typed_property(class_entry, property_tags_name, &property_tags_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
+	zend_string_release(property_tags_name);
+
+	zval property_maxStalenessSeconds_default_value;
+	ZVAL_UNDEF(&property_maxStalenessSeconds_default_value);
+	zend_string *property_maxStalenessSeconds_name = zend_string_init("maxStalenessSeconds", sizeof("maxStalenessSeconds") - 1, 1);
+	zend_declare_typed_property(class_entry, property_maxStalenessSeconds_name, &property_maxStalenessSeconds_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_maxStalenessSeconds_name);
+
+	zval property_hedge_default_value;
+	ZVAL_UNDEF(&property_hedge_default_value);
+	zend_string *property_hedge_name = zend_string_init("hedge", sizeof("hedge") - 1, 1);
+	zend_declare_typed_property(class_entry, property_hedge_name, &property_hedge_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT|MAY_BE_NULL));
+	zend_string_release(property_hedge_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/ReadPreference_arginfo.h
+++ b/src/MongoDB/ReadPreference_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e7204ca51d594bcc92f399d4c2d5fe728114c1e4 */
+ * Stub hash: 86acc6ab8c7a94f4a72a8cd98167d8037cf59c1d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ReadPreference___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_STRING, 0)
@@ -30,6 +30,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ReadPrefere
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_MongoDB_Driver_ReadPreference___serialize arginfo_class_MongoDB_Driver_ReadPreference_getTagSets
 
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __construct);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, getHedge);
@@ -39,7 +40,7 @@ static ZEND_METHOD(MongoDB_Driver_ReadPreference, getTagSets);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __set_state);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ReadPreference, __unserialize);
-
+static ZEND_METHOD(MongoDB_Driver_ReadPreference, __serialize);
 
 static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] = {
 	ZEND_ME(MongoDB_Driver_ReadPreference, __construct, arginfo_class_MongoDB_Driver_ReadPreference___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -50,6 +51,7 @@ static const zend_function_entry class_MongoDB_Driver_ReadPreference_methods[] =
 	ZEND_ME(MongoDB_Driver_ReadPreference, __set_state, arginfo_class_MongoDB_Driver_ReadPreference___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, bsonSerialize, arginfo_class_MongoDB_Driver_ReadPreference_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_ReadPreference, __unserialize, arginfo_class_MongoDB_Driver_ReadPreference___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	ZEND_ME(MongoDB_Driver_ReadPreference, __serialize, arginfo_class_MongoDB_Driver_ReadPreference___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -58,8 +60,12 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadPreference(zend_class
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "ReadPreference", class_MongoDB_Driver_ReadPreference_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 1, class_entry_MongoDB_BSON_Serializable);
 
 	zval const_PRIMARY_value;
@@ -108,30 +114,6 @@ static zend_class_entry *register_class_MongoDB_Driver_ReadPreference(zend_class
 	zend_string *const_SMALLEST_MAX_STALENESS_SECONDS_name = zend_string_init_interned("SMALLEST_MAX_STALENESS_SECONDS", sizeof("SMALLEST_MAX_STALENESS_SECONDS") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SMALLEST_MAX_STALENESS_SECONDS_name, &const_SMALLEST_MAX_STALENESS_SECONDS_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_SMALLEST_MAX_STALENESS_SECONDS_name);
-
-	zval property_mode_default_value;
-	ZVAL_UNDEF(&property_mode_default_value);
-	zend_string *property_mode_name = zend_string_init("mode", sizeof("mode") - 1, 1);
-	zend_declare_typed_property(class_entry, property_mode_name, &property_mode_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_mode_name);
-
-	zval property_tags_default_value;
-	ZVAL_UNDEF(&property_tags_default_value);
-	zend_string *property_tags_name = zend_string_init("tags", sizeof("tags") - 1, 1);
-	zend_declare_typed_property(class_entry, property_tags_name, &property_tags_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
-	zend_string_release(property_tags_name);
-
-	zval property_maxStalenessSeconds_default_value;
-	ZVAL_UNDEF(&property_maxStalenessSeconds_default_value);
-	zend_string *property_maxStalenessSeconds_name = zend_string_init("maxStalenessSeconds", sizeof("maxStalenessSeconds") - 1, 1);
-	zend_declare_typed_property(class_entry, property_maxStalenessSeconds_name, &property_maxStalenessSeconds_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_maxStalenessSeconds_name);
-
-	zval property_hedge_default_value;
-	ZVAL_UNDEF(&property_hedge_default_value);
-	zend_string *property_hedge_name = zend_string_init("hedge", sizeof("hedge") - 1, 1);
-	zend_declare_typed_property(class_entry, property_hedge_name, &property_hedge_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT|MAY_BE_NULL));
-	zend_string_release(property_hedge_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/Server.stub.php
+++ b/src/MongoDB/Server.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/ServerApi.stub.php
+++ b/src/MongoDB/ServerApi.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/ServerApi_arginfo.h
+++ b/src/MongoDB/ServerApi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 74dd9fd0766587d269341f3c74a43ab9959a03a4 */
+ * Stub hash: e9d2009a853e8e36f7ef9ae08f066456d56383b8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, version, IS_STRING, 0)
@@ -21,13 +21,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_ServerApi___serialize, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_ServerApi, __construct);
 static ZEND_METHOD(MongoDB_Driver_ServerApi, __set_state);
 static ZEND_METHOD(MongoDB_Driver_ServerApi, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_ServerApi, __unserialize);
 static ZEND_METHOD(MongoDB_Driver_ServerApi, __serialize);
-
 
 static const zend_function_entry class_MongoDB_Driver_ServerApi_methods[] = {
 	ZEND_ME(MongoDB_Driver_ServerApi, __construct, arginfo_class_MongoDB_Driver_ServerApi___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -43,8 +41,12 @@ static zend_class_entry *register_class_MongoDB_Driver_ServerApi(zend_class_entr
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "ServerApi", class_MongoDB_Driver_ServerApi_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 1, class_entry_MongoDB_BSON_Serializable);
 
 	zval const_V1_value;

--- a/src/MongoDB/ServerDescription.stub.php
+++ b/src/MongoDB/ServerDescription.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/ServerDescription_arginfo.h
+++ b/src/MongoDB/ServerDescription_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 482425509937fc9119cf140099b41af3c4a20fde */
+ * Stub hash: 471e09dc661f1a128415738d3204bb1fa30909ab */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_ServerDescription___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -20,7 +20,6 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_ServerDescription_getType arginfo_class_MongoDB_Driver_ServerDescription_getHost
 
-
 static ZEND_METHOD(MongoDB_Driver_ServerDescription, __construct);
 static ZEND_METHOD(MongoDB_Driver_ServerDescription, getHelloResponse);
 static ZEND_METHOD(MongoDB_Driver_ServerDescription, getHost);
@@ -28,7 +27,6 @@ static ZEND_METHOD(MongoDB_Driver_ServerDescription, getLastUpdateTime);
 static ZEND_METHOD(MongoDB_Driver_ServerDescription, getPort);
 static ZEND_METHOD(MongoDB_Driver_ServerDescription, getRoundTripTime);
 static ZEND_METHOD(MongoDB_Driver_ServerDescription, getType);
-
 
 static const zend_function_entry class_MongoDB_Driver_ServerDescription_methods[] = {
 	ZEND_ME(MongoDB_Driver_ServerDescription, __construct, arginfo_class_MongoDB_Driver_ServerDescription___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -46,8 +44,12 @@ static zend_class_entry *register_class_MongoDB_Driver_ServerDescription(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "ServerDescription", class_MongoDB_Driver_ServerDescription_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 	zval const_TYPE_UNKNOWN_value;
 	zend_string *const_TYPE_UNKNOWN_value_str = zend_string_init(PHONGO_SERVER_TYPE_UNKNOWN, strlen(PHONGO_SERVER_TYPE_UNKNOWN), 1);

--- a/src/MongoDB/Server_arginfo.h
+++ b/src/MongoDB/Server_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ed6e371d10ddbcfd3ffed6aeb48758d0e88d717f */
+ * Stub hash: bb19c587cfdda8bcc988184a2ae6256ffcdfbcd0 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Server___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -63,7 +63,6 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_MongoDB_Driver_Server_isSecondary arginfo_class_MongoDB_Driver_Server_isArbiter
 
-
 static ZEND_METHOD(MongoDB_Driver_Server, __construct);
 static ZEND_METHOD(MongoDB_Driver_Server, executeBulkWrite);
 static ZEND_METHOD(MongoDB_Driver_Server, executeBulkWriteCommand);
@@ -84,7 +83,6 @@ static ZEND_METHOD(MongoDB_Driver_Server, isHidden);
 static ZEND_METHOD(MongoDB_Driver_Server, isPassive);
 static ZEND_METHOD(MongoDB_Driver_Server, isPrimary);
 static ZEND_METHOD(MongoDB_Driver_Server, isSecondary);
-
 
 static const zend_function_entry class_MongoDB_Driver_Server_methods[] = {
 	ZEND_ME(MongoDB_Driver_Server, __construct, arginfo_class_MongoDB_Driver_Server___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -115,8 +113,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Server(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "Server", class_MongoDB_Driver_Server_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 	zval const_TYPE_UNKNOWN_value;
 	ZVAL_LONG(&const_TYPE_UNKNOWN_value, PHONGO_SERVER_UNKNOWN);

--- a/src/MongoDB/Session.stub.php
+++ b/src/MongoDB/Session.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/Session_arginfo.h
+++ b/src/MongoDB/Session_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 22e0a387ed21d232c61f805ba258c4781a08a68e */
+ * Stub hash: f42d4c319eca5db335af6effdc192cab17d225e9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Session___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -46,7 +46,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_Session_sta
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_Session, __construct);
 static ZEND_METHOD(MongoDB_Driver_Session, abortTransaction);
 static ZEND_METHOD(MongoDB_Driver_Session, advanceClusterTime);
@@ -62,7 +61,6 @@ static ZEND_METHOD(MongoDB_Driver_Session, getTransactionState);
 static ZEND_METHOD(MongoDB_Driver_Session, isDirty);
 static ZEND_METHOD(MongoDB_Driver_Session, isInTransaction);
 static ZEND_METHOD(MongoDB_Driver_Session, startTransaction);
-
 
 static const zend_function_entry class_MongoDB_Driver_Session_methods[] = {
 	ZEND_ME(MongoDB_Driver_Session, __construct, arginfo_class_MongoDB_Driver_Session___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -88,8 +86,12 @@ static zend_class_entry *register_class_MongoDB_Driver_Session(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "Session", class_MongoDB_Driver_Session_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 	zval const_TRANSACTION_NONE_value;
 	zend_string *const_TRANSACTION_NONE_value_str = zend_string_init(PHONGO_TRANSACTION_NONE, strlen(PHONGO_TRANSACTION_NONE), 1);

--- a/src/MongoDB/TopologyDescription.stub.php
+++ b/src/MongoDB/TopologyDescription.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/TopologyDescription_arginfo.h
+++ b/src/MongoDB/TopologyDescription_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2cd175f4e81e332cd83adb867d51db77907ee8c7 */
+ * Stub hash: cb65bdadb0f057bdc4e88fd8e1e60c3ef52a2b69 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_TopologyDescription___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -17,13 +17,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_TopologyDescription_hasWritableServer, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_TopologyDescription, __construct);
 static ZEND_METHOD(MongoDB_Driver_TopologyDescription, getServers);
 static ZEND_METHOD(MongoDB_Driver_TopologyDescription, getType);
 static ZEND_METHOD(MongoDB_Driver_TopologyDescription, hasReadableServer);
 static ZEND_METHOD(MongoDB_Driver_TopologyDescription, hasWritableServer);
-
 
 static const zend_function_entry class_MongoDB_Driver_TopologyDescription_methods[] = {
 	ZEND_ME(MongoDB_Driver_TopologyDescription, __construct, arginfo_class_MongoDB_Driver_TopologyDescription___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -39,8 +37,12 @@ static zend_class_entry *register_class_MongoDB_Driver_TopologyDescription(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "TopologyDescription", class_MongoDB_Driver_TopologyDescription_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 	zval const_TYPE_UNKNOWN_value;
 	zend_string *const_TYPE_UNKNOWN_value_str = zend_string_init(PHONGO_TOPOLOGY_UNKNOWN, strlen(PHONGO_TOPOLOGY_UNKNOWN), 1);

--- a/src/MongoDB/WriteConcern.stub.php
+++ b/src/MongoDB/WriteConcern.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/WriteConcernError.stub.php
+++ b/src/MongoDB/WriteConcernError.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/WriteConcernError_arginfo.h
+++ b/src/MongoDB/WriteConcernError_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a405afbb8eaa3bf544759f7a6ae9330ced7e7cc0 */
+ * Stub hash: c924ca635d5f5a97ca918b59ca313ac77aae075c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcernError___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -13,12 +13,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcernError_getMessage, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_WriteConcernError, __construct);
 static ZEND_METHOD(MongoDB_Driver_WriteConcernError, getCode);
 static ZEND_METHOD(MongoDB_Driver_WriteConcernError, getInfo);
 static ZEND_METHOD(MongoDB_Driver_WriteConcernError, getMessage);
-
 
 static const zend_function_entry class_MongoDB_Driver_WriteConcernError_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteConcernError, __construct, arginfo_class_MongoDB_Driver_WriteConcernError___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -33,8 +31,12 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteConcernError(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "WriteConcernError", class_MongoDB_Driver_WriteConcernError_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/WriteConcern_arginfo.h
+++ b/src/MongoDB/WriteConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 419a3a5ab13c377900e08013c3c91bd7a2b07200 */
+ * Stub hash: c7a2c5d76012ed7d1846d70241eeefa876d18342 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_MASK(0, w, MAY_BE_STRING|MAY_BE_LONG, NULL)
@@ -30,6 +30,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcer
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___serialize, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
 
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __construct);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, getJournal);
@@ -39,7 +41,7 @@ static ZEND_METHOD(MongoDB_Driver_WriteConcern, isDefault);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __set_state);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __unserialize);
-
+static ZEND_METHOD(MongoDB_Driver_WriteConcern, __serialize);
 
 static const zend_function_entry class_MongoDB_Driver_WriteConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteConcern, __construct, arginfo_class_MongoDB_Driver_WriteConcern___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -50,6 +52,7 @@ static const zend_function_entry class_MongoDB_Driver_WriteConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteConcern, __set_state, arginfo_class_MongoDB_Driver_WriteConcern___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteConcern, bsonSerialize, arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteConcern, __unserialize, arginfo_class_MongoDB_Driver_WriteConcern___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	ZEND_ME(MongoDB_Driver_WriteConcern, __serialize, arginfo_class_MongoDB_Driver_WriteConcern___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -58,8 +61,12 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteConcern(zend_class_e
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "WriteConcern", class_MongoDB_Driver_WriteConcern_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+#endif
 	zend_class_implements(class_entry, 1, class_entry_MongoDB_BSON_Serializable);
 
 	zval const_MAJORITY_value;
@@ -68,24 +75,6 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteConcern(zend_class_e
 	zend_string *const_MAJORITY_name = zend_string_init_interned("MAJORITY", sizeof("MAJORITY") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_MAJORITY_name, &const_MAJORITY_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_MAJORITY_name);
-
-	zval property_w_default_value;
-	ZVAL_UNDEF(&property_w_default_value);
-	zend_string *property_w_name = zend_string_init("w", sizeof("w") - 1, 1);
-	zend_declare_typed_property(class_entry, property_w_name, &property_w_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL));
-	zend_string_release(property_w_name);
-
-	zval property_j_default_value;
-	ZVAL_UNDEF(&property_j_default_value);
-	zend_string *property_j_name = zend_string_init("j", sizeof("j") - 1, 1);
-	zend_declare_typed_property(class_entry, property_j_name, &property_j_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL|MAY_BE_NULL));
-	zend_string_release(property_j_name);
-
-	zval property_wtimeout_default_value;
-	ZVAL_UNDEF(&property_wtimeout_default_value);
-	zend_string *property_wtimeout_name = zend_string_init("wtimeout", sizeof("wtimeout") - 1, 1);
-	zend_declare_typed_property(class_entry, property_wtimeout_name, &property_wtimeout_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_wtimeout_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/WriteConcern_arginfo.h
+++ b/src/MongoDB/WriteConcern_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c7a2c5d76012ed7d1846d70241eeefa876d18342 */
+ * Stub hash: ad76e5683d263a0f0f0f07099d651dc8afd25199 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_MASK(0, w, MAY_BE_STRING|MAY_BE_LONG, NULL)
@@ -30,9 +30,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcer
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteConcern___serialize, 0, 0, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
-
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __construct);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, getJournal);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, getW);
@@ -41,7 +38,6 @@ static ZEND_METHOD(MongoDB_Driver_WriteConcern, isDefault);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __set_state);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, bsonSerialize);
 static ZEND_METHOD(MongoDB_Driver_WriteConcern, __unserialize);
-static ZEND_METHOD(MongoDB_Driver_WriteConcern, __serialize);
 
 static const zend_function_entry class_MongoDB_Driver_WriteConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteConcern, __construct, arginfo_class_MongoDB_Driver_WriteConcern___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
@@ -52,7 +48,6 @@ static const zend_function_entry class_MongoDB_Driver_WriteConcern_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteConcern, __set_state, arginfo_class_MongoDB_Driver_WriteConcern___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteConcern, bsonSerialize, arginfo_class_MongoDB_Driver_WriteConcern_bsonSerialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_ME(MongoDB_Driver_WriteConcern, __unserialize, arginfo_class_MongoDB_Driver_WriteConcern___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
-	ZEND_ME(MongoDB_Driver_WriteConcern, __serialize, arginfo_class_MongoDB_Driver_WriteConcern___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
 	ZEND_FE_END
 };
 
@@ -75,6 +70,24 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteConcern(zend_class_e
 	zend_string *const_MAJORITY_name = zend_string_init_interned("MAJORITY", sizeof("MAJORITY") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_MAJORITY_name, &const_MAJORITY_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_MAJORITY_name);
+
+	zval property_w_default_value;
+	ZVAL_UNDEF(&property_w_default_value);
+	zend_string *property_w_name = zend_string_init("w", sizeof("w") - 1, 1);
+	zend_declare_typed_property(class_entry, property_w_name, &property_w_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_w_name);
+
+	zval property_j_default_value;
+	ZVAL_UNDEF(&property_j_default_value);
+	zend_string *property_j_name = zend_string_init("j", sizeof("j") - 1, 1);
+	zend_declare_typed_property(class_entry, property_j_name, &property_j_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL|MAY_BE_NULL));
+	zend_string_release(property_j_name);
+
+	zval property_wtimeout_default_value;
+	ZVAL_UNDEF(&property_wtimeout_default_value);
+	zend_string *property_wtimeout_name = zend_string_init("wtimeout", sizeof("wtimeout") - 1, 1);
+	zend_declare_typed_property(class_entry, property_wtimeout_name, &property_wtimeout_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_wtimeout_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/WriteError.stub.php
+++ b/src/MongoDB/WriteError.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/WriteError_arginfo.h
+++ b/src/MongoDB/WriteError_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dc2cbbabe219231d5838554420407c525dfb4fee */
+ * Stub hash: 8a43b466269b8d85a2e790f69f0ec2e2cc3e4066 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteError___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -41,6 +41,26 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteError(void)
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_message_default_value;
+	ZVAL_UNDEF(&property_message_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_MESSAGE), &property_message_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+
+	zval property_code_default_value;
+	ZVAL_UNDEF(&property_code_default_value);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_CODE), &property_code_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+
+	zval property_index_default_value;
+	ZVAL_UNDEF(&property_index_default_value);
+	zend_string *property_index_name = zend_string_init("index", sizeof("index") - 1, 1);
+	zend_declare_typed_property(class_entry, property_index_name, &property_index_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_index_name);
+
+	zval property_info_default_value;
+	ZVAL_UNDEF(&property_info_default_value);
+	zend_string *property_info_name = zend_string_init("info", sizeof("info") - 1, 1);
+	zend_declare_typed_property(class_entry, property_info_name, &property_info_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT|MAY_BE_NULL));
+	zend_string_release(property_info_name);
 
 	return class_entry;
 }

--- a/src/MongoDB/WriteError_arginfo.h
+++ b/src/MongoDB/WriteError_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a31919ef78a0a36e04aab7db68ef5b235d3ec477 */
+ * Stub hash: dc2cbbabe219231d5838554420407c525dfb4fee */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteError___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -15,13 +15,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteError_getMessage, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_WriteError, __construct);
 static ZEND_METHOD(MongoDB_Driver_WriteError, getCode);
 static ZEND_METHOD(MongoDB_Driver_WriteError, getIndex);
 static ZEND_METHOD(MongoDB_Driver_WriteError, getInfo);
 static ZEND_METHOD(MongoDB_Driver_WriteError, getMessage);
-
 
 static const zend_function_entry class_MongoDB_Driver_WriteError_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteError, __construct, arginfo_class_MongoDB_Driver_WriteError___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -37,32 +35,12 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteError(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "WriteError", class_MongoDB_Driver_WriteError_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_message_default_value;
-	ZVAL_UNDEF(&property_message_default_value);
-	zend_string *property_message_name = zend_string_init("message", sizeof("message") - 1, 1);
-	zend_declare_typed_property(class_entry, property_message_name, &property_message_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_message_name);
-
-	zval property_code_default_value;
-	ZVAL_UNDEF(&property_code_default_value);
-	zend_string *property_code_name = zend_string_init("code", sizeof("code") - 1, 1);
-	zend_declare_typed_property(class_entry, property_code_name, &property_code_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_code_name);
-
-	zval property_index_default_value;
-	ZVAL_UNDEF(&property_index_default_value);
-	zend_string *property_index_name = zend_string_init("index", sizeof("index") - 1, 1);
-	zend_declare_typed_property(class_entry, property_index_name, &property_index_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_index_name);
-
-	zval property_info_default_value;
-	ZVAL_UNDEF(&property_info_default_value);
-	zend_string *property_info_name = zend_string_init("info", sizeof("info") - 1, 1);
-	zend_declare_typed_property(class_entry, property_info_name, &property_info_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_OBJECT|MAY_BE_NULL));
-	zend_string_release(property_info_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/WriteResult.stub.php
+++ b/src/MongoDB/WriteResult.stub.php
@@ -2,7 +2,7 @@
 
 /**
  * @generate-class-entries static
- * @generate-function-entries static
+ * @generate-legacy-arginfo 80100
  */
 
 namespace MongoDB\Driver;

--- a/src/MongoDB/WriteResult_arginfo.h
+++ b/src/MongoDB/WriteResult_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f75ffdff80697e2a32ac197b1901d6bf75180ab8 */
+ * Stub hash: 2c705ef20a2c9cad0f9381bda102518299544b70 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteResult___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -31,7 +31,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MongoDB_Driver_WriteResult_isAcknowledged, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
 static ZEND_METHOD(MongoDB_Driver_WriteResult, __construct);
 static ZEND_METHOD(MongoDB_Driver_WriteResult, getInsertedCount);
 static ZEND_METHOD(MongoDB_Driver_WriteResult, getMatchedCount);
@@ -44,7 +43,6 @@ static ZEND_METHOD(MongoDB_Driver_WriteResult, getWriteConcernError);
 static ZEND_METHOD(MongoDB_Driver_WriteResult, getWriteErrors);
 static ZEND_METHOD(MongoDB_Driver_WriteResult, getErrorReplies);
 static ZEND_METHOD(MongoDB_Driver_WriteResult, isAcknowledged);
-
 
 static const zend_function_entry class_MongoDB_Driver_WriteResult_methods[] = {
 	ZEND_ME(MongoDB_Driver_WriteResult, __construct, arginfo_class_MongoDB_Driver_WriteResult___construct, ZEND_ACC_PRIVATE|ZEND_ACC_FINAL)
@@ -67,77 +65,12 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteResult(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "MongoDB\\Driver", "WriteResult", class_MongoDB_Driver_WriteResult_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
-
-	zval property_insertedCount_default_value;
-	ZVAL_UNDEF(&property_insertedCount_default_value);
-	zend_string *property_insertedCount_name = zend_string_init("insertedCount", sizeof("insertedCount") - 1, 1);
-	zend_declare_typed_property(class_entry, property_insertedCount_name, &property_insertedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
-	zend_string_release(property_insertedCount_name);
-
-	zval property_matchedCount_default_value;
-	ZVAL_UNDEF(&property_matchedCount_default_value);
-	zend_string *property_matchedCount_name = zend_string_init("matchedCount", sizeof("matchedCount") - 1, 1);
-	zend_declare_typed_property(class_entry, property_matchedCount_name, &property_matchedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
-	zend_string_release(property_matchedCount_name);
-
-	zval property_modifiedCount_default_value;
-	ZVAL_UNDEF(&property_modifiedCount_default_value);
-	zend_string *property_modifiedCount_name = zend_string_init("modifiedCount", sizeof("modifiedCount") - 1, 1);
-	zend_declare_typed_property(class_entry, property_modifiedCount_name, &property_modifiedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
-	zend_string_release(property_modifiedCount_name);
-
-	zval property_deletedCount_default_value;
-	ZVAL_UNDEF(&property_deletedCount_default_value);
-	zend_string *property_deletedCount_name = zend_string_init("deletedCount", sizeof("deletedCount") - 1, 1);
-	zend_declare_typed_property(class_entry, property_deletedCount_name, &property_deletedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
-	zend_string_release(property_deletedCount_name);
-
-	zval property_upsertedCount_default_value;
-	ZVAL_UNDEF(&property_upsertedCount_default_value);
-	zend_string *property_upsertedCount_name = zend_string_init("upsertedCount", sizeof("upsertedCount") - 1, 1);
-	zend_declare_typed_property(class_entry, property_upsertedCount_name, &property_upsertedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
-	zend_string_release(property_upsertedCount_name);
-
-	zend_string *property_server_class_MongoDB_Driver_Server = zend_string_init("MongoDB\\Driver\\Server", sizeof("MongoDB\\Driver\\Server")-1, 1);
-	zval property_server_default_value;
-	ZVAL_UNDEF(&property_server_default_value);
-	zend_string *property_server_name = zend_string_init("server", sizeof("server") - 1, 1);
-	zend_declare_typed_property(class_entry, property_server_name, &property_server_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_server_class_MongoDB_Driver_Server, 0, 0));
-	zend_string_release(property_server_name);
-
-	zval property_upsertedIds_default_value;
-	ZVAL_UNDEF(&property_upsertedIds_default_value);
-	zend_string *property_upsertedIds_name = zend_string_init("upsertedIds", sizeof("upsertedIds") - 1, 1);
-	zend_declare_typed_property(class_entry, property_upsertedIds_name, &property_upsertedIds_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
-	zend_string_release(property_upsertedIds_name);
-
-	zval property_writeErrors_default_value;
-	ZVAL_UNDEF(&property_writeErrors_default_value);
-	zend_string *property_writeErrors_name = zend_string_init("writeErrors", sizeof("writeErrors") - 1, 1);
-	zend_declare_typed_property(class_entry, property_writeErrors_name, &property_writeErrors_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
-	zend_string_release(property_writeErrors_name);
-
-	zend_string *property_writeConcernError_class_MongoDB_Driver_WriteConcernError = zend_string_init("MongoDB\\Driver\\WriteConcernError", sizeof("MongoDB\\Driver\\WriteConcernError")-1, 1);
-	zval property_writeConcernError_default_value;
-	ZVAL_UNDEF(&property_writeConcernError_default_value);
-	zend_string *property_writeConcernError_name = zend_string_init("writeConcernError", sizeof("writeConcernError") - 1, 1);
-	zend_declare_typed_property(class_entry, property_writeConcernError_name, &property_writeConcernError_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_writeConcernError_class_MongoDB_Driver_WriteConcernError, 0, MAY_BE_NULL));
-	zend_string_release(property_writeConcernError_name);
-
-	zend_string *property_writeConcern_class_MongoDB_Driver_WriteConcern = zend_string_init("MongoDB\\Driver\\WriteConcern", sizeof("MongoDB\\Driver\\WriteConcern")-1, 1);
-	zval property_writeConcern_default_value;
-	ZVAL_UNDEF(&property_writeConcern_default_value);
-	zend_string *property_writeConcern_name = zend_string_init("writeConcern", sizeof("writeConcern") - 1, 1);
-	zend_declare_typed_property(class_entry, property_writeConcern_name, &property_writeConcern_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_writeConcern_class_MongoDB_Driver_WriteConcern, 0, MAY_BE_NULL));
-	zend_string_release(property_writeConcern_name);
-
-	zval property_errorReplies_default_value;
-	ZVAL_UNDEF(&property_errorReplies_default_value);
-	zend_string *property_errorReplies_name = zend_string_init("errorReplies", sizeof("errorReplies") - 1, 1);
-	zend_declare_typed_property(class_entry, property_errorReplies_name, &property_errorReplies_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
-	zend_string_release(property_errorReplies_name);
+#endif
 
 	return class_entry;
 }

--- a/src/MongoDB/WriteResult_arginfo.h
+++ b/src/MongoDB/WriteResult_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2c705ef20a2c9cad0f9381bda102518299544b70 */
+ * Stub hash: 75d0ae9c2264b5e833f49af96ba474a64ce56bc3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_WriteResult___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -71,6 +71,75 @@ static zend_class_entry *register_class_MongoDB_Driver_WriteResult(void)
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NOT_SERIALIZABLE;
 #endif
+
+	zval property_insertedCount_default_value;
+	ZVAL_UNDEF(&property_insertedCount_default_value);
+	zend_string *property_insertedCount_name = zend_string_init("insertedCount", sizeof("insertedCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_insertedCount_name, &property_insertedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_insertedCount_name);
+
+	zval property_matchedCount_default_value;
+	ZVAL_UNDEF(&property_matchedCount_default_value);
+	zend_string *property_matchedCount_name = zend_string_init("matchedCount", sizeof("matchedCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_matchedCount_name, &property_matchedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_matchedCount_name);
+
+	zval property_modifiedCount_default_value;
+	ZVAL_UNDEF(&property_modifiedCount_default_value);
+	zend_string *property_modifiedCount_name = zend_string_init("modifiedCount", sizeof("modifiedCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_modifiedCount_name, &property_modifiedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_modifiedCount_name);
+
+	zval property_deletedCount_default_value;
+	ZVAL_UNDEF(&property_deletedCount_default_value);
+	zend_string *property_deletedCount_name = zend_string_init("deletedCount", sizeof("deletedCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_deletedCount_name, &property_deletedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_deletedCount_name);
+
+	zval property_upsertedCount_default_value;
+	ZVAL_UNDEF(&property_upsertedCount_default_value);
+	zend_string *property_upsertedCount_name = zend_string_init("upsertedCount", sizeof("upsertedCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_upsertedCount_name, &property_upsertedCount_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
+	zend_string_release(property_upsertedCount_name);
+
+	zval property_server_default_value;
+	ZVAL_UNDEF(&property_server_default_value);
+	zend_string *property_server_name = zend_string_init("server", sizeof("server") - 1, 1);
+	zend_string *property_server_class_MongoDB_Driver_Server = zend_string_init("MongoDB\\Driver\\Server", sizeof("MongoDB\\Driver\\Server")-1, 1);
+	zend_declare_typed_property(class_entry, property_server_name, &property_server_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_server_class_MongoDB_Driver_Server, 0, 0));
+	zend_string_release(property_server_name);
+
+	zval property_upsertedIds_default_value;
+	ZVAL_UNDEF(&property_upsertedIds_default_value);
+	zend_string *property_upsertedIds_name = zend_string_init("upsertedIds", sizeof("upsertedIds") - 1, 1);
+	zend_declare_typed_property(class_entry, property_upsertedIds_name, &property_upsertedIds_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
+	zend_string_release(property_upsertedIds_name);
+
+	zval property_writeErrors_default_value;
+	ZVAL_UNDEF(&property_writeErrors_default_value);
+	zend_string *property_writeErrors_name = zend_string_init("writeErrors", sizeof("writeErrors") - 1, 1);
+	zend_declare_typed_property(class_entry, property_writeErrors_name, &property_writeErrors_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
+	zend_string_release(property_writeErrors_name);
+
+	zval property_writeConcernError_default_value;
+	ZVAL_UNDEF(&property_writeConcernError_default_value);
+	zend_string *property_writeConcernError_name = zend_string_init("writeConcernError", sizeof("writeConcernError") - 1, 1);
+	zend_string *property_writeConcernError_class_MongoDB_Driver_WriteConcernError = zend_string_init("MongoDB\\Driver\\WriteConcernError", sizeof("MongoDB\\Driver\\WriteConcernError")-1, 1);
+	zend_declare_typed_property(class_entry, property_writeConcernError_name, &property_writeConcernError_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_writeConcernError_class_MongoDB_Driver_WriteConcernError, 0, MAY_BE_NULL));
+	zend_string_release(property_writeConcernError_name);
+
+	zval property_writeConcern_default_value;
+	ZVAL_UNDEF(&property_writeConcern_default_value);
+	zend_string *property_writeConcern_name = zend_string_init("writeConcern", sizeof("writeConcern") - 1, 1);
+	zend_string *property_writeConcern_class_MongoDB_Driver_WriteConcern = zend_string_init("MongoDB\\Driver\\WriteConcern", sizeof("MongoDB\\Driver\\WriteConcern")-1, 1);
+	zend_declare_typed_property(class_entry, property_writeConcern_name, &property_writeConcern_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_writeConcern_class_MongoDB_Driver_WriteConcern, 0, MAY_BE_NULL));
+	zend_string_release(property_writeConcern_name);
+
+	zval property_errorReplies_default_value;
+	ZVAL_UNDEF(&property_errorReplies_default_value);
+	zend_string *property_errorReplies_name = zend_string_init("errorReplies", sizeof("errorReplies") - 1, 1);
+	zend_declare_typed_property(class_entry, property_errorReplies_name, &property_errorReplies_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
+	zend_string_release(property_errorReplies_name);
 
 	return class_entry;
 }

--- a/src/functions.stub.php
+++ b/src/functions.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-function-entries */
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo 80100
+ */
 
 namespace MongoDB\Driver\Monitoring {
     function addSubscriber(Subscriber $subscriber): void {}

--- a/src/functions_arginfo.h
+++ b/src/functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fac870fef1ab3d172fb2f2227a3a30fd76406b38 */
+ * Stub hash: 49f42083b44ce54a5dce3d4f619b0d7210437527 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_MongoDB_Driver_Monitoring_addSubscriber, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, subscriber, MongoDB\\Driver\\Monitoring\\Subscriber, 0)
@@ -13,15 +13,25 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_MongoDB_Driver_Monitoring_removeSubscriber arginfo_MongoDB_Driver_Monitoring_addSubscriber
 
-
 ZEND_FUNCTION(MongoDB_Driver_Monitoring_addSubscriber);
 ZEND_FUNCTION(MongoDB_Driver_Monitoring_mongoc_log);
 ZEND_FUNCTION(MongoDB_Driver_Monitoring_removeSubscriber);
 
-
 static const zend_function_entry ext_functions[] = {
-	ZEND_NS_FALIAS("MongoDB\\Driver\\Monitoring", addSubscriber, MongoDB_Driver_Monitoring_addSubscriber, arginfo_MongoDB_Driver_Monitoring_addSubscriber)
-	ZEND_NS_FALIAS("MongoDB\\Driver\\Monitoring", mongoc_log, MongoDB_Driver_Monitoring_mongoc_log, arginfo_MongoDB_Driver_Monitoring_mongoc_log)
-	ZEND_NS_FALIAS("MongoDB\\Driver\\Monitoring", removeSubscriber, MongoDB_Driver_Monitoring_removeSubscriber, arginfo_MongoDB_Driver_Monitoring_removeSubscriber)
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("MongoDB\\Driver\\Monitoring", "addSubscriber"), zif_MongoDB_Driver_Monitoring_addSubscriber, arginfo_MongoDB_Driver_Monitoring_addSubscriber, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("MongoDB\\Driver\\Monitoring", "addSubscriber"), zif_MongoDB_Driver_Monitoring_addSubscriber, arginfo_MongoDB_Driver_Monitoring_addSubscriber, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("MongoDB\\Driver\\Monitoring", "mongoc_log"), zif_MongoDB_Driver_Monitoring_mongoc_log, arginfo_MongoDB_Driver_Monitoring_mongoc_log, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("MongoDB\\Driver\\Monitoring", "mongoc_log"), zif_MongoDB_Driver_Monitoring_mongoc_log, arginfo_MongoDB_Driver_Monitoring_mongoc_log, 0)
+#endif
+#if (PHP_VERSION_ID >= 80400)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("MongoDB\\Driver\\Monitoring", "removeSubscriber"), zif_MongoDB_Driver_Monitoring_removeSubscriber, arginfo_MongoDB_Driver_Monitoring_removeSubscriber, 0, NULL, NULL)
+#else
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("MongoDB\\Driver\\Monitoring", "removeSubscriber"), zif_MongoDB_Driver_Monitoring_removeSubscriber, arginfo_MongoDB_Driver_Monitoring_removeSubscriber, 0)
+#endif
 	ZEND_FE_END
 };


### PR DESCRIPTION
The arginfo generator allows for [maintaining backward compatibility](https://php.github.io/php-src/miscellaneous/stubs.html#maintaining-backward-compatibility) through the use of the `generate-legacy-arginfo` annotation, together with the minimum PHP version being targeted. Using this, we can remove the limitation to only generate arginfo on PHP 8.2 and instead use the latest stable PHP version.