### PR TITLE
Remove `phongo_write_concern_to_zval`

### DIFF
--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -642,7 +642,7 @@ static HashTable* phongo_bulkwrite_get_debug_info(zend_object* object, int* is_t
 	if (mongoc_bulk_operation_get_write_concern(intern->bulk)) {
 		zval write_concern;
 
-		phongo_write_concern_to_zval(&write_concern, mongoc_bulk_operation_get_write_concern(intern->bulk));
+		phongo_writeconcern_init(&write_concern, mongoc_bulk_operation_get_write_concern(intern->bulk));
 		ADD_ASSOC_ZVAL_EX(&retval, "write_concern", &write_concern);
 	} else {
 		ADD_ASSOC_NULL_EX(&retval, "write_concern");

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -388,36 +388,3 @@ const mongoc_write_concern_t* phongo_write_concern_from_zval(zval* zwrite_concer
 
 	return NULL;
 }
-
-void phongo_write_concern_to_zval(zval* retval, const mongoc_write_concern_t* write_concern)
-{
-	const char*   wtag     = mongoc_write_concern_get_wtag(write_concern);
-	const int32_t w        = mongoc_write_concern_get_w(write_concern);
-	const int64_t wtimeout = mongoc_write_concern_get_wtimeout_int64(write_concern);
-
-	array_init_size(retval, 4);
-
-	if (wtag) {
-		ADD_ASSOC_STRING(retval, "w", wtag);
-	} else if (mongoc_write_concern_get_wmajority(write_concern)) {
-		ADD_ASSOC_STRING(retval, "w", PHONGO_WRITE_CONCERN_W_MAJORITY);
-	} else if (w != MONGOC_WRITE_CONCERN_W_DEFAULT) {
-		ADD_ASSOC_LONG_EX(retval, "w", w);
-	}
-
-	if (mongoc_write_concern_journal_is_set(write_concern)) {
-		ADD_ASSOC_BOOL_EX(retval, "j", mongoc_write_concern_get_journal(write_concern));
-	}
-
-	if (wtimeout != 0) {
-#if SIZEOF_ZEND_LONG == 4
-		if (wtimeout > INT32_MAX || wtimeout < INT32_MIN) {
-			ADD_ASSOC_INT64_AS_STRING(retval, "wtimeout", wtimeout);
-		} else {
-			ADD_ASSOC_LONG_EX(retval, "wtimeout", wtimeout);
-		}
-#else
-		ADD_ASSOC_LONG_EX(retval, "wtimeout", wtimeout);
-#endif
-	}
-}

--- a/src/MongoDB/WriteConcern.h
+++ b/src/MongoDB/WriteConcern.h
@@ -27,6 +27,4 @@ void phongo_writeconcern_init(zval* return_value, const mongoc_write_concern_t* 
 
 const mongoc_write_concern_t* phongo_write_concern_from_zval(zval* zwrite_concern);
 
-void phongo_write_concern_to_zval(zval* retval, const mongoc_write_concern_t* write_concern);
-
 #endif /* PHONGO_WRITECONCERN_H */

--- a/tests/bulk/write-0002.phpt
+++ b/tests/bulk/write-0002.phpt
@@ -70,9 +70,11 @@ object(MongoDB\Driver\BulkWrite)#%d (%d) {
   ["session"]=>
   NULL
   ["write_concern"]=>
-  array(%d) {
+  object(MongoDB\Driver\WriteConcern)#%d (%d) {
     ["w"]=>
     int(1)
+    ["j"]=>
+    NULL
     ["wtimeout"]=>
     int(1000)
   }


### PR DESCRIPTION
It was only used in `bulkwrite_get_debug_info`, where we could really just instantiate the `WriteConcern` instance and add that to the debug info, which would result in the `WriteConcern` object being var_dumped and it more in line with what you'd expect as a PHP user anyway.