### PR TITLE
Use `json_decode` to produce a non-interned string in typeMap test

### DIFF
--- a/tests/bson/bug1839-005.phpt
+++ b/tests/bson/bug1839-005.phpt
@@ -6,9 +6,9 @@ require_once __DIR__ . "/../utils/basic.inc";
 
 function createTypemap()
 {
-    // Assemble the string so as to not have an interned string
-    $rootValue = chr(ord('a')) . 'rray';
-    $documentValue = chr(ord('a')) . 'rray';
+    // Use json_decode to produce a non-interned string that opcache cannot optimise
+    $rootValue = json_decode('"array"');
+    $documentValue = json_decode('"array"');
 
     // Use a reference to this non-interned string in the type map
     $typemap = ['root' => &$rootValue, 'document' => &$documentValue];

--- a/tests/bson/bug1839-006.phpt
+++ b/tests/bson/bug1839-006.phpt
@@ -4,9 +4,9 @@ PHPC-1839: Referenced, local, non-interned string in typeMap (PHP >= 8.1)
 <?php
 require_once __DIR__ . "/../utils/basic.inc";
 
-// Assemble the string so as to not have an interned string
-$rootValue = chr(ord('a')) . 'rray';
-$documentValue = chr(ord('a')) . 'rray';
+// Use json_decode to produce a non-interned string that opcache cannot optimise
+$rootValue = json_decode('"array"');
+$documentValue = json_decode('"array"');
 
 $typemap = ['root' => &$rootValue, 'document' => &$documentValue];
 $bson    = MongoDB\BSON\Document::fromPHP((object) []);


### PR DESCRIPTION
Replace `chr(ord('a')).'rray'` with `json_decode('"array"')` to produce a non-interned string that opcache cannot fold, allowing the test to run under all configurations.