### PR TITLE
PHPC-1519: Remove phongo_server_to_zval and include Server objects in Manager debug output

### DIFF
--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -802,6 +802,7 @@ static HashTable* phongo_manager_get_debug_info(zend_object* object, int* is_tem
 	size_t                        i, n = 0;
 	zval                          retval = ZVAL_STATIC_INIT;
 	zval                          cluster;
+	zval                          manager_zval;
 
 	*is_temp = 1;
 	intern   = Z_OBJ_MANAGER(object);
@@ -814,16 +815,12 @@ static HashTable* phongo_manager_get_debug_info(zend_object* object, int* is_tem
 
 	array_init_size(&cluster, n);
 
+	ZVAL_OBJ(&manager_zval, object);
+
 	for (i = 0; i < n; i++) {
 		zval obj;
 
-		if (!phongo_server_to_zval(&obj, intern->client, sds[i])) {
-			/* Exception already thrown */
-			zval_ptr_dtor(&obj);
-			zval_ptr_dtor(&cluster);
-			goto done;
-		}
-
+		phongo_server_init(&obj, &manager_zval, mongoc_server_description_id(sds[i]));
 		add_next_index_zval(&cluster, &obj);
 	}
 
@@ -839,7 +836,6 @@ static HashTable* phongo_manager_get_debug_info(zend_object* object, int* is_tem
 		}
 	}
 
-done:
 	mongoc_server_descriptions_destroy_all(sds, n);
 
 	return Z_ARRVAL(retval);

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -815,6 +815,10 @@ static HashTable* phongo_manager_get_debug_info(zend_object* object, int* is_tem
 
 	array_init_size(&cluster, n);
 
+	/* phongo_server_init requires a zval* but get_debug_info only provides a
+	 * zend_object*. Wrap the object pointer in a temporary zval without
+	 * incrementing the refcount, since phongo_server_init will do so itself
+	 * when it stores the manager reference via ZVAL_ZVAL. */
 	ZVAL_OBJ(&manager_zval, object);
 
 	for (i = 0; i < n; i++) {

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -559,6 +559,9 @@ static HashTable* phongo_server_get_debug_info(zend_object* object, int* is_temp
 	zval                         retval = ZVAL_STATIC_INIT;
 	mongoc_client_t*             client;
 	mongoc_server_description_t* sd;
+	const mongoc_host_list_t*    host;
+	const bson_t*                hello_response;
+	bson_iter_t                  iter;
 
 	*is_temp = 1;
 	intern   = Z_OBJ_SERVER(object);
@@ -569,7 +572,91 @@ static HashTable* phongo_server_get_debug_info(zend_object* object, int* is_temp
 		return NULL;
 	}
 
-	phongo_server_to_zval(&retval, client, sd);
+	host           = mongoc_server_description_host(sd);
+	hello_response = mongoc_server_description_hello_response(sd);
+
+	array_init(&retval);
+
+	ADD_ASSOC_STRING(&retval, "host", host->host);
+	ADD_ASSOC_LONG_EX(&retval, "port", host->port);
+	ADD_ASSOC_LONG_EX(&retval, "type", phongo_server_description_type(sd));
+	ADD_ASSOC_BOOL_EX(&retval, "is_primary", !strcmp(mongoc_server_description_type(sd), phongo_server_description_type_map[PHONGO_SERVER_RS_PRIMARY].name));
+	ADD_ASSOC_BOOL_EX(&retval, "is_secondary", !strcmp(mongoc_server_description_type(sd), phongo_server_description_type_map[PHONGO_SERVER_RS_SECONDARY].name));
+	ADD_ASSOC_BOOL_EX(&retval, "is_arbiter", !strcmp(mongoc_server_description_type(sd), phongo_server_description_type_map[PHONGO_SERVER_RS_ARBITER].name));
+	ADD_ASSOC_BOOL_EX(&retval, "is_hidden", bson_iter_init_find_case(&iter, hello_response, "hidden") && bson_iter_as_bool(&iter));
+	ADD_ASSOC_BOOL_EX(&retval, "is_passive", bson_iter_init_find_case(&iter, hello_response, "passive") && bson_iter_as_bool(&iter));
+
+	if (bson_iter_init_find(&iter, hello_response, "tags") && BSON_ITER_HOLDS_DOCUMENT(&iter)) {
+		const uint8_t*    bytes;
+		uint32_t          len;
+		phongo_bson_state state;
+
+		PHONGO_BSON_INIT_DEBUG_STATE(state);
+		bson_iter_document(&iter, &len, &bytes);
+		if (!phongo_bson_data_to_zval_ex(bytes, len, &state)) {
+			/* Exception already thrown */
+			zval_ptr_dtor(&state.zchild);
+			mongoc_server_description_destroy(sd);
+			zval_ptr_dtor(&retval);
+			return NULL;
+		}
+
+		ADD_ASSOC_ZVAL_EX(&retval, "tags", &state.zchild);
+	}
+
+	/* If the server description is a load balancer, its hello_response will be
+	 * empty. Instead, report the hello_response from the handshake description
+	 * (i.e. backing server). */
+	if (!strcmp(mongoc_server_description_type(sd), phongo_server_description_type_map[PHONGO_SERVER_LOAD_BALANCER].name)) {
+		const bson_t*                handshake_response;
+		mongoc_server_description_t* handshake_sd;
+		bson_error_t                 error = { 0 };
+		phongo_bson_state            state;
+
+		if (!(handshake_sd = mongoc_client_get_handshake_description(client, mongoc_server_description_id(sd), NULL, &error))) {
+			phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Failed to get handshake server description: %s", error.message);
+			mongoc_server_description_destroy(sd);
+			zval_ptr_dtor(&retval);
+			return NULL;
+		}
+
+		PHONGO_BSON_INIT_DEBUG_STATE(state);
+		handshake_response = mongoc_server_description_hello_response(handshake_sd);
+
+		if (!phongo_bson_to_zval_ex(handshake_response, &state)) {
+			/* Exception already thrown */
+			mongoc_server_description_destroy(handshake_sd);
+			zval_ptr_dtor(&state.zchild);
+			mongoc_server_description_destroy(sd);
+			zval_ptr_dtor(&retval);
+			return NULL;
+		}
+
+		ADD_ASSOC_ZVAL_EX(&retval, "last_hello_response", &state.zchild);
+		mongoc_server_description_destroy(handshake_sd);
+	} else {
+		phongo_bson_state state;
+
+		PHONGO_BSON_INIT_DEBUG_STATE(state);
+
+		if (!phongo_bson_to_zval_ex(hello_response, &state)) {
+			/* Exception already thrown */
+			zval_ptr_dtor(&state.zchild);
+			mongoc_server_description_destroy(sd);
+			zval_ptr_dtor(&retval);
+			return NULL;
+		}
+
+		ADD_ASSOC_ZVAL_EX(&retval, "last_hello_response", &state.zchild);
+	}
+
+	/* TODO: Use MONGOC_RTT_UNSET once it is added to libmongoc's public API (CDRIVER-4176) */
+	if (mongoc_server_description_round_trip_time(sd) == -1) {
+		ADD_ASSOC_NULL_EX(&retval, "round_trip_time");
+	} else {
+		ADD_ASSOC_LONG_EX(&retval, "round_trip_time", mongoc_server_description_round_trip_time(sd));
+	}
+
 	mongoc_server_description_destroy(sd);
 
 	return Z_ARRVAL(retval);
@@ -599,85 +686,3 @@ void phongo_server_init(zval* return_value, zval* manager, uint32_t server_id)
 	ZVAL_ZVAL(&server->manager, manager, 1, 0);
 }
 
-bool phongo_server_to_zval(zval* retval, mongoc_client_t* client, mongoc_server_description_t* sd)
-{
-	const mongoc_host_list_t* host           = mongoc_server_description_host(sd);
-	const bson_t*             hello_response = mongoc_server_description_hello_response(sd);
-	bson_iter_t               iter;
-
-	array_init(retval);
-
-	ADD_ASSOC_STRING(retval, "host", host->host);
-	ADD_ASSOC_LONG_EX(retval, "port", host->port);
-	ADD_ASSOC_LONG_EX(retval, "type", phongo_server_description_type(sd));
-	ADD_ASSOC_BOOL_EX(retval, "is_primary", !strcmp(mongoc_server_description_type(sd), phongo_server_description_type_map[PHONGO_SERVER_RS_PRIMARY].name));
-	ADD_ASSOC_BOOL_EX(retval, "is_secondary", !strcmp(mongoc_server_description_type(sd), phongo_server_description_type_map[PHONGO_SERVER_RS_SECONDARY].name));
-	ADD_ASSOC_BOOL_EX(retval, "is_arbiter", !strcmp(mongoc_server_description_type(sd), phongo_server_description_type_map[PHONGO_SERVER_RS_ARBITER].name));
-	ADD_ASSOC_BOOL_EX(retval, "is_hidden", bson_iter_init_find_case(&iter, hello_response, "hidden") && bson_iter_as_bool(&iter));
-	ADD_ASSOC_BOOL_EX(retval, "is_passive", bson_iter_init_find_case(&iter, hello_response, "passive") && bson_iter_as_bool(&iter));
-
-	if (bson_iter_init_find(&iter, hello_response, "tags") && BSON_ITER_HOLDS_DOCUMENT(&iter)) {
-		const uint8_t*    bytes;
-		uint32_t          len;
-		phongo_bson_state state;
-
-		PHONGO_BSON_INIT_DEBUG_STATE(state);
-		bson_iter_document(&iter, &len, &bytes);
-		if (!phongo_bson_data_to_zval_ex(bytes, len, &state)) {
-			/* Exception already thrown */
-			zval_ptr_dtor(&state.zchild);
-			return false;
-		}
-
-		ADD_ASSOC_ZVAL_EX(retval, "tags", &state.zchild);
-	}
-
-	/* If the server description is a load balancer, its hello_response will be
-	 * empty. Instead, report the hello_response from the handshake description
-	 * (i.e. backing server). */
-	if (!strcmp(mongoc_server_description_type(sd), phongo_server_description_type_map[PHONGO_SERVER_LOAD_BALANCER].name)) {
-		const bson_t*                handshake_response;
-		mongoc_server_description_t* handshake_sd;
-		bson_error_t                 error = { 0 };
-		phongo_bson_state            state;
-
-		if (!(handshake_sd = mongoc_client_get_handshake_description(client, mongoc_server_description_id(sd), NULL, &error))) {
-			phongo_throw_exception(PHONGO_ERROR_RUNTIME, "Failed to get handshake server description: %s", error.message);
-			return false;
-		}
-
-		PHONGO_BSON_INIT_DEBUG_STATE(state);
-		handshake_response = mongoc_server_description_hello_response(handshake_sd);
-
-		if (!phongo_bson_to_zval_ex(handshake_response, &state)) {
-			/* Exception already thrown */
-			mongoc_server_description_destroy(handshake_sd);
-			zval_ptr_dtor(&state.zchild);
-			return false;
-		}
-
-		ADD_ASSOC_ZVAL_EX(retval, "last_hello_response", &state.zchild);
-		mongoc_server_description_destroy(handshake_sd);
-	} else {
-		phongo_bson_state state;
-
-		PHONGO_BSON_INIT_DEBUG_STATE(state);
-
-		if (!phongo_bson_to_zval_ex(hello_response, &state)) {
-			/* Exception already thrown */
-			zval_ptr_dtor(&state.zchild);
-			return false;
-		}
-
-		ADD_ASSOC_ZVAL_EX(retval, "last_hello_response", &state.zchild);
-	}
-
-	/* TODO: Use MONGOC_RTT_UNSET once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (mongoc_server_description_round_trip_time(sd) == -1) {
-		ADD_ASSOC_NULL_EX(retval, "round_trip_time");
-	} else {
-		ADD_ASSOC_LONG_EX(retval, "round_trip_time", mongoc_server_description_round_trip_time(sd));
-	}
-
-	return true;
-}

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -685,4 +685,3 @@ void phongo_server_init(zval* return_value, zval* manager, uint32_t server_id)
 
 	ZVAL_ZVAL(&server->manager, manager, 1, 0);
 }
-

--- a/src/MongoDB/Server.h
+++ b/src/MongoDB/Server.h
@@ -23,6 +23,4 @@
 
 void phongo_server_init(zval* return_value, zval* manager, uint32_t server_id);
 
-bool phongo_server_to_zval(zval* retval, mongoc_client_t* client, mongoc_server_description_t* sd);
-
 #endif /* PHONGO_SERVER_H */

--- a/tests/manager/manager-debug-005.phpt
+++ b/tests/manager/manager-debug-005.phpt
@@ -1,0 +1,33 @@
+--TEST--
+PHPC-1519: MongoDB\Driver\Manager debug output includes Server objects in cluster
+--SKIPIF--
+<?php require __DIR__ . "/../utils/basic-skipif.inc"; ?>
+<?php skip_if_not_live(); ?>
+<?php skip_if_not_clean(); ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils/basic.inc";
+
+$manager = create_test_manager();
+$manager->selectServer(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::PRIMARY));
+
+var_dump($manager);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\Driver\Manager)#%d (%d) {
+  ["uri"]=>
+  string(%d) "%s"
+  ["cluster"]=>
+  array(%d) {
+    [%d]=>
+    object(MongoDB\Driver\Server)#%d (%d) {
+      %A
+    }%A
+  }
+  ["cryptSharedVersion"]=>
+  NULL
+}
+===DONE===

--- a/tests/manager/manager-var-dump-001.phpt
+++ b/tests/manager/manager-var-dump-001.phpt
@@ -37,7 +37,7 @@ object(MongoDB\Driver\Manager)#%d (%d) {
   ["cluster"]=>
   array(1) {
     [0]=>
-    array(10) {
+    object(MongoDB\Driver\Server)#%d (%d) {
       ["host"]=>
       string(%d) "%s"
       ["port"]=>


### PR DESCRIPTION
Fix PHPC-1519
`phongo_server_to_zval` was used by both `phongo_server_get_debug_info` and `phongo_manager_get_debug_info` to build an array representation of a server. The Manager's debug handler now creates `Server` objects via `phongo_server_init` instead, consistent with how other value objects appear in debug output. The array-building logic is inlined into `phongo_server_get_debug_info` with proper error handling.