### PR TITLE
PHPC-1514 Remove `php_phongo_read_concern_to_zval`

### DIFF
--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -396,7 +396,7 @@ static HashTable* phongo_query_get_debug_info(zend_object* object, int* is_temp)
 	if (intern->read_concern) {
 		zval read_concern;
 
-		phongo_read_concern_to_zval(&read_concern, intern->read_concern);
+		phongo_readconcern_init(&read_concern, intern->read_concern);
 		ADD_ASSOC_ZVAL_EX(&retval, "readConcern", &read_concern);
 	} else {
 		ADD_ASSOC_NULL_EX(&retval, "readConcern");

--- a/src/MongoDB/ReadConcern.c
+++ b/src/MongoDB/ReadConcern.c
@@ -218,14 +218,3 @@ const mongoc_read_concern_t* phongo_read_concern_from_zval(zval* zread_concern)
 
 	return NULL;
 }
-
-void phongo_read_concern_to_zval(zval* retval, const mongoc_read_concern_t* read_concern)
-{
-	const char* level = mongoc_read_concern_get_level(read_concern);
-
-	array_init_size(retval, 1);
-
-	if (level) {
-		ADD_ASSOC_STRING(retval, "level", level);
-	}
-}

--- a/src/MongoDB/ReadConcern.h
+++ b/src/MongoDB/ReadConcern.h
@@ -25,6 +25,4 @@ void phongo_readconcern_init(zval* return_value, const mongoc_read_concern_t* re
 
 const mongoc_read_concern_t* phongo_read_concern_from_zval(zval* zread_concern);
 
-void phongo_read_concern_to_zval(zval* retval, const mongoc_read_concern_t* read_concern);
-
 #endif /* PHONGO_READCONCERN_H */

--- a/tests/query/query-ctor-002.phpt
+++ b/tests/query/query-ctor-002.phpt
@@ -155,7 +155,7 @@ object(MongoDB\Driver\Query)#%d (%d) {
   object(stdClass)#%d (%d) {
   }
   ["readConcern"]=>
-  array(1) {
+  object(MongoDB\Driver\ReadConcern)#%d (%d) {
     ["level"]=>
     string(5) "local"
   }

--- a/tests/query/query-debug-001.phpt
+++ b/tests/query/query-debug-001.phpt
@@ -42,7 +42,7 @@ object(MongoDB\Driver\Query)#%d (%d) {
     }
   }
   ["readConcern"]=>
-  array(1) {
+  object(MongoDB\Driver\ReadConcern)#%d (%d) {
     ["level"]=>
     string(5) "local"
   }


### PR DESCRIPTION
Fix PHPC-1514
It's only used by the `Query` debug handler and can be replaced by adding a `ReadConcern` object to `Query`'s debug info instead