### PR TITLE
PHPC-2699: Rename durationMicros properties

### DIFF
--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -172,7 +172,7 @@ static void phongo_commandfailedevent_update_properties(phongo_commandfailedeven
 	zend_update_property_long(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
 	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("commandName"), intern->command_name);
 	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("databaseName"), intern->database_name);
-	zend_update_property_long(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("durationMicros"), intern->duration_micros);
+	zend_update_property_long(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("duration"), intern->duration_micros);
 	zend_update_property(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("error"), &intern->z_error);
 
 	if (phongo_bson_to_zval_ex(intern->reply, &reply_state)) {

--- a/src/MongoDB/Monitoring/CommandFailedEvent.stub.php
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.stub.php
@@ -14,7 +14,7 @@ final class CommandFailedEvent
     public readonly int $port;
     public readonly string $commandName;
     public readonly string $databaseName;
-    public readonly int $durationMicros;
+    public readonly int $duration;
     public readonly \Exception $error;
     public readonly object $reply;
     public readonly string $operationId;

--- a/src/MongoDB/Monitoring/CommandFailedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandFailedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 290fcb84655aea3822ce90394e198c1055ab75a9 */
+ * Stub hash: a8c6d822dc54c673adeb79b31e5df8d1277df4dd */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandFailedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -93,11 +93,11 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandFailedE
 	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_databaseName_name);
 
-	zval property_durationMicros_default_value;
-	ZVAL_UNDEF(&property_durationMicros_default_value);
-	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
-	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_durationMicros_name);
+	zval property_duration_default_value;
+	ZVAL_UNDEF(&property_duration_default_value);
+	zend_string *property_duration_name = zend_string_init("duration", sizeof("duration") - 1, 1);
+	zend_declare_typed_property(class_entry, property_duration_name, &property_duration_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_duration_name);
 
 	zval property_error_default_value;
 	ZVAL_UNDEF(&property_error_default_value);

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -162,7 +162,7 @@ static void phongo_commandsucceededevent_update_properties(phongo_commandsucceed
 	zend_update_property_long(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
 	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("commandName"), intern->command_name);
 	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("databaseName"), intern->database_name);
-	zend_update_property_long(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("durationMicros"), intern->duration_micros);
+	zend_update_property_long(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("duration"), intern->duration_micros);
 
 	if (phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
 		zend_update_property(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("reply"), &reply_state.zchild);

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.stub.php
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.stub.php
@@ -14,7 +14,7 @@ final class CommandSucceededEvent
     public readonly int $port;
     public readonly string $commandName;
     public readonly string $databaseName;
-    public readonly int $durationMicros;
+    public readonly int $duration;
     public readonly object $reply;
     public readonly string $operationId;
     public readonly string $requestId;

--- a/src/MongoDB/Monitoring/CommandSucceededEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 153383f0dae4ebcbaece5b307b623f6903fec00b */
+ * Stub hash: 9341ea392077dd748049c3c7a1eadb0eff540969 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_CommandSucceededEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -88,11 +88,11 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_CommandSucceed
 	zend_declare_typed_property(class_entry, property_databaseName_name, &property_databaseName_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_databaseName_name);
 
-	zval property_durationMicros_default_value;
-	ZVAL_UNDEF(&property_durationMicros_default_value);
-	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
-	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_durationMicros_name);
+	zval property_duration_default_value;
+	ZVAL_UNDEF(&property_duration_default_value);
+	zend_string *property_duration_name = zend_string_init("duration", sizeof("duration") - 1, 1);
+	zend_declare_typed_property(class_entry, property_duration_name, &property_duration_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_duration_name);
 
 	zval property_reply_default_value;
 	ZVAL_UNDEF(&property_reply_default_value);

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.c
@@ -81,7 +81,7 @@ static void phongo_serverheartbeatfailedevent_update_properties(phongo_serverhea
 	zend_update_property_string(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
 	zend_update_property_long(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
 	zend_update_property_bool(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("awaited"), intern->awaited);
-	zend_update_property_long(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("durationMicros"), intern->duration_micros);
+	zend_update_property_long(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("duration"), intern->duration_micros);
 	zend_update_property(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("error"), &intern->z_error);
 }
 

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.stub.php
@@ -13,7 +13,7 @@ final class ServerHeartbeatFailedEvent
     public readonly string $host;
     public readonly int $port;
     public readonly bool $awaited;
-    public readonly int $durationMicros;
+    public readonly int $duration;
     public readonly \Exception $error;
 
     final private function __construct() {}

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: abff51dfbb54b9d9a61c38bf71853c20df352171 */
+ * Stub hash: 2d55d85a35a4a21004611412546aeab7ffdbad93 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -61,11 +61,11 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_awaited_name);
 
-	zval property_durationMicros_default_value;
-	ZVAL_UNDEF(&property_durationMicros_default_value);
-	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
-	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_durationMicros_name);
+	zval property_duration_default_value;
+	ZVAL_UNDEF(&property_duration_default_value);
+	zend_string *property_duration_name = zend_string_init("duration", sizeof("duration") - 1, 1);
+	zend_declare_typed_property(class_entry, property_duration_name, &property_duration_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_duration_name);
 
 	zval property_error_default_value;
 	ZVAL_UNDEF(&property_error_default_value);

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
@@ -93,7 +93,7 @@ static void phongo_serverheartbeatsucceededevent_update_properties(phongo_server
 	zend_update_property_string(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
 	zend_update_property_long(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
 	zend_update_property_bool(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("awaited"), intern->awaited);
-	zend_update_property_long(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("durationMicros"), intern->duration_micros);
+	zend_update_property_long(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("duration"), intern->duration_micros);
 
 	if (phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
 		zend_update_property(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("reply"), &reply_state.zchild);

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.stub.php
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.stub.php
@@ -13,7 +13,7 @@ final class ServerHeartbeatSucceededEvent
     public readonly string $host;
     public readonly int $port;
     public readonly bool $awaited;
-    public readonly int $durationMicros;
+    public readonly int $duration;
     public readonly object $reply;
 
     final private function __construct() {}

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent_arginfo.h
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fe93a333a39554b9660c2eeb47852755dbea7e97 */
+ * Stub hash: 7fccc6765f058925077bb698c8a79ddb8355b852 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -61,11 +61,11 @@ static zend_class_entry *register_class_MongoDB_Driver_Monitoring_ServerHeartbea
 	zend_declare_typed_property(class_entry, property_awaited_name, &property_awaited_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_awaited_name);
 
-	zval property_durationMicros_default_value;
-	ZVAL_UNDEF(&property_durationMicros_default_value);
-	zend_string *property_durationMicros_name = zend_string_init("durationMicros", sizeof("durationMicros") - 1, 1);
-	zend_declare_typed_property(class_entry, property_durationMicros_name, &property_durationMicros_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_durationMicros_name);
+	zval property_duration_default_value;
+	ZVAL_UNDEF(&property_duration_default_value);
+	zend_string *property_duration_name = zend_string_init("duration", sizeof("duration") - 1, 1);
+	zend_declare_typed_property(class_entry, property_duration_name, &property_duration_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_duration_name);
 
 	zval property_reply_default_value;
 	ZVAL_UNDEF(&property_reply_default_value);

--- a/tests/apm/commandFailedEvent-001.phpt
+++ b/tests/apm/commandFailedEvent-001.phpt
@@ -31,9 +31,9 @@ class MySubscriber implements MongoDB\Driver\Monitoring\CommandSubscriber
         var_dump($event->getDatabaseName());
         var_dump($event->databaseName);
         var_dump($event->getDurationMicros());
-        var_dump($event->durationMicros);
+        var_dump($event->duration);
         echo "getDurationMicros() returns > 0: ", $event->getDurationMicros() > 0 ? 'yes' : 'no', "\n";
-        echo "durationMicros returns > 0: ", $event->durationMicros > 0 ? 'yes' : 'no', "\n";
+        echo "duration returns > 0: ", $event->duration > 0 ? 'yes' : 'no', "\n";
         var_dump($event->getError() instanceof MongoDB\Driver\Exception\Exception);
         var_dump($event->error instanceof MongoDB\Driver\Exception\Exception);
         var_dump($event->getHost());
@@ -74,7 +74,7 @@ string(5) "admin"
 int(%d)
 int(%d)
 getDurationMicros() returns > 0: yes
-durationMicros returns > 0: yes
+duration returns > 0: yes
 bool(true)
 bool(true)
 string(%d) "%s"

--- a/tests/apm/commandFailedEvent-debug-001.phpt
+++ b/tests/apm/commandFailedEvent-debug-001.phpt
@@ -50,7 +50,7 @@ object(MongoDB\Driver\Monitoring\CommandFailedEvent)#%d (11) {
   string(9) "aggregate"
   ["databaseName"]=>
   string(%d) "%s"
-  ["durationMicros"]=>
+  ["duration"]=>
   int(%d)
   ["error"]=>
   object(MongoDB\Driver\Exception\ServerException)#%d (%d) {%A

--- a/tests/apm/commandSucceededEvent-001.phpt
+++ b/tests/apm/commandSucceededEvent-001.phpt
@@ -29,9 +29,9 @@ class MySubscriber implements MongoDB\Driver\Monitoring\CommandSubscriber
         var_dump($event->getDatabaseName());
         var_dump($event->databaseName);
         var_dump($event->getDurationMicros());
-        var_dump($event->durationMicros);
+        var_dump($event->duration);
         echo "getDurationMicros() returns > 0: ", $event->getDurationMicros() > 0 ? 'yes' : 'no', "\n";
-        echo "durationMicros returns > 0: ", $event->durationMicros > 0 ? 'yes' : 'no', "\n";
+        echo "duration returns > 0: ", $event->duration > 0 ? 'yes' : 'no', "\n";
         var_dump($event->getHost());
         var_dump($event->host);
         var_dump($event->getOperationId());
@@ -70,7 +70,7 @@ string(5) "admin"
 int(%d)
 int(%d)
 getDurationMicros() returns > 0: yes
-durationMicros returns > 0: yes
+duration returns > 0: yes
 string(%d) "%s"
 string(%d) "%s"
 string(%d) "%d"

--- a/tests/apm/commandSucceededEvent-debug-001.phpt
+++ b/tests/apm/commandSucceededEvent-debug-001.phpt
@@ -41,7 +41,7 @@ object(MongoDB\Driver\Monitoring\CommandSucceededEvent)#%d (10) {
   string(4) "ping"
   ["databaseName"]=>
   string(%d) "%s"
-  ["durationMicros"]=>
+  ["duration"]=>
   int(%d)
   ["reply"]=>
   object(stdClass)#%d (%d) {%A

--- a/tests/apm/serverHeartbeatFailedEvent-001.phpt
+++ b/tests/apm/serverHeartbeatFailedEvent-001.phpt
@@ -19,7 +19,7 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
     public function serverHeartbeatFailed(MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent $event): void
     {
         printf("getDurationMicros() returns an integer: %s\n", is_integer($event->getDurationMicros()) ? 'yes' : 'no');
-        printf("durationMicros returns an integer: %s\n", is_integer($event->durationMicros) ? 'yes' : 'no');
+        printf("duration returns an integer: %s\n", is_integer($event->duration) ? 'yes' : 'no');
         printf("getError() returns an Exception: %s\n", ($event->getError() instanceof Exception) ? 'yes' : 'no');
         printf("error returns an Exception: %s\n", ($event->error instanceof Exception) ? 'yes' : 'no');
         printf("getHost() returns a string: %s\n", is_string($event->getHost()) ? 'yes' : 'no');
@@ -67,7 +67,7 @@ configureFailPoint($m2, 'failCommand', 'off');
 <?php exit(0); ?>
 --EXPECTF--
 getDurationMicros() returns an integer: yes
-durationMicros returns an integer: yes
+duration returns an integer: yes
 getError() returns an Exception: yes
 error returns an Exception: yes
 getHost() returns a string: yes
@@ -83,7 +83,7 @@ object(MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent)#%d (%d) {
   int(%d)
   ["awaited"]=>
   bool(%s)
-  ["durationMicros"]=>
+  ["duration"]=>
   int(%d)
   ["error"]=>
   object(MongoDB\Driver\Exception\RuntimeException)#%d (%d) {%A

--- a/tests/apm/serverHeartbeatSucceededEvent-001.phpt
+++ b/tests/apm/serverHeartbeatSucceededEvent-001.phpt
@@ -29,7 +29,7 @@ class MySubscriber implements MongoDB\Driver\Monitoring\SDAMSubscriber
         $this->isObserved = true;
 
         printf("getDurationMicros() returns an integer: %s\n", is_integer($event->getDurationMicros()) ? 'yes' : 'no');
-        printf("durationMicros returns an integer: %s\n", is_integer($event->durationMicros) ? 'yes' : 'no');
+        printf("duration returns an integer: %s\n", is_integer($event->duration) ? 'yes' : 'no');
         printf("getHost() returns a string: %s\n", is_string($event->getHost()) ? 'yes' : 'no');
         printf("host returns a string: %s\n", is_string($event->host) ? 'yes' : 'no');
         printf("getPort() returns an integer: %s\n", is_integer($event->getPort()) ? 'yes' : 'no');
@@ -62,7 +62,7 @@ $m->executeCommand(DATABASE_NAME, $command);
 <?php exit(0); ?>
 --EXPECTF--
 getDurationMicros() returns an integer: yes
-durationMicros returns an integer: yes
+duration returns an integer: yes
 getHost() returns a string: yes
 host returns a string: yes
 getPort() returns an integer: yes
@@ -78,7 +78,7 @@ object(MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent)#%d (%d) {
   int(%d)
   ["awaited"]=>
   bool(%s)
-  ["durationMicros"]=>
+  ["duration"]=>
   int(%d)
   ["reply"]=>
   object(stdClass)#%d (%d) {%A


### PR DESCRIPTION
PHPC-2699

After consideration, we're using this opportunity to fix the naming of the `duration` properties on APM event classes. `durationMicros` may be clearer in terms of units, but the specification actually calls for a `duration` property, so we're a bit more consistent with the spec here. Note that libmongoc also uses `duration` as naming, which brought this to my attention.