### PR TITLE
Remove extra structs for objects with properties

### DIFF
--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -32,82 +32,17 @@ zend_class_entry* phongo_commandfailedevent_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_CommandFailedEvent)
 
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getCommandName)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "commandName");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getDatabaseName)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "databaseName");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getDurationMicros)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "duration");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getError)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "error");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getHost)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "host");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getOperationId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "operationId");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getPort)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "port");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getReply)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "reply");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getRequestId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "requestId");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getServiceId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "serviceId");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getServerConnectionId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandfailedevent, "serverConnectionId");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getCommandName, commandfailedevent, "commandName")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getDatabaseName, commandfailedevent, "databaseName")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getDurationMicros, commandfailedevent, "duration")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getError, commandfailedevent, "error")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getHost, commandfailedevent, "host")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getOperationId, commandfailedevent, "operationId")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getPort, commandfailedevent, "port")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getReply, commandfailedevent, "reply")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getRequestId, commandfailedevent, "requestId")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getServiceId, commandfailedevent, "serviceId")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandFailedEvent, getServerConnectionId, commandfailedevent, "serverConnectionId")
 
 static void phongo_commandfailedevent_update_properties(zend_object* object, const mongoc_apm_command_failed_t* event)
 {

--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -48,6 +48,7 @@ static void phongo_commandfailedevent_update_properties(zend_object* object, con
 {
 	char              operation_id[24], request_id[24];
 	phongo_bson_state reply_state;
+	int64_t           server_connection_id = mongoc_apm_command_failed_get_server_connection_id_int64(event);
 
 	PHONGO_BSON_INIT_STATE(reply_state);
 
@@ -94,10 +95,16 @@ static void phongo_commandfailedevent_update_properties(zend_object* object, con
 	}
 
 	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (mongoc_apm_command_failed_get_server_connection_id_int64(event) == -1) {
+	if (server_connection_id == -1) {
 		zend_update_property_null(phongo_commandfailedevent_ce, object, ZEND_STRL("serverConnectionId"));
 	} else {
-		zend_update_property_long(phongo_commandfailedevent_ce, object, ZEND_STRL("serverConnectionId"), mongoc_apm_command_failed_get_server_connection_id_int64(event));
+#if SIZEOF_ZEND_LONG == 4
+		if (server_connection_id > INT32_MAX || server_connection_id < INT32_MIN) {
+			zend_error(E_WARNING, "Truncating 64-bit value %" PRId64 " for serverConnectionId", server_connection_id);
+		}
+#endif
+
+		zend_update_property_long(phongo_commandfailedevent_ce, object, ZEND_STRL("serverConnectionId"), server_connection_id);
 	}
 }
 

--- a/src/MongoDB/Monitoring/CommandFailedEvent.c
+++ b/src/MongoDB/Monitoring/CommandFailedEvent.c
@@ -34,252 +34,146 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_CommandFailedEvent)
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getCommandName)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->command_name);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "commandName");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getDatabaseName)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->database_name);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "databaseName");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getDurationMicros)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETURN_LONG(intern->duration_micros);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "duration");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getError)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETURN_ZVAL(&intern->z_error, 1, 0);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "error");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getHost)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->host.host);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "host");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getOperationId)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
-	char operation_id[24];
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
-	RETVAL_STRING(operation_id);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "operationId");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getPort)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_LONG(intern->host.port);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "port");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getReply)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
-	phongo_bson_state state;
-
-	PHONGO_BSON_INIT_STATE(state);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!phongo_bson_to_zval_ex(intern->reply, &state)) {
-		zval_ptr_dtor(&state.zchild);
-		return;
-	}
-
-	RETURN_ZVAL(&state.zchild, 0, 1);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "reply");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getRequestId)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
-	char request_id[24];
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
-	RETVAL_STRING(request_id);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "requestId");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getServiceId)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!intern->has_service_id) {
-		RETURN_NULL();
-	}
-
-	phongo_objectid_new(return_value, &intern->service_id);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "serviceId");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandFailedEvent, getServerConnectionId)
 {
-	PHONGO_INTERN_FROM_THIS(commandfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (intern->server_connection_id == -1) {
-		RETURN_NULL();
-	}
-
-#if SIZEOF_ZEND_LONG == 4
-	if (intern->server_connection_id > INT32_MAX || intern->server_connection_id < INT32_MIN) {
-		zend_error(E_WARNING, "Truncating 64-bit value %" PRId64 " for serverConnectionId", intern->server_connection_id);
-	}
-#endif
-
-	RETURN_LONG(intern->server_connection_id);
+	PHONGO_RETURN_PROPERTY(commandfailedevent, "serverConnectionId");
 }
 
-static void phongo_commandfailedevent_update_properties(phongo_commandfailedevent_t* intern)
+static void phongo_commandfailedevent_update_properties(zend_object* object, const mongoc_apm_command_failed_t* event)
 {
 	char              operation_id[24], request_id[24];
 	phongo_bson_state reply_state;
 
 	PHONGO_BSON_INIT_STATE(reply_state);
 
-	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
-	zend_update_property_long(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
-	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("commandName"), intern->command_name);
-	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("databaseName"), intern->database_name);
-	zend_update_property_long(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("duration"), intern->duration_micros);
-	zend_update_property(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("error"), &intern->z_error);
+	zend_update_property_string(phongo_commandfailedevent_ce, object, ZEND_STRL("host"), mongoc_apm_command_failed_get_host(event)->host);
+	zend_update_property_long(phongo_commandfailedevent_ce, object, ZEND_STRL("port"), mongoc_apm_command_failed_get_host(event)->port);
+	zend_update_property_string(phongo_commandfailedevent_ce, object, ZEND_STRL("commandName"), mongoc_apm_command_failed_get_command_name(event));
+	zend_update_property_string(phongo_commandfailedevent_ce, object, ZEND_STRL("databaseName"), mongoc_apm_command_failed_get_database_name(event));
+	zend_update_property_long(phongo_commandfailedevent_ce, object, ZEND_STRL("duration"), mongoc_apm_command_failed_get_duration(event));
 
-	if (phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
-		zend_update_property(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("reply"), &reply_state.zchild);
+	{
+		bson_error_t tmp_error = { 0 };
+		zval         z_error;
+
+		mongoc_apm_command_failed_get_error(event, &tmp_error);
+
+		object_init_ex(&z_error, phongo_exception_from_mongoc_domain(tmp_error.domain, tmp_error.code));
+		zend_update_property_string(zend_ce_exception, Z_OBJ_P(&z_error), ZEND_STRL("message"), tmp_error.message);
+		zend_update_property_long(zend_ce_exception, Z_OBJ_P(&z_error), ZEND_STRL("code"), tmp_error.code);
+
+		zend_update_property(phongo_commandfailedevent_ce, object, ZEND_STRL("error"), &z_error);
+		zval_ptr_dtor(&z_error);
+	}
+
+	if (phongo_bson_to_zval_ex(mongoc_apm_command_failed_get_reply(event), &reply_state)) {
+		zend_update_property(phongo_commandfailedevent_ce, object, ZEND_STRL("reply"), &reply_state.zchild);
 	}
 	zval_ptr_dtor(&reply_state.zchild);
 
-	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
-	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("operationId"), operation_id);
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, mongoc_apm_command_failed_get_operation_id(event));
+	zend_update_property_string(phongo_commandfailedevent_ce, object, ZEND_STRL("operationId"), operation_id);
 
-	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
-	zend_update_property_string(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("requestId"), request_id);
+	snprintf(request_id, sizeof(request_id), "%" PRId64, mongoc_apm_command_failed_get_request_id(event));
+	zend_update_property_string(phongo_commandfailedevent_ce, object, ZEND_STRL("requestId"), request_id);
 
-	if (intern->has_service_id) {
+	if (mongoc_apm_command_failed_get_service_id(event)) {
 		zval service_id;
 
-		if (phongo_objectid_new(&service_id, &intern->service_id)) {
-			zend_update_property(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("serviceId"), &service_id);
+		if (phongo_objectid_new(&service_id, mongoc_apm_command_failed_get_service_id(event))) {
+			zend_update_property(phongo_commandfailedevent_ce, object, ZEND_STRL("serviceId"), &service_id);
 			zval_ptr_dtor(&service_id);
 		}
 	} else {
-		zend_update_property_null(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("serviceId"));
+		zend_update_property_null(phongo_commandfailedevent_ce, object, ZEND_STRL("serviceId"));
 	}
 
 	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (intern->server_connection_id == -1) {
-		zend_update_property_null(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("serverConnectionId"));
+	if (mongoc_apm_command_failed_get_server_connection_id_int64(event) == -1) {
+		zend_update_property_null(phongo_commandfailedevent_ce, object, ZEND_STRL("serverConnectionId"));
 	} else {
-		zend_update_property_long(phongo_commandfailedevent_ce, &intern->std, ZEND_STRL("serverConnectionId"), intern->server_connection_id);
+		zend_update_property_long(phongo_commandfailedevent_ce, object, ZEND_STRL("serverConnectionId"), mongoc_apm_command_failed_get_server_connection_id_int64(event));
 	}
-}
-
-/* MongoDB\Driver\Monitoring\CommandFailedEvent object handlers */
-static zend_object_handlers phongo_handler_commandfailedevent;
-
-static void phongo_commandfailedevent_free_object(zend_object* object)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(commandfailedevent, object);
-
-	zend_object_std_dtor(&intern->std);
-
-	if (!Z_ISUNDEF(intern->z_error)) {
-		zval_ptr_dtor(&intern->z_error);
-	}
-
-	if (intern->reply) {
-		bson_destroy(intern->reply);
-	}
-
-	if (intern->command_name) {
-		efree(intern->command_name);
-	}
-
-	if (intern->database_name) {
-		efree(intern->database_name);
-	}
-}
-
-static zend_object* phongo_commandfailedevent_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(commandfailedevent, class_type);
-
-	intern->std.handlers = &phongo_handler_commandfailedevent;
-
-	return &intern->std;
 }
 
 void phongo_commandfailedevent_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_commandfailedevent_ce                = register_class_MongoDB_Driver_Monitoring_CommandFailedEvent();
-	phongo_commandfailedevent_ce->create_object = phongo_commandfailedevent_create_object;
-
-	memcpy(&phongo_handler_commandfailedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_commandfailedevent.free_obj = phongo_commandfailedevent_free_object;
-	phongo_handler_commandfailedevent.offset   = XtOffsetOf(phongo_commandfailedevent_t, std);
+	phongo_commandfailedevent_ce = register_class_MongoDB_Driver_Monitoring_CommandFailedEvent();
 }
 
 void phongo_commandfailedevent_init(zval* return_value, const mongoc_apm_command_failed_t* event)
 {
-	PHONGO_INTERN_INIT_EX(commandfailedevent, return_value);
+	PHONGO_OBJECT_INIT_EX(commandfailedevent, return_value);
 
-	bson_error_t tmp_error = { 0 };
-
-	memcpy(&intern->host, mongoc_apm_command_failed_get_host(event), sizeof(mongoc_host_list_t));
-
-	intern->command_name         = estrdup(mongoc_apm_command_failed_get_command_name(event));
-	intern->database_name        = estrdup(mongoc_apm_command_failed_get_database_name(event));
-	intern->server_id            = mongoc_apm_command_failed_get_server_id(event);
-	intern->operation_id         = mongoc_apm_command_failed_get_operation_id(event);
-	intern->request_id           = mongoc_apm_command_failed_get_request_id(event);
-	intern->duration_micros      = mongoc_apm_command_failed_get_duration(event);
-	intern->reply                = bson_copy(mongoc_apm_command_failed_get_reply(event));
-	intern->server_connection_id = mongoc_apm_command_failed_get_server_connection_id_int64(event);
-	intern->has_service_id       = mongoc_apm_command_failed_get_service_id(event) != NULL;
-
-	if (intern->has_service_id) {
-		bson_oid_copy(mongoc_apm_command_failed_get_service_id(event), &intern->service_id);
-	}
-
-	/* We need to process and convert the error right here, otherwise
-	 * debug_info will turn into a recursive loop, and with the wrong trace
-	 * locations */
-	mongoc_apm_command_failed_get_error(event, &tmp_error);
-
-	object_init_ex(&intern->z_error, phongo_exception_from_mongoc_domain(tmp_error.domain, tmp_error.code));
-	zend_update_property_string(zend_ce_exception, Z_OBJ_P(&intern->z_error), ZEND_STRL("message"), tmp_error.message);
-	zend_update_property_long(zend_ce_exception, Z_OBJ_P(&intern->z_error), ZEND_STRL("code"), tmp_error.code);
-
-	phongo_commandfailedevent_update_properties(intern);
+	phongo_commandfailedevent_update_properties(object, event);
 }

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -31,68 +31,15 @@ zend_class_entry* phongo_commandstartedevent_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_CommandStartedEvent)
 
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getCommand)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandstartedevent, "command");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getCommandName)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandstartedevent, "commandName");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getDatabaseName)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandstartedevent, "databaseName");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getHost)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandstartedevent, "host");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getOperationId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandstartedevent, "operationId");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getPort)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandstartedevent, "port");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getRequestId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandstartedevent, "requestId");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getServiceId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandstartedevent, "serviceId");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getServerConnectionId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandstartedevent, "serverConnectionId");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandStartedEvent, getCommand, commandstartedevent, "command")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandStartedEvent, getCommandName, commandstartedevent, "commandName")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandStartedEvent, getDatabaseName, commandstartedevent, "databaseName")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandStartedEvent, getHost, commandstartedevent, "host")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandStartedEvent, getOperationId, commandstartedevent, "operationId")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandStartedEvent, getPort, commandstartedevent, "port")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandStartedEvent, getRequestId, commandstartedevent, "requestId")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandStartedEvent, getServiceId, commandstartedevent, "serviceId")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandStartedEvent, getServerConnectionId, commandstartedevent, "serverConnectionId")
 
 static void phongo_commandstartedevent_update_properties(zend_object* object, const mongoc_apm_command_started_t* event)
 {

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -33,216 +33,117 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_CommandStartedEvent)
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getCommand)
 {
-	PHONGO_INTERN_FROM_THIS(commandstartedevent);
-
-	phongo_bson_state state;
-
-	PHONGO_BSON_INIT_STATE(state);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!phongo_bson_to_zval_ex(intern->command, &state)) {
-		zval_ptr_dtor(&state.zchild);
-		return;
-	}
-
-	RETURN_ZVAL(&state.zchild, 0, 1);
+	PHONGO_RETURN_PROPERTY(commandstartedevent, "command");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getCommandName)
 {
-	PHONGO_INTERN_FROM_THIS(commandstartedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->command_name);
+	PHONGO_RETURN_PROPERTY(commandstartedevent, "commandName");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getDatabaseName)
 {
-	PHONGO_INTERN_FROM_THIS(commandstartedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->database_name);
+	PHONGO_RETURN_PROPERTY(commandstartedevent, "databaseName");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getHost)
 {
-	PHONGO_INTERN_FROM_THIS(commandstartedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->host.host);
+	PHONGO_RETURN_PROPERTY(commandstartedevent, "host");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getOperationId)
 {
-	PHONGO_INTERN_FROM_THIS(commandstartedevent);
-
-	char operation_id[24];
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
-	RETVAL_STRING(operation_id);
+	PHONGO_RETURN_PROPERTY(commandstartedevent, "operationId");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getPort)
 {
-	PHONGO_INTERN_FROM_THIS(commandstartedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_LONG(intern->host.port);
+	PHONGO_RETURN_PROPERTY(commandstartedevent, "port");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getRequestId)
 {
-	PHONGO_INTERN_FROM_THIS(commandstartedevent);
-
-	char request_id[24];
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
-	RETVAL_STRING(request_id);
+	PHONGO_RETURN_PROPERTY(commandstartedevent, "requestId");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getServiceId)
 {
-	PHONGO_INTERN_FROM_THIS(commandstartedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!intern->has_service_id) {
-		RETURN_NULL();
-	}
-
-	phongo_objectid_new(return_value, &intern->service_id);
+	PHONGO_RETURN_PROPERTY(commandstartedevent, "serviceId");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandStartedEvent, getServerConnectionId)
 {
-	PHONGO_INTERN_FROM_THIS(commandstartedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (intern->server_connection_id == -1) {
-		RETURN_NULL();
-	}
-
-#if SIZEOF_ZEND_LONG == 4
-	if (intern->server_connection_id > INT32_MAX || intern->server_connection_id < INT32_MIN) {
-		zend_error(E_WARNING, "Truncating 64-bit value %" PRId64 " for serverConnectionId", intern->server_connection_id);
-	}
-#endif
-
-	RETURN_LONG(intern->server_connection_id);
+	PHONGO_RETURN_PROPERTY(commandstartedevent, "serverConnectionId");
 }
 
-static void phongo_commandstartedevent_update_properties(phongo_commandstartedevent_t* intern)
+static void phongo_commandstartedevent_update_properties(zend_object* object, const mongoc_apm_command_started_t* event)
 {
 	char              operation_id[24], request_id[24];
 	phongo_bson_state command_state;
 
 	PHONGO_BSON_INIT_STATE(command_state);
 
-	zend_update_property_string(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
-	zend_update_property_long(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
-	zend_update_property_string(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("commandName"), intern->command_name);
-	zend_update_property_string(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("databaseName"), intern->database_name);
+	zend_update_property_string(phongo_commandstartedevent_ce, object, ZEND_STRL("host"), mongoc_apm_command_started_get_host(event)->host);
+	zend_update_property_long(phongo_commandstartedevent_ce, object, ZEND_STRL("port"), mongoc_apm_command_started_get_host(event)->port);
+	zend_update_property_string(phongo_commandstartedevent_ce, object, ZEND_STRL("commandName"), mongoc_apm_command_started_get_command_name(event));
+	zend_update_property_string(phongo_commandstartedevent_ce, object, ZEND_STRL("databaseName"), mongoc_apm_command_started_get_database_name(event));
 
-	if (phongo_bson_to_zval_ex(intern->command, &command_state)) {
-		zend_update_property(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("command"), &command_state.zchild);
+	if (phongo_bson_to_zval_ex(mongoc_apm_command_started_get_command(event), &command_state)) {
+		zend_update_property(phongo_commandstartedevent_ce, object, ZEND_STRL("command"), &command_state.zchild);
 	}
 	zval_ptr_dtor(&command_state.zchild);
 
-	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
-	zend_update_property_string(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("operationId"), operation_id);
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, mongoc_apm_command_started_get_operation_id(event));
+	zend_update_property_string(phongo_commandstartedevent_ce, object, ZEND_STRL("operationId"), operation_id);
 
-	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
-	zend_update_property_string(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("requestId"), request_id);
+	snprintf(request_id, sizeof(request_id), "%" PRId64, mongoc_apm_command_started_get_request_id(event));
+	zend_update_property_string(phongo_commandstartedevent_ce, object, ZEND_STRL("requestId"), request_id);
 
-	if (intern->has_service_id) {
+	if (mongoc_apm_command_started_get_service_id(event)) {
 		zval service_id;
 
-		if (phongo_objectid_new(&service_id, &intern->service_id)) {
-			zend_update_property(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("serviceId"), &service_id);
+		if (phongo_objectid_new(&service_id, mongoc_apm_command_started_get_service_id(event))) {
+			zend_update_property(phongo_commandstartedevent_ce, object, ZEND_STRL("serviceId"), &service_id);
 			zval_ptr_dtor(&service_id);
 		}
 	} else {
-		zend_update_property_null(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("serviceId"));
+		zend_update_property_null(phongo_commandstartedevent_ce, object, ZEND_STRL("serviceId"));
 	}
 
 	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (intern->server_connection_id == -1) {
-		zend_update_property_null(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("serverConnectionId"));
+	if (mongoc_apm_command_started_get_server_connection_id_int64(event) == -1) {
+		zend_update_property_null(phongo_commandstartedevent_ce, object, ZEND_STRL("serverConnectionId"));
 	} else {
-		zend_update_property_long(phongo_commandstartedevent_ce, &intern->std, ZEND_STRL("serverConnectionId"), intern->server_connection_id);
+		zend_update_property_long(phongo_commandstartedevent_ce, object, ZEND_STRL("serverConnectionId"), mongoc_apm_command_started_get_server_connection_id_int64(event));
 	}
-}
-
-/* MongoDB\Driver\Monitoring\CommandStartedEvent object handlers */
-static zend_object_handlers phongo_handler_commandstartedevent;
-
-static void phongo_commandstartedevent_free_object(zend_object* object)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(commandstartedevent, object);
-
-	zend_object_std_dtor(&intern->std);
-
-	if (intern->command) {
-		bson_destroy(intern->command);
-	}
-
-	if (intern->command_name) {
-		efree(intern->command_name);
-	}
-
-	if (intern->database_name) {
-		efree(intern->database_name);
-	}
-}
-
-static zend_object* phongo_commandstartedevent_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(commandstartedevent, class_type);
-
-	intern->std.handlers = &phongo_handler_commandstartedevent;
-
-	return &intern->std;
 }
 
 void phongo_commandstartedevent_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_commandstartedevent_ce                = register_class_MongoDB_Driver_Monitoring_CommandStartedEvent();
-	phongo_commandstartedevent_ce->create_object = phongo_commandstartedevent_create_object;
-
-	memcpy(&phongo_handler_commandstartedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_commandstartedevent.free_obj = phongo_commandstartedevent_free_object;
-	phongo_handler_commandstartedevent.offset   = XtOffsetOf(phongo_commandstartedevent_t, std);
+	phongo_commandstartedevent_ce = register_class_MongoDB_Driver_Monitoring_CommandStartedEvent();
 }
 
 void phongo_commandstartedevent_init(zval* return_value, const mongoc_apm_command_started_t* event)
 {
-	PHONGO_INTERN_INIT_EX(commandstartedevent, return_value);
+	PHONGO_OBJECT_INIT_EX(commandstartedevent, return_value);
 
-	memcpy(&intern->host, mongoc_apm_command_started_get_host(event), sizeof(mongoc_host_list_t));
-
-	intern->command_name         = estrdup(mongoc_apm_command_started_get_command_name(event));
-	intern->database_name        = estrdup(mongoc_apm_command_started_get_database_name(event));
-	intern->server_id            = mongoc_apm_command_started_get_server_id(event);
-	intern->operation_id         = mongoc_apm_command_started_get_operation_id(event);
-	intern->request_id           = mongoc_apm_command_started_get_request_id(event);
-	intern->command              = bson_copy(mongoc_apm_command_started_get_command(event));
-	intern->server_connection_id = mongoc_apm_command_started_get_server_connection_id_int64(event);
-	intern->has_service_id       = mongoc_apm_command_started_get_service_id(event) != NULL;
-
-	if (intern->has_service_id) {
-		bson_oid_copy(mongoc_apm_command_started_get_service_id(event), &intern->service_id);
-	}
-
-	phongo_commandstartedevent_update_properties(intern);
+	phongo_commandstartedevent_update_properties(object, event);
 }

--- a/src/MongoDB/Monitoring/CommandStartedEvent.c
+++ b/src/MongoDB/Monitoring/CommandStartedEvent.c
@@ -45,6 +45,7 @@ static void phongo_commandstartedevent_update_properties(zend_object* object, co
 {
 	char              operation_id[24], request_id[24];
 	phongo_bson_state command_state;
+	int64_t           server_connection_id = mongoc_apm_command_started_get_server_connection_id_int64(event);
 
 	PHONGO_BSON_INIT_STATE(command_state);
 
@@ -76,10 +77,16 @@ static void phongo_commandstartedevent_update_properties(zend_object* object, co
 	}
 
 	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (mongoc_apm_command_started_get_server_connection_id_int64(event) == -1) {
+	if (server_connection_id == -1) {
 		zend_update_property_null(phongo_commandstartedevent_ce, object, ZEND_STRL("serverConnectionId"));
 	} else {
-		zend_update_property_long(phongo_commandstartedevent_ce, object, ZEND_STRL("serverConnectionId"), mongoc_apm_command_started_get_server_connection_id_int64(event));
+#if SIZEOF_ZEND_LONG == 4
+		if (server_connection_id > INT32_MAX || server_connection_id < INT32_MIN) {
+			zend_error(E_WARNING, "Truncating 64-bit value %" PRId64 " for serverConnectionId", server_connection_id);
+		}
+#endif
+
+		zend_update_property_long(phongo_commandstartedevent_ce, object, ZEND_STRL("serverConnectionId"), server_connection_id);
 	}
 }
 

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -33,227 +33,125 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_CommandSucceededEvent)
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getCommandName)
 {
-	PHONGO_INTERN_FROM_THIS(commandsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->command_name);
+	PHONGO_RETURN_PROPERTY(commandsucceededevent, "commandName");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getDatabaseName)
 {
-	PHONGO_INTERN_FROM_THIS(commandsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->database_name);
+	PHONGO_RETURN_PROPERTY(commandsucceededevent, "databaseName");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getDurationMicros)
 {
-	PHONGO_INTERN_FROM_THIS(commandsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETURN_LONG(intern->duration_micros);
+	PHONGO_RETURN_PROPERTY(commandsucceededevent, "duration");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getHost)
 {
-	PHONGO_INTERN_FROM_THIS(commandsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->host.host);
+	PHONGO_RETURN_PROPERTY(commandsucceededevent, "host");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getOperationId)
 {
-	PHONGO_INTERN_FROM_THIS(commandsucceededevent);
-
-	char operation_id[24];
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
-	RETVAL_STRING(operation_id);
+	PHONGO_RETURN_PROPERTY(commandsucceededevent, "operationId");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getPort)
 {
-	PHONGO_INTERN_FROM_THIS(commandsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_LONG(intern->host.port);
+	PHONGO_RETURN_PROPERTY(commandsucceededevent, "port");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getReply)
 {
-	PHONGO_INTERN_FROM_THIS(commandsucceededevent);
-
-	phongo_bson_state state;
-
-	PHONGO_BSON_INIT_STATE(state);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!phongo_bson_to_zval_ex(intern->reply, &state)) {
-		zval_ptr_dtor(&state.zchild);
-		return;
-	}
-
-	RETURN_ZVAL(&state.zchild, 0, 1);
+	PHONGO_RETURN_PROPERTY(commandsucceededevent, "reply");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getRequestId)
 {
-	PHONGO_INTERN_FROM_THIS(commandsucceededevent);
-
-	char request_id[24];
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
-	RETVAL_STRING(request_id);
+	PHONGO_RETURN_PROPERTY(commandsucceededevent, "requestId");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getServiceId)
 {
-	PHONGO_INTERN_FROM_THIS(commandsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!intern->has_service_id) {
-		RETURN_NULL();
-	}
-
-	phongo_objectid_new(return_value, &intern->service_id);
+	PHONGO_RETURN_PROPERTY(commandsucceededevent, "serviceId");
 }
 
 static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getServerConnectionId)
 {
-	PHONGO_INTERN_FROM_THIS(commandsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (intern->server_connection_id == -1) {
-		RETURN_NULL();
-	}
-
-#if SIZEOF_ZEND_LONG == 4
-	if (intern->server_connection_id > INT32_MAX || intern->server_connection_id < INT32_MIN) {
-		zend_error(E_WARNING, "Truncating 64-bit value %" PRId64 " for serverConnectionId", intern->server_connection_id);
-	}
-#endif
-
-	RETURN_LONG(intern->server_connection_id);
+	PHONGO_RETURN_PROPERTY(commandsucceededevent, "serverConnectionId");
 }
 
-static void phongo_commandsucceededevent_update_properties(phongo_commandsucceededevent_t* intern)
+static void phongo_commandsucceededevent_update_properties(zend_object* object, const mongoc_apm_command_succeeded_t* event)
 {
 	char              operation_id[24], request_id[24];
 	phongo_bson_state reply_state;
 
 	PHONGO_BSON_INIT_STATE(reply_state);
 
-	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
-	zend_update_property_long(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
-	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("commandName"), intern->command_name);
-	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("databaseName"), intern->database_name);
-	zend_update_property_long(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("duration"), intern->duration_micros);
+	zend_update_property_string(phongo_commandsucceededevent_ce, object, ZEND_STRL("host"), mongoc_apm_command_succeeded_get_host(event)->host);
+	zend_update_property_long(phongo_commandsucceededevent_ce, object, ZEND_STRL("port"), mongoc_apm_command_succeeded_get_host(event)->port);
+	zend_update_property_string(phongo_commandsucceededevent_ce, object, ZEND_STRL("commandName"), mongoc_apm_command_succeeded_get_command_name(event));
+	zend_update_property_string(phongo_commandsucceededevent_ce, object, ZEND_STRL("databaseName"), mongoc_apm_command_succeeded_get_database_name(event));
+	zend_update_property_long(phongo_commandsucceededevent_ce, object, ZEND_STRL("duration"), mongoc_apm_command_succeeded_get_duration(event));
 
-	if (phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
-		zend_update_property(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("reply"), &reply_state.zchild);
+	if (phongo_bson_to_zval_ex(mongoc_apm_command_succeeded_get_reply(event), &reply_state)) {
+		zend_update_property(phongo_commandsucceededevent_ce, object, ZEND_STRL("reply"), &reply_state.zchild);
 	}
 	zval_ptr_dtor(&reply_state.zchild);
 
-	snprintf(operation_id, sizeof(operation_id), "%" PRId64, intern->operation_id);
-	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("operationId"), operation_id);
+	snprintf(operation_id, sizeof(operation_id), "%" PRId64, mongoc_apm_command_succeeded_get_operation_id(event));
+	zend_update_property_string(phongo_commandsucceededevent_ce, object, ZEND_STRL("operationId"), operation_id);
 
-	snprintf(request_id, sizeof(request_id), "%" PRId64, intern->request_id);
-	zend_update_property_string(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("requestId"), request_id);
+	snprintf(request_id, sizeof(request_id), "%" PRId64, mongoc_apm_command_succeeded_get_request_id(event));
+	zend_update_property_string(phongo_commandsucceededevent_ce, object, ZEND_STRL("requestId"), request_id);
 
-	if (intern->has_service_id) {
+	if (mongoc_apm_command_succeeded_get_service_id(event)) {
 		zval service_id;
 
-		if (phongo_objectid_new(&service_id, &intern->service_id)) {
-			zend_update_property(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("serviceId"), &service_id);
+		if (phongo_objectid_new(&service_id, mongoc_apm_command_succeeded_get_service_id(event))) {
+			zend_update_property(phongo_commandsucceededevent_ce, object, ZEND_STRL("serviceId"), &service_id);
 			zval_ptr_dtor(&service_id);
 		}
 	} else {
-		zend_update_property_null(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("serviceId"));
+		zend_update_property_null(phongo_commandsucceededevent_ce, object, ZEND_STRL("serviceId"));
 	}
 
 	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (intern->server_connection_id == -1) {
-		zend_update_property_null(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("serverConnectionId"));
+	if (mongoc_apm_command_succeeded_get_server_connection_id_int64(event) == -1) {
+		zend_update_property_null(phongo_commandsucceededevent_ce, object, ZEND_STRL("serverConnectionId"));
 	} else {
-		zend_update_property_long(phongo_commandsucceededevent_ce, &intern->std, ZEND_STRL("serverConnectionId"), intern->server_connection_id);
+		zend_update_property_long(phongo_commandsucceededevent_ce, object, ZEND_STRL("serverConnectionId"), mongoc_apm_command_succeeded_get_server_connection_id_int64(event));
 	}
-}
-
-/* MongoDB\Driver\Monitoring\CommandSucceededEvent object handlers */
-static zend_object_handlers phongo_handler_commandsucceededevent;
-
-static void phongo_commandsucceededevent_free_object(zend_object* object)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(commandsucceededevent, object);
-
-	zend_object_std_dtor(&intern->std);
-
-	if (intern->reply) {
-		bson_destroy(intern->reply);
-	}
-
-	if (intern->command_name) {
-		efree(intern->command_name);
-	}
-
-	if (intern->database_name) {
-		efree(intern->database_name);
-	}
-}
-
-static zend_object* phongo_commandsucceededevent_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(commandsucceededevent, class_type);
-
-	intern->std.handlers = &phongo_handler_commandsucceededevent;
-
-	return &intern->std;
 }
 
 void phongo_commandsucceededevent_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_commandsucceededevent_ce                = register_class_MongoDB_Driver_Monitoring_CommandSucceededEvent();
-	phongo_commandsucceededevent_ce->create_object = phongo_commandsucceededevent_create_object;
-
-	memcpy(&phongo_handler_commandsucceededevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_commandsucceededevent.free_obj = phongo_commandsucceededevent_free_object;
-	phongo_handler_commandsucceededevent.offset   = XtOffsetOf(phongo_commandsucceededevent_t, std);
+	phongo_commandsucceededevent_ce = register_class_MongoDB_Driver_Monitoring_CommandSucceededEvent();
 }
 
 void phongo_commandsucceededevent_init(zval* return_value, const mongoc_apm_command_succeeded_t* event)
 {
-	PHONGO_INTERN_INIT_EX(commandsucceededevent, return_value);
+	PHONGO_OBJECT_INIT_EX(commandsucceededevent, return_value);
 
-	memcpy(&intern->host, mongoc_apm_command_succeeded_get_host(event), sizeof(mongoc_host_list_t));
-
-	intern->command_name         = estrdup(mongoc_apm_command_succeeded_get_command_name(event));
-	intern->database_name        = estrdup(mongoc_apm_command_succeeded_get_database_name(event));
-	intern->server_id            = mongoc_apm_command_succeeded_get_server_id(event);
-	intern->operation_id         = mongoc_apm_command_succeeded_get_operation_id(event);
-	intern->request_id           = mongoc_apm_command_succeeded_get_request_id(event);
-	intern->duration_micros      = mongoc_apm_command_succeeded_get_duration(event);
-	intern->reply                = bson_copy(mongoc_apm_command_succeeded_get_reply(event));
-	intern->server_connection_id = mongoc_apm_command_succeeded_get_server_connection_id_int64(event);
-	intern->has_service_id       = mongoc_apm_command_succeeded_get_service_id(event) != NULL;
-
-	if (intern->has_service_id) {
-		bson_oid_copy(mongoc_apm_command_succeeded_get_service_id(event), &intern->service_id);
-	}
-
-	phongo_commandsucceededevent_update_properties(intern);
+	phongo_commandsucceededevent_update_properties(object, event);
 }

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -31,75 +31,16 @@ zend_class_entry* phongo_commandsucceededevent_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_CommandSucceededEvent)
 
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getCommandName)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandsucceededevent, "commandName");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getDatabaseName)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandsucceededevent, "databaseName");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getDurationMicros)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandsucceededevent, "duration");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getHost)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandsucceededevent, "host");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getOperationId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandsucceededevent, "operationId");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getPort)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandsucceededevent, "port");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getReply)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandsucceededevent, "reply");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getRequestId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandsucceededevent, "requestId");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getServiceId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandsucceededevent, "serviceId");
-}
-
-static PHP_METHOD(MongoDB_Driver_Monitoring_CommandSucceededEvent, getServerConnectionId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(commandsucceededevent, "serverConnectionId");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandSucceededEvent, getCommandName, commandsucceededevent, "commandName")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandSucceededEvent, getDatabaseName, commandsucceededevent, "databaseName")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandSucceededEvent, getDurationMicros, commandsucceededevent, "duration")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandSucceededEvent, getHost, commandsucceededevent, "host")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandSucceededEvent, getOperationId, commandsucceededevent, "operationId")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandSucceededEvent, getPort, commandsucceededevent, "port")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandSucceededEvent, getReply, commandsucceededevent, "reply")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandSucceededEvent, getRequestId, commandsucceededevent, "requestId")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandSucceededEvent, getServiceId, commandsucceededevent, "serviceId")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_CommandSucceededEvent, getServerConnectionId, commandsucceededevent, "serverConnectionId")
 
 static void phongo_commandsucceededevent_update_properties(zend_object* object, const mongoc_apm_command_succeeded_t* event)
 {

--- a/src/MongoDB/Monitoring/CommandSucceededEvent.c
+++ b/src/MongoDB/Monitoring/CommandSucceededEvent.c
@@ -46,6 +46,7 @@ static void phongo_commandsucceededevent_update_properties(zend_object* object, 
 {
 	char              operation_id[24], request_id[24];
 	phongo_bson_state reply_state;
+	int64_t           server_connection_id = mongoc_apm_command_succeeded_get_server_connection_id_int64(event);
 
 	PHONGO_BSON_INIT_STATE(reply_state);
 
@@ -78,10 +79,16 @@ static void phongo_commandsucceededevent_update_properties(zend_object* object, 
 	}
 
 	/* TODO: Use MONGOC_NO_SERVER_CONNECTION_ID once it is added to libmongoc's public API (CDRIVER-4176) */
-	if (mongoc_apm_command_succeeded_get_server_connection_id_int64(event) == -1) {
+	if (server_connection_id == -1) {
 		zend_update_property_null(phongo_commandsucceededevent_ce, object, ZEND_STRL("serverConnectionId"));
 	} else {
-		zend_update_property_long(phongo_commandsucceededevent_ce, object, ZEND_STRL("serverConnectionId"), mongoc_apm_command_succeeded_get_server_connection_id_int64(event));
+#if SIZEOF_ZEND_LONG == 4
+		if (server_connection_id > INT32_MAX || server_connection_id < INT32_MIN) {
+			zend_error(E_WARNING, "Truncating 64-bit value %" PRId64 " for serverConnectionId", server_connection_id);
+		}
+#endif
+
+		zend_update_property_long(phongo_commandsucceededevent_ce, object, ZEND_STRL("serverConnectionId"), server_connection_id);
 	}
 }
 

--- a/src/MongoDB/Monitoring/ServerClosedEvent.c
+++ b/src/MongoDB/Monitoring/ServerClosedEvent.c
@@ -27,29 +27,9 @@ zend_class_entry* phongo_serverclosedevent_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_ServerClosedEvent)
 
-/* Returns this event's host */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, getHost)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverclosedevent, "host");
-}
-
-/* Returns this event's port */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, getPort)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverclosedevent, "port");
-}
-
-/* Returns this event's topology id */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, getTopologyId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverclosedevent, "topologyId");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerClosedEvent, getHost, serverclosedevent, "host")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerClosedEvent, getPort, serverclosedevent, "port")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerClosedEvent, getTopologyId, serverclosedevent, "topologyId")
 
 static void phongo_serverclosedevent_update_properties(zend_object* object, const mongoc_apm_server_closed_t* event)
 {

--- a/src/MongoDB/Monitoring/ServerClosedEvent.c
+++ b/src/MongoDB/Monitoring/ServerClosedEvent.c
@@ -30,81 +30,51 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_ServerClosedEvent)
 /* Returns this event's host */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, getHost)
 {
-	PHONGO_INTERN_FROM_THIS(serverclosedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->host.host);
+	PHONGO_RETURN_PROPERTY(serverclosedevent, "host");
 }
 
 /* Returns this event's port */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, getPort)
 {
-	PHONGO_INTERN_FROM_THIS(serverclosedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_LONG(intern->host.port);
+	PHONGO_RETURN_PROPERTY(serverclosedevent, "port");
 }
 
 /* Returns this event's topology id */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerClosedEvent, getTopologyId)
 {
-	PHONGO_INTERN_FROM_THIS(serverclosedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	phongo_objectid_new(return_value, &intern->topology_id);
+	PHONGO_RETURN_PROPERTY(serverclosedevent, "topologyId");
 }
 
-static void phongo_serverclosedevent_update_properties(phongo_serverclosedevent_t* intern)
+static void phongo_serverclosedevent_update_properties(zend_object* object, const mongoc_apm_server_closed_t* event)
 {
-	zval topology_id;
+	zval       ztopology_id;
+	bson_oid_t topology_id;
 
-	zend_update_property_string(phongo_serverclosedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
-	zend_update_property_long(phongo_serverclosedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+	zend_update_property_string(phongo_serverclosedevent_ce, object, ZEND_STRL("host"), mongoc_apm_server_closed_get_host(event)->host);
+	zend_update_property_long(phongo_serverclosedevent_ce, object, ZEND_STRL("port"), mongoc_apm_server_closed_get_host(event)->port);
 
-	if (phongo_objectid_new(&topology_id, &intern->topology_id)) {
-		zend_update_property(phongo_serverclosedevent_ce, &intern->std, ZEND_STRL("topologyId"), &topology_id);
-		zval_ptr_dtor(&topology_id);
+	mongoc_apm_server_closed_get_topology_id(event, &topology_id);
+
+	if (phongo_objectid_new(&ztopology_id, &topology_id)) {
+		zend_update_property(phongo_serverclosedevent_ce, object, ZEND_STRL("topologyId"), &ztopology_id);
+		zval_ptr_dtor(&ztopology_id);
 	}
-}
-
-/* MongoDB\Driver\Monitoring\ServerClosedEvent object handlers */
-static zend_object_handlers phongo_handler_serverclosedevent;
-
-static void phongo_serverclosedevent_free_object(zend_object* object)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serverclosedevent, object);
-
-	zend_object_std_dtor(&intern->std);
-}
-
-static zend_object* phongo_serverclosedevent_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(serverclosedevent, class_type);
-
-	intern->std.handlers = &phongo_handler_serverclosedevent;
-
-	return &intern->std;
 }
 
 void phongo_serverclosedevent_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_serverclosedevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerClosedEvent();
-	phongo_serverclosedevent_ce->create_object = phongo_serverclosedevent_create_object;
-
-	memcpy(&phongo_handler_serverclosedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serverclosedevent.free_obj = phongo_serverclosedevent_free_object;
-	phongo_handler_serverclosedevent.offset   = XtOffsetOf(phongo_serverclosedevent_t, std);
+	phongo_serverclosedevent_ce = register_class_MongoDB_Driver_Monitoring_ServerClosedEvent();
 }
 
 void phongo_serverclosedevent_init(zval* return_value, const mongoc_apm_server_closed_t* event)
 {
-	PHONGO_INTERN_INIT_EX(serverclosedevent, return_value);
+	PHONGO_OBJECT_INIT_EX(serverclosedevent, return_value);
 
-	memcpy(&intern->host, mongoc_apm_server_closed_get_host(event), sizeof(mongoc_host_list_t));
-	mongoc_apm_server_closed_get_topology_id(event, &intern->topology_id);
-
-	phongo_serverclosedevent_update_properties(intern);
+	phongo_serverclosedevent_update_properties(object, event);
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.c
@@ -26,45 +26,11 @@ zend_class_entry* phongo_serverheartbeatfailedevent_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent)
 
-/* Returns this event's duration in microseconds */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getDurationMicros)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatfailedevent, "duration");
-}
-
-/* Returns the error associated with the event */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getError)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatfailedevent, "error");
-}
-
-/* Returns this event's host */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getHost)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatfailedevent, "host");
-}
-
-/* Returns this event's port */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getPort)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatfailedevent, "port");
-}
-
-/* Returns whether this event came from an awaitable hello */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, isAwaited)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatfailedevent, "awaited");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getDurationMicros, serverheartbeatfailedevent, "duration")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getError, serverheartbeatfailedevent, "error")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getHost, serverheartbeatfailedevent, "host")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getPort, serverheartbeatfailedevent, "port")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, isAwaited, serverheartbeatfailedevent, "awaited")
 
 static void phongo_serverheartbeatfailedevent_update_properties(zend_object* object, const mongoc_apm_server_heartbeat_failed_t* event)
 {

--- a/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatFailedEvent.c
@@ -29,113 +29,76 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent
 /* Returns this event's duration in microseconds */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getDurationMicros)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_LONG(intern->duration_micros);
+	PHONGO_RETURN_PROPERTY(serverheartbeatfailedevent, "duration");
 }
 
 /* Returns the error associated with the event */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getError)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETURN_ZVAL(&intern->z_error, 1, 0);
+	PHONGO_RETURN_PROPERTY(serverheartbeatfailedevent, "error");
 }
 
 /* Returns this event's host */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getHost)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->host.host);
+	PHONGO_RETURN_PROPERTY(serverheartbeatfailedevent, "host");
 }
 
 /* Returns this event's port */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, getPort)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_LONG(intern->host.port);
+	PHONGO_RETURN_PROPERTY(serverheartbeatfailedevent, "port");
 }
 
 /* Returns whether this event came from an awaitable hello */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent, isAwaited)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatfailedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_BOOL(intern->awaited);
+	PHONGO_RETURN_PROPERTY(serverheartbeatfailedevent, "awaited");
 }
 
-static void phongo_serverheartbeatfailedevent_update_properties(phongo_serverheartbeatfailedevent_t* intern)
+static void phongo_serverheartbeatfailedevent_update_properties(zend_object* object, const mongoc_apm_server_heartbeat_failed_t* event)
 {
-	zend_update_property_string(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
-	zend_update_property_long(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
-	zend_update_property_bool(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("awaited"), intern->awaited);
-	zend_update_property_long(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("duration"), intern->duration_micros);
-	zend_update_property(phongo_serverheartbeatfailedevent_ce, &intern->std, ZEND_STRL("error"), &intern->z_error);
-}
+	zend_update_property_string(phongo_serverheartbeatfailedevent_ce, object, ZEND_STRL("host"), mongoc_apm_server_heartbeat_failed_get_host(event)->host);
+	zend_update_property_long(phongo_serverheartbeatfailedevent_ce, object, ZEND_STRL("port"), mongoc_apm_server_heartbeat_failed_get_host(event)->port);
+	zend_update_property_bool(phongo_serverheartbeatfailedevent_ce, object, ZEND_STRL("awaited"), mongoc_apm_server_heartbeat_failed_get_awaited(event));
+	zend_update_property_long(phongo_serverheartbeatfailedevent_ce, object, ZEND_STRL("duration"), mongoc_apm_server_heartbeat_failed_get_duration(event));
 
-/* MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent object handlers */
-static zend_object_handlers phongo_handler_serverheartbeatfailedevent;
+	{
+		bson_error_t tmp_error = { 0 };
+		zval         zerror;
 
-static void phongo_serverheartbeatfailedevent_free_object(zend_object* object)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serverheartbeatfailedevent, object);
+		/* We need to process and convert the error right here, otherwise
+		 * debug_info will turn into a recursive loop, and with the wrong trace
+		 * locations */
+		mongoc_apm_server_heartbeat_failed_get_error(event, &tmp_error);
 
-	zend_object_std_dtor(&intern->std);
+		object_init_ex(&zerror, phongo_exception_from_mongoc_domain(tmp_error.domain, tmp_error.code));
+		zend_update_property_string(zend_ce_exception, Z_OBJ_P(&zerror), ZEND_STRL("message"), tmp_error.message);
+		zend_update_property_long(zend_ce_exception, Z_OBJ_P(&zerror), ZEND_STRL("code"), tmp_error.code);
 
-	if (!Z_ISUNDEF(intern->z_error)) {
-		zval_ptr_dtor(&intern->z_error);
+		zend_update_property(phongo_serverheartbeatfailedevent_ce, object, ZEND_STRL("error"), &zerror);
+		zval_ptr_dtor(&zerror);
 	}
-}
-
-static zend_object* phongo_serverheartbeatfailedevent_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(serverheartbeatfailedevent, class_type);
-
-	intern->std.handlers = &phongo_handler_serverheartbeatfailedevent;
-
-	return &intern->std;
 }
 
 void phongo_serverheartbeatfailedevent_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_serverheartbeatfailedevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent();
-	phongo_serverheartbeatfailedevent_ce->create_object = phongo_serverheartbeatfailedevent_create_object;
-
-	memcpy(&phongo_handler_serverheartbeatfailedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serverheartbeatfailedevent.free_obj = phongo_serverheartbeatfailedevent_free_object;
-	phongo_handler_serverheartbeatfailedevent.offset   = XtOffsetOf(phongo_serverheartbeatfailedevent_t, std);
+	phongo_serverheartbeatfailedevent_ce = register_class_MongoDB_Driver_Monitoring_ServerHeartbeatFailedEvent();
 }
 
 void phongo_serverheartbeatfailedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_failed_t* event)
 {
-	PHONGO_INTERN_INIT_EX(serverheartbeatfailedevent, return_value);
+	PHONGO_OBJECT_INIT_EX(serverheartbeatfailedevent, return_value);
 
-	bson_error_t tmp_error = { 0 };
-
-	memcpy(&intern->host, mongoc_apm_server_heartbeat_failed_get_host(event), sizeof(mongoc_host_list_t));
-	intern->awaited         = mongoc_apm_server_heartbeat_failed_get_awaited(event);
-	intern->duration_micros = mongoc_apm_server_heartbeat_failed_get_duration(event);
-
-	/* We need to process and convert the error right here, otherwise
-	 * debug_info will turn into a recursive loop, and with the wrong trace
-	 * locations */
-	mongoc_apm_server_heartbeat_failed_get_error(event, &tmp_error);
-
-	object_init_ex(&intern->z_error, phongo_exception_from_mongoc_domain(tmp_error.domain, tmp_error.code));
-	zend_update_property_string(zend_ce_exception, Z_OBJ_P(&intern->z_error), ZEND_STRL("message"), tmp_error.message);
-	zend_update_property_long(zend_ce_exception, Z_OBJ_P(&intern->z_error), ZEND_STRL("code"), tmp_error.code);
-
-	phongo_serverheartbeatfailedevent_update_properties(intern);
+	phongo_serverheartbeatfailedevent_update_properties(object, event);
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.c
@@ -28,75 +28,42 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEven
 /* Returns this event's host */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, getHost)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatstartedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->host.host);
+	PHONGO_RETURN_PROPERTY(serverheartbeatstartedevent, "host");
 }
 
 /* Returns this event's port */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, getPort)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatstartedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_LONG(intern->host.port);
+	PHONGO_RETURN_PROPERTY(serverheartbeatstartedevent, "port");
 }
 
 /* Returns whether this event came from an awaitable hello */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, isAwaited)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatstartedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_BOOL(intern->awaited);
+	PHONGO_RETURN_PROPERTY(serverheartbeatstartedevent, "awaited");
 }
 
-static void phongo_serverheartbeatstartedevent_update_properties(phongo_serverheartbeatstartedevent_t* intern)
+static void phongo_serverheartbeatstartedevent_update_properties(zend_object* object, const mongoc_apm_server_heartbeat_started_t* event)
 {
-	zend_update_property_string(phongo_serverheartbeatstartedevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
-	zend_update_property_long(phongo_serverheartbeatstartedevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
-	zend_update_property_bool(phongo_serverheartbeatstartedevent_ce, &intern->std, ZEND_STRL("awaited"), intern->awaited);
-}
-
-/* MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent object handlers */
-static zend_object_handlers phongo_handler_serverheartbeatstartedevent;
-
-static void phongo_serverheartbeatstartedevent_free_object(zend_object* object)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serverheartbeatstartedevent, object);
-
-	zend_object_std_dtor(&intern->std);
-}
-
-static zend_object* phongo_serverheartbeatstartedevent_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(serverheartbeatstartedevent, class_type);
-
-	intern->std.handlers = &phongo_handler_serverheartbeatstartedevent;
-
-	return &intern->std;
+	zend_update_property_string(phongo_serverheartbeatstartedevent_ce, object, ZEND_STRL("host"), mongoc_apm_server_heartbeat_started_get_host(event)->host);
+	zend_update_property_long(phongo_serverheartbeatstartedevent_ce, object, ZEND_STRL("port"), mongoc_apm_server_heartbeat_started_get_host(event)->port);
+	zend_update_property_bool(phongo_serverheartbeatstartedevent_ce, object, ZEND_STRL("awaited"), mongoc_apm_server_heartbeat_started_get_awaited(event));
 }
 
 void phongo_serverheartbeatstartedevent_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_serverheartbeatstartedevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent();
-	phongo_serverheartbeatstartedevent_ce->create_object = phongo_serverheartbeatstartedevent_create_object;
-
-	memcpy(&phongo_handler_serverheartbeatstartedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serverheartbeatstartedevent.free_obj = phongo_serverheartbeatstartedevent_free_object;
-	phongo_handler_serverheartbeatstartedevent.offset   = XtOffsetOf(phongo_serverheartbeatstartedevent_t, std);
+	phongo_serverheartbeatstartedevent_ce = register_class_MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent();
 }
 
 void phongo_serverheartbeatstartedevent_init(zval* return_value, const mongoc_apm_server_heartbeat_started_t* event)
 {
-	PHONGO_INTERN_INIT_EX(serverheartbeatstartedevent, return_value);
+	PHONGO_OBJECT_INIT_EX(serverheartbeatstartedevent, return_value);
 
-	memcpy(&intern->host, mongoc_apm_server_heartbeat_started_get_host(event), sizeof(mongoc_host_list_t));
-	intern->awaited = mongoc_apm_server_heartbeat_started_get_awaited(event);
-
-	phongo_serverheartbeatstartedevent_update_properties(intern);
+	phongo_serverheartbeatstartedevent_update_properties(object, event);
 }

--- a/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatStartedEvent.c
@@ -25,29 +25,9 @@ zend_class_entry* phongo_serverheartbeatstartedevent_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent)
 
-/* Returns this event's host */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, getHost)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatstartedevent, "host");
-}
-
-/* Returns this event's port */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, getPort)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatstartedevent, "port");
-}
-
-/* Returns whether this event came from an awaitable hello */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, isAwaited)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatstartedevent, "awaited");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, getHost, serverheartbeatstartedevent, "host")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, getPort, serverheartbeatstartedevent, "port")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatStartedEvent, isAwaited, serverheartbeatstartedevent, "awaited")
 
 static void phongo_serverheartbeatstartedevent_update_properties(zend_object* object, const mongoc_apm_server_heartbeat_started_t* event)
 {

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
@@ -25,45 +25,11 @@ zend_class_entry* phongo_serverheartbeatsucceededevent_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent)
 
-/* Returns this event's duration in microseconds */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getDurationMicros)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatsucceededevent, "duration");
-}
-
-/* Returns this event's host */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getHost)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatsucceededevent, "host");
-}
-
-/* Returns this event's port */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getPort)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatsucceededevent, "port");
-}
-
-/* Returns this event's reply */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getReply)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatsucceededevent, "reply");
-}
-
-/* Returns whether this event came from an awaitable hello */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, isAwaited)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serverheartbeatsucceededevent, "awaited");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getDurationMicros, serverheartbeatsucceededevent, "duration")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getHost, serverheartbeatsucceededevent, "host")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getPort, serverheartbeatsucceededevent, "port")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getReply, serverheartbeatsucceededevent, "reply")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, isAwaited, serverheartbeatsucceededevent, "awaited")
 
 static void phongo_serverheartbeatsucceededevent_update_properties(zend_object* object, const mongoc_apm_server_heartbeat_succeeded_t* event)
 {

--- a/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
+++ b/src/MongoDB/Monitoring/ServerHeartbeatSucceededEvent.c
@@ -28,120 +28,68 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEv
 /* Returns this event's duration in microseconds */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getDurationMicros)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_LONG(intern->duration_micros);
+	PHONGO_RETURN_PROPERTY(serverheartbeatsucceededevent, "duration");
 }
 
 /* Returns this event's host */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getHost)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->host.host);
+	PHONGO_RETURN_PROPERTY(serverheartbeatsucceededevent, "host");
 }
 
 /* Returns this event's port */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getPort)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_LONG(intern->host.port);
+	PHONGO_RETURN_PROPERTY(serverheartbeatsucceededevent, "port");
 }
 
 /* Returns this event's reply */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, getReply)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatsucceededevent);
-
-	phongo_bson_state state;
-
-	PHONGO_BSON_INIT_STATE(state);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!phongo_bson_to_zval_ex(intern->reply, &state)) {
-		zval_ptr_dtor(&state.zchild);
-		return;
-	}
-
-	RETURN_ZVAL(&state.zchild, 0, 1);
+	PHONGO_RETURN_PROPERTY(serverheartbeatsucceededevent, "reply");
 }
 
 /* Returns whether this event came from an awaitable hello */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent, isAwaited)
 {
-	PHONGO_INTERN_FROM_THIS(serverheartbeatsucceededevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_BOOL(intern->awaited);
+	PHONGO_RETURN_PROPERTY(serverheartbeatsucceededevent, "awaited");
 }
 
-static void phongo_serverheartbeatsucceededevent_update_properties(phongo_serverheartbeatsucceededevent_t* intern)
+static void phongo_serverheartbeatsucceededevent_update_properties(zend_object* object, const mongoc_apm_server_heartbeat_succeeded_t* event)
 {
 	phongo_bson_state reply_state;
 
 	PHONGO_BSON_INIT_STATE(reply_state);
 
-	zend_update_property_string(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
-	zend_update_property_long(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
-	zend_update_property_bool(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("awaited"), intern->awaited);
-	zend_update_property_long(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("duration"), intern->duration_micros);
+	zend_update_property_string(phongo_serverheartbeatsucceededevent_ce, object, ZEND_STRL("host"), mongoc_apm_server_heartbeat_succeeded_get_host(event)->host);
+	zend_update_property_long(phongo_serverheartbeatsucceededevent_ce, object, ZEND_STRL("port"), mongoc_apm_server_heartbeat_succeeded_get_host(event)->port);
+	zend_update_property_bool(phongo_serverheartbeatsucceededevent_ce, object, ZEND_STRL("awaited"), mongoc_apm_server_heartbeat_succeeded_get_awaited(event));
+	zend_update_property_long(phongo_serverheartbeatsucceededevent_ce, object, ZEND_STRL("duration"), mongoc_apm_server_heartbeat_succeeded_get_duration(event));
 
-	if (phongo_bson_to_zval_ex(intern->reply, &reply_state)) {
-		zend_update_property(phongo_serverheartbeatsucceededevent_ce, &intern->std, ZEND_STRL("reply"), &reply_state.zchild);
+	if (phongo_bson_to_zval_ex(mongoc_apm_server_heartbeat_succeeded_get_reply(event), &reply_state)) {
+		zend_update_property(phongo_serverheartbeatsucceededevent_ce, object, ZEND_STRL("reply"), &reply_state.zchild);
 	}
 	zval_ptr_dtor(&reply_state.zchild);
 }
 
-/* MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent object handlers */
-static zend_object_handlers phongo_handler_serverheartbeatsucceededevent;
-
-static void phongo_serverheartbeatsucceededevent_free_object(zend_object* object)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serverheartbeatsucceededevent, object);
-
-	zend_object_std_dtor(&intern->std);
-
-	if (intern->reply) {
-		bson_destroy(intern->reply);
-	}
-}
-
-static zend_object* phongo_serverheartbeatsucceededevent_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(serverheartbeatsucceededevent, class_type);
-
-	intern->std.handlers = &phongo_handler_serverheartbeatsucceededevent;
-
-	return &intern->std;
-}
-
 void phongo_serverheartbeatsucceededevent_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_serverheartbeatsucceededevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent();
-	phongo_serverheartbeatsucceededevent_ce->create_object = phongo_serverheartbeatsucceededevent_create_object;
-
-	memcpy(&phongo_handler_serverheartbeatsucceededevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serverheartbeatsucceededevent.free_obj = phongo_serverheartbeatsucceededevent_free_object;
-	phongo_handler_serverheartbeatsucceededevent.offset   = XtOffsetOf(phongo_serverheartbeatsucceededevent_t, std);
+	phongo_serverheartbeatsucceededevent_ce = register_class_MongoDB_Driver_Monitoring_ServerHeartbeatSucceededEvent();
 }
 
 void phongo_serverheartbeatsucceededevent_init(zval* return_value, const mongoc_apm_server_heartbeat_succeeded_t* event)
 {
-	PHONGO_INTERN_INIT_EX(serverheartbeatsucceededevent, return_value);
+	PHONGO_OBJECT_INIT_EX(serverheartbeatsucceededevent, return_value);
 
-	memcpy(&intern->host, mongoc_apm_server_heartbeat_succeeded_get_host(event), sizeof(mongoc_host_list_t));
-	intern->awaited         = mongoc_apm_server_heartbeat_succeeded_get_awaited(event);
-	intern->duration_micros = mongoc_apm_server_heartbeat_succeeded_get_duration(event);
-	intern->reply           = bson_copy(mongoc_apm_server_heartbeat_succeeded_get_reply(event));
-
-	phongo_serverheartbeatsucceededevent_update_properties(intern);
+	phongo_serverheartbeatsucceededevent_update_properties(object, event);
 }

--- a/src/MongoDB/Monitoring/ServerOpeningEvent.c
+++ b/src/MongoDB/Monitoring/ServerOpeningEvent.c
@@ -27,29 +27,9 @@ zend_class_entry* phongo_serveropeningevent_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_ServerOpeningEvent)
 
-/* Returns this event's host */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, getHost)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serveropeningevent, "host");
-}
-
-/* Returns this event's port */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, getPort)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serveropeningevent, "port");
-}
-
-/* Returns this event's topology id */
-static PHP_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, getTopologyId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(serveropeningevent, "topologyId");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerOpeningEvent, getHost, serveropeningevent, "host")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerOpeningEvent, getPort, serveropeningevent, "port")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_ServerOpeningEvent, getTopologyId, serveropeningevent, "topologyId")
 
 static void phongo_serveropeningevent_update_properties(zend_object* object, const mongoc_apm_server_opening_t* event)
 {

--- a/src/MongoDB/Monitoring/ServerOpeningEvent.c
+++ b/src/MongoDB/Monitoring/ServerOpeningEvent.c
@@ -30,81 +30,51 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_ServerOpeningEvent)
 /* Returns this event's host */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, getHost)
 {
-	PHONGO_INTERN_FROM_THIS(serveropeningevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_STRING(intern->host.host);
+	PHONGO_RETURN_PROPERTY(serveropeningevent, "host");
 }
 
 /* Returns this event's port */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, getPort)
 {
-	PHONGO_INTERN_FROM_THIS(serveropeningevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETVAL_LONG(intern->host.port);
+	PHONGO_RETURN_PROPERTY(serveropeningevent, "port");
 }
 
 /* Returns this event's topology id */
 static PHP_METHOD(MongoDB_Driver_Monitoring_ServerOpeningEvent, getTopologyId)
 {
-	PHONGO_INTERN_FROM_THIS(serveropeningevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	phongo_objectid_new(return_value, &intern->topology_id);
+	PHONGO_RETURN_PROPERTY(serveropeningevent, "topologyId");
 }
 
-static void phongo_serveropeningevent_update_properties(phongo_serveropeningevent_t* intern)
+static void phongo_serveropeningevent_update_properties(zend_object* object, const mongoc_apm_server_opening_t* event)
 {
-	zval topology_id;
+	zval       ztopology_id;
+	bson_oid_t topology_id;
 
-	zend_update_property_string(phongo_serveropeningevent_ce, &intern->std, ZEND_STRL("host"), intern->host.host);
-	zend_update_property_long(phongo_serveropeningevent_ce, &intern->std, ZEND_STRL("port"), intern->host.port);
+	zend_update_property_string(phongo_serveropeningevent_ce, object, ZEND_STRL("host"), mongoc_apm_server_opening_get_host(event)->host);
+	zend_update_property_long(phongo_serveropeningevent_ce, object, ZEND_STRL("port"), mongoc_apm_server_opening_get_host(event)->port);
 
-	if (phongo_objectid_new(&topology_id, &intern->topology_id)) {
-		zend_update_property(phongo_serveropeningevent_ce, &intern->std, ZEND_STRL("topologyId"), &topology_id);
-		zval_ptr_dtor(&topology_id);
+	mongoc_apm_server_opening_get_topology_id(event, &topology_id);
+
+	if (phongo_objectid_new(&ztopology_id, &topology_id)) {
+		zend_update_property(phongo_serveropeningevent_ce, object, ZEND_STRL("topologyId"), &ztopology_id);
+		zval_ptr_dtor(&ztopology_id);
 	}
-}
-
-/* MongoDB\Driver\Monitoring\ServerOpeningEvent object handlers */
-static zend_object_handlers phongo_handler_serveropeningevent;
-
-static void phongo_serveropeningevent_free_object(zend_object* object)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(serveropeningevent, object);
-
-	zend_object_std_dtor(&intern->std);
-}
-
-static zend_object* phongo_serveropeningevent_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(serveropeningevent, class_type);
-
-	intern->std.handlers = &phongo_handler_serveropeningevent;
-
-	return &intern->std;
 }
 
 void phongo_serveropeningevent_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_serveropeningevent_ce                = register_class_MongoDB_Driver_Monitoring_ServerOpeningEvent();
-	phongo_serveropeningevent_ce->create_object = phongo_serveropeningevent_create_object;
-
-	memcpy(&phongo_handler_serveropeningevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_serveropeningevent.free_obj = phongo_serveropeningevent_free_object;
-	phongo_handler_serveropeningevent.offset   = XtOffsetOf(phongo_serveropeningevent_t, std);
+	phongo_serveropeningevent_ce = register_class_MongoDB_Driver_Monitoring_ServerOpeningEvent();
 }
 
 void phongo_serveropeningevent_init(zval* return_value, const mongoc_apm_server_opening_t* event)
 {
-	PHONGO_INTERN_INIT_EX(serveropeningevent, return_value);
+	PHONGO_OBJECT_INIT_EX(serveropeningevent, return_value);
 
-	memcpy(&intern->host, mongoc_apm_server_opening_get_host(event), sizeof(mongoc_host_list_t));
-	mongoc_apm_server_opening_get_topology_id(event, &intern->topology_id);
-
-	phongo_serveropeningevent_update_properties(intern);
+	phongo_serveropeningevent_update_properties(object, event);
 }

--- a/src/MongoDB/Monitoring/TopologyClosedEvent.c
+++ b/src/MongoDB/Monitoring/TopologyClosedEvent.c
@@ -30,57 +30,32 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_TopologyClosedEvent)
 /* Returns this event's topology id */
 static PHP_METHOD(MongoDB_Driver_Monitoring_TopologyClosedEvent, getTopologyId)
 {
-	PHONGO_INTERN_FROM_THIS(topologyclosedevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	phongo_objectid_new(return_value, &intern->topology_id);
+	PHONGO_RETURN_PROPERTY(topologyclosedevent, "topologyId");
 }
 
-static void phongo_topologyclosedevent_update_properties(phongo_topologyclosedevent_t* intern)
+static void phongo_topologyclosedevent_update_properties(zend_object* object, const mongoc_apm_topology_closed_t* event)
 {
-	zval topology_id;
+	zval       ztopology_id;
+	bson_oid_t topology_id;
 
-	if (phongo_objectid_new(&topology_id, &intern->topology_id)) {
-		zend_update_property(phongo_topologyclosedevent_ce, &intern->std, ZEND_STRL("topologyId"), &topology_id);
-		zval_ptr_dtor(&topology_id);
+	mongoc_apm_topology_closed_get_topology_id(event, &topology_id);
+
+	if (phongo_objectid_new(&ztopology_id, &topology_id)) {
+		zend_update_property(phongo_topologyclosedevent_ce, object, ZEND_STRL("topologyId"), &ztopology_id);
+		zval_ptr_dtor(&ztopology_id);
 	}
-}
-
-/* MongoDB\Driver\Monitoring\TopologyClosedEvent object handlers */
-static zend_object_handlers phongo_handler_topologyclosedevent;
-
-static void phongo_topologyclosedevent_free_object(zend_object* object)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(topologyclosedevent, object);
-
-	zend_object_std_dtor(&intern->std);
-}
-
-static zend_object* phongo_topologyclosedevent_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(topologyclosedevent, class_type);
-
-	intern->std.handlers = &phongo_handler_topologyclosedevent;
-
-	return &intern->std;
 }
 
 void phongo_topologyclosedevent_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_topologyclosedevent_ce                = register_class_MongoDB_Driver_Monitoring_TopologyClosedEvent();
-	phongo_topologyclosedevent_ce->create_object = phongo_topologyclosedevent_create_object;
-
-	memcpy(&phongo_handler_topologyclosedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_topologyclosedevent.free_obj = phongo_topologyclosedevent_free_object;
-	phongo_handler_topologyclosedevent.offset   = XtOffsetOf(phongo_topologyclosedevent_t, std);
+	phongo_topologyclosedevent_ce = register_class_MongoDB_Driver_Monitoring_TopologyClosedEvent();
 }
 
 void phongo_topologyclosedevent_init(zval* return_value, const mongoc_apm_topology_closed_t* event)
 {
-	PHONGO_INTERN_INIT_EX(topologyclosedevent, return_value);
+	PHONGO_OBJECT_INIT_EX(topologyclosedevent, return_value);
 
-	mongoc_apm_topology_closed_get_topology_id(event, &intern->topology_id);
-
-	phongo_topologyclosedevent_update_properties(intern);
+	phongo_topologyclosedevent_update_properties(object, event);
 }

--- a/src/MongoDB/Monitoring/TopologyClosedEvent.c
+++ b/src/MongoDB/Monitoring/TopologyClosedEvent.c
@@ -27,13 +27,7 @@ zend_class_entry* phongo_topologyclosedevent_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_TopologyClosedEvent)
 
-/* Returns this event's topology id */
-static PHP_METHOD(MongoDB_Driver_Monitoring_TopologyClosedEvent, getTopologyId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(topologyclosedevent, "topologyId");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_TopologyClosedEvent, getTopologyId, topologyclosedevent, "topologyId")
 
 static void phongo_topologyclosedevent_update_properties(zend_object* object, const mongoc_apm_topology_closed_t* event)
 {

--- a/src/MongoDB/Monitoring/TopologyOpeningEvent.c
+++ b/src/MongoDB/Monitoring/TopologyOpeningEvent.c
@@ -27,13 +27,7 @@ zend_class_entry* phongo_topologyopeningevent_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_TopologyOpeningEvent)
 
-/* Returns this event's topology id */
-static PHP_METHOD(MongoDB_Driver_Monitoring_TopologyOpeningEvent, getTopologyId)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(topologyopeningevent, "topologyId");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_Monitoring_TopologyOpeningEvent, getTopologyId, topologyopeningevent, "topologyId")
 
 static void phongo_topologyopeningevent_update_properties(zend_object* object, const mongoc_apm_topology_opening_t* event)
 {

--- a/src/MongoDB/Monitoring/TopologyOpeningEvent.c
+++ b/src/MongoDB/Monitoring/TopologyOpeningEvent.c
@@ -30,57 +30,32 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_Monitoring_TopologyOpeningEvent)
 /* Returns this event's topology id */
 static PHP_METHOD(MongoDB_Driver_Monitoring_TopologyOpeningEvent, getTopologyId)
 {
-	PHONGO_INTERN_FROM_THIS(topologyopeningevent);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	phongo_objectid_new(return_value, &intern->topology_id);
+	PHONGO_RETURN_PROPERTY(topologyopeningevent, "topologyId");
 }
 
-static void phongo_topologyopeningevent_update_properties(phongo_topologyopeningevent_t* intern)
+static void phongo_topologyopeningevent_update_properties(zend_object* object, const mongoc_apm_topology_opening_t* event)
 {
-	zval topology_id;
+	zval       ztopology_id;
+	bson_oid_t topology_id;
 
-	if (phongo_objectid_new(&topology_id, &intern->topology_id)) {
-		zend_update_property(phongo_topologyopeningevent_ce, &intern->std, ZEND_STRL("topologyId"), &topology_id);
-		zval_ptr_dtor(&topology_id);
+	mongoc_apm_topology_opening_get_topology_id(event, &topology_id);
+
+	if (phongo_objectid_new(&ztopology_id, &topology_id)) {
+		zend_update_property(phongo_topologyopeningevent_ce, object, ZEND_STRL("topologyId"), &ztopology_id);
+		zval_ptr_dtor(&ztopology_id);
 	}
-}
-
-/* MongoDB\Driver\Monitoring\TopologyOpeningEvent object handlers */
-static zend_object_handlers phongo_handler_topologyopeningevent;
-
-static void phongo_topologyopeningevent_free_object(zend_object* object)
-{
-	PHONGO_INTERN_FROM_Z_OBJ(topologyopeningevent, object);
-
-	zend_object_std_dtor(&intern->std);
-}
-
-static zend_object* phongo_topologyopeningevent_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(topologyopeningevent, class_type);
-
-	intern->std.handlers = &phongo_handler_topologyopeningevent;
-
-	return &intern->std;
 }
 
 void phongo_topologyopeningevent_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_topologyopeningevent_ce                = register_class_MongoDB_Driver_Monitoring_TopologyOpeningEvent();
-	phongo_topologyopeningevent_ce->create_object = phongo_topologyopeningevent_create_object;
-
-	memcpy(&phongo_handler_topologyopeningevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_topologyopeningevent.free_obj = phongo_topologyopeningevent_free_object;
-	phongo_handler_topologyopeningevent.offset   = XtOffsetOf(phongo_topologyopeningevent_t, std);
+	phongo_topologyopeningevent_ce = register_class_MongoDB_Driver_Monitoring_TopologyOpeningEvent();
 }
 
 void phongo_topologyopeningevent_init(zval* return_value, const mongoc_apm_topology_opening_t* event)
 {
-	PHONGO_INTERN_INIT_EX(topologyopeningevent, return_value);
+	PHONGO_OBJECT_INIT_EX(topologyopeningevent, return_value);
 
-	mongoc_apm_topology_opening_get_topology_id(event, &intern->topology_id);
-
-	phongo_topologyopeningevent_update_properties(intern);
+	phongo_topologyopeningevent_update_properties(object, event);
 }

--- a/src/MongoDB/WriteConcernError.c
+++ b/src/MongoDB/WriteConcernError.c
@@ -29,29 +29,9 @@ zend_class_entry* phongo_writeconcernerror_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_WriteConcernError)
 
-/* Returns the MongoDB error code */
-static PHP_METHOD(MongoDB_Driver_WriteConcernError, getCode)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(writeconcernerror, "code");
-}
-
-/* Returns additional metadata for the error */
-static PHP_METHOD(MongoDB_Driver_WriteConcernError, getInfo)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(writeconcernerror, "info");
-}
-
-/* Returns the actual error message from the server */
-static PHP_METHOD(MongoDB_Driver_WriteConcernError, getMessage)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(writeconcernerror, "message");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_WriteConcernError, getCode, writeconcernerror, "code")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_WriteConcernError, getMessage, writeconcernerror, "message")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_WriteConcernError, getInfo, writeconcernerror, "info")
 
 static bool phongo_writeconcernerror_update_properties(zend_object* object, const bson_t* bson)
 {

--- a/src/MongoDB/WriteConcernError.c
+++ b/src/MongoDB/WriteConcernError.c
@@ -32,86 +32,76 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_WriteConcernError)
 /* Returns the MongoDB error code */
 static PHP_METHOD(MongoDB_Driver_WriteConcernError, getCode)
 {
-	PHONGO_INTERN_FROM_THIS(writeconcernerror);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETURN_LONG(intern->code);
+	PHONGO_RETURN_PROPERTY(writeconcernerror, "code");
 }
 
 /* Returns additional metadata for the error */
 static PHP_METHOD(MongoDB_Driver_WriteConcernError, getInfo)
 {
-	PHONGO_INTERN_FROM_THIS(writeconcernerror);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!Z_ISUNDEF(intern->info)) {
-		RETURN_ZVAL(&intern->info, 1, 0);
-	}
+	PHONGO_RETURN_PROPERTY(writeconcernerror, "info");
 }
 
 /* Returns the actual error message from the server */
 static PHP_METHOD(MongoDB_Driver_WriteConcernError, getMessage)
 {
-	PHONGO_INTERN_FROM_THIS(writeconcernerror);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!intern->message) {
-		RETURN_STRING("");
-	}
-
-	RETURN_STRING(intern->message);
+	PHONGO_RETURN_PROPERTY(writeconcernerror, "message");
 }
 
-/* MongoDB\Driver\WriteConcernError object handlers */
-static zend_object_handlers phongo_handler_writeconcernerror;
-
-static void phongo_writeconcernerror_free_object(zend_object* object)
+static bool phongo_writeconcernerror_update_properties(zend_object* object, const bson_t* bson)
 {
-	PHONGO_INTERN_FROM_Z_OBJ(writeconcernerror, object);
+	bson_iter_t iter;
 
-	zend_object_std_dtor(&intern->std);
-
-	if (intern->message) {
-		efree(intern->message);
-	}
-
-	if (!Z_ISUNDEF(intern->info)) {
-		zval_ptr_dtor(&intern->info);
-	}
-}
-
-static zend_object* phongo_writeconcernerror_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(writeconcernerror, class_type);
-
-	intern->std.handlers = &phongo_handler_writeconcernerror;
-
-	return &intern->std;
-}
-
-static void phongo_writeconcernerror_update_properties(phongo_writeconcernerror_t* intern)
-{
-	zend_update_property_string(phongo_writeconcernerror_ce, &intern->std, ZEND_STRL("message"), intern->message ? intern->message : "");
-	zend_update_property_long(phongo_writeconcernerror_ce, &intern->std, ZEND_STRL("code"), intern->code);
-
-	if (!Z_ISUNDEF(intern->info)) {
-		zend_update_property(phongo_writeconcernerror_ce, &intern->std, ZEND_STRL("info"), &intern->info);
+	if (bson_iter_init_find(&iter, bson, "code") && BSON_ITER_HOLDS_INT32(&iter)) {
+		zend_update_property_long(phongo_writeconcernerror_ce, object, ZEND_STRL("code"), bson_iter_int32(&iter));
 	} else {
-		zend_update_property_null(phongo_writeconcernerror_ce, &intern->std, ZEND_STRL("info"));
+		zend_update_property_long(phongo_writeconcernerror_ce, object, ZEND_STRL("code"), 0);
 	}
+
+	// Additionally check for field name used by mongoc_bulkwriteexception_t
+	if ((bson_iter_init_find(&iter, bson, "errmsg") && BSON_ITER_HOLDS_UTF8(&iter)) ||
+		(bson_iter_init_find(&iter, bson, "message") && BSON_ITER_HOLDS_UTF8(&iter))) {
+		uint32_t    errmsg_len;
+		const char* message = bson_iter_utf8(&iter, &errmsg_len);
+
+		zend_update_property_string(phongo_writeconcernerror_ce, object, ZEND_STRL("message"), message ? message : "");
+	} else {
+		zend_update_property_string(phongo_writeconcernerror_ce, object, ZEND_STRL("message"), "");
+	}
+
+	// Additionally check for field name used by mongoc_bulkwriteexception_t
+	if ((bson_iter_init_find(&iter, bson, "errInfo") && BSON_ITER_HOLDS_DOCUMENT(&iter)) ||
+		(bson_iter_init_find(&iter, bson, "details") && BSON_ITER_HOLDS_DOCUMENT(&iter))) {
+		uint32_t       len;
+		const uint8_t* data = NULL;
+		zval           zinfo;
+
+		bson_iter_document(&iter, &len, &data);
+
+		if (!phongo_bson_data_to_zval(data, len, &zinfo)) {
+			/* Exception already thrown */
+			zval_ptr_dtor(&zinfo);
+
+			return false;
+		}
+
+		zend_update_property(phongo_writeconcernerror_ce, object, ZEND_STRL("info"), &zinfo);
+		zval_ptr_dtor(&zinfo);
+	} else {
+		zend_update_property_null(phongo_writeconcernerror_ce, object, ZEND_STRL("info"));
+	}
+
+	return true;
 }
 
 void phongo_writeconcernerror_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_writeconcernerror_ce                = register_class_MongoDB_Driver_WriteConcernError();
-	phongo_writeconcernerror_ce->create_object = phongo_writeconcernerror_create_object;
-
-	memcpy(&phongo_handler_writeconcernerror, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_writeconcernerror.free_obj = phongo_writeconcernerror_free_object;
-	phongo_handler_writeconcernerror.offset   = XtOffsetOf(phongo_writeconcernerror_t, std);
+	phongo_writeconcernerror_ce = register_class_MongoDB_Driver_WriteConcernError();
 }
 
 /* Initializes a new WriteConcernError in return_value using the BSON document.
@@ -122,41 +112,7 @@ void phongo_writeconcernerror_init_ce(INIT_FUNC_ARGS)
  * mongoc_bulkwriteexception_t (returned by mongoc_bulkwrite_execute). */
 bool phongo_writeconcernerror_init(zval* return_value, const bson_t* bson)
 {
-	bson_iter_t iter;
+	PHONGO_OBJECT_INIT_EX(writeconcernerror, return_value);
 
-	PHONGO_INTERN_INIT_EX(writeconcernerror, return_value);
-	intern->code = 0;
-
-	if (bson_iter_init_find(&iter, bson, "code") && BSON_ITER_HOLDS_INT32(&iter)) {
-		intern->code = bson_iter_int32(&iter);
-	}
-
-	// Additionally check for field name used by mongoc_bulkwriteexception_t
-	if ((bson_iter_init_find(&iter, bson, "errmsg") && BSON_ITER_HOLDS_UTF8(&iter)) ||
-		(bson_iter_init_find(&iter, bson, "message") && BSON_ITER_HOLDS_UTF8(&iter))) {
-		uint32_t    len;
-		const char* message = bson_iter_utf8(&iter, &len);
-
-		intern->message = estrndup(message, len);
-	}
-
-	// Additionally check for field name used by mongoc_bulkwriteexception_t
-	if ((bson_iter_init_find(&iter, bson, "errInfo") && BSON_ITER_HOLDS_DOCUMENT(&iter)) ||
-		(bson_iter_init_find(&iter, bson, "details") && BSON_ITER_HOLDS_DOCUMENT(&iter))) {
-		uint32_t       len;
-		const uint8_t* data = NULL;
-
-		bson_iter_document(&iter, &len, &data);
-
-		if (!phongo_bson_data_to_zval(data, len, &intern->info)) {
-			zval_ptr_dtor(&intern->info);
-			ZVAL_UNDEF(&intern->info);
-
-			return false;
-		}
-	}
-
-	phongo_writeconcernerror_update_properties(intern);
-
-	return true;
+	return phongo_writeconcernerror_update_properties(object, bson);
 }

--- a/src/MongoDB/WriteError.c
+++ b/src/MongoDB/WriteError.c
@@ -29,38 +29,10 @@ zend_class_entry* phongo_writeerror_ce;
 
 PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_WriteError)
 
-/* Returns the MongoDB error code */
-static PHP_METHOD(MongoDB_Driver_WriteError, getCode)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(writeerror, "code");
-}
-
-/* Returns the index of the operation in the BulkWrite to which this WriteError
-   corresponds. */
-static PHP_METHOD(MongoDB_Driver_WriteError, getIndex)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(writeerror, "index");
-}
-
-/* Returns the actual error message from the server */
-static PHP_METHOD(MongoDB_Driver_WriteError, getMessage)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(writeerror, "message");
-}
-
-/* Returns additional metadata for the error */
-static PHP_METHOD(MongoDB_Driver_WriteError, getInfo)
-{
-	PHONGO_PARSE_PARAMETERS_NONE();
-
-	PHONGO_RETURN_PROPERTY(writeerror, "info");
-}
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_WriteError, getCode, writeerror, "code")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_WriteError, getIndex, writeerror, "index")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_WriteError, getMessage, writeerror, "message")
+PHONGO_PROPERTY_GETTER(MongoDB_Driver_WriteError, getInfo, writeerror, "info")
 
 static bool phongo_writeerror_update_properties(zend_object* object, const bson_t* bson, int32_t index)
 {

--- a/src/MongoDB/WriteError.c
+++ b/src/MongoDB/WriteError.c
@@ -32,94 +32,93 @@ PHONGO_DISABLED_CONSTRUCTOR(MongoDB_Driver_WriteError)
 /* Returns the MongoDB error code */
 static PHP_METHOD(MongoDB_Driver_WriteError, getCode)
 {
-	PHONGO_INTERN_FROM_THIS(writeerror);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETURN_LONG(intern->code);
+	PHONGO_RETURN_PROPERTY(writeerror, "code");
 }
 
 /* Returns the index of the operation in the BulkWrite to which this WriteError
    corresponds. */
 static PHP_METHOD(MongoDB_Driver_WriteError, getIndex)
 {
-	PHONGO_INTERN_FROM_THIS(writeerror);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETURN_LONG(intern->index);
+	PHONGO_RETURN_PROPERTY(writeerror, "index");
 }
 
 /* Returns the actual error message from the server */
 static PHP_METHOD(MongoDB_Driver_WriteError, getMessage)
 {
-	PHONGO_INTERN_FROM_THIS(writeerror);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	RETURN_STRING(intern->message);
+	PHONGO_RETURN_PROPERTY(writeerror, "message");
 }
 
 /* Returns additional metadata for the error */
 static PHP_METHOD(MongoDB_Driver_WriteError, getInfo)
 {
-	PHONGO_INTERN_FROM_THIS(writeerror);
-
 	PHONGO_PARSE_PARAMETERS_NONE();
 
-	if (!Z_ISUNDEF(intern->info)) {
-		RETURN_ZVAL(&intern->info, 1, 0);
-	}
+	PHONGO_RETURN_PROPERTY(writeerror, "info");
 }
 
-/* MongoDB\Driver\WriteError object handlers */
-static zend_object_handlers phongo_handler_writeerror;
-
-static void phongo_writeerror_free_object(zend_object* object)
+static bool phongo_writeerror_update_properties(zend_object* object, const bson_t* bson, int32_t index)
 {
-	PHONGO_INTERN_FROM_Z_OBJ(writeerror, object);
+	bson_iter_t iter;
 
-	zend_object_std_dtor(&intern->std);
-
-	if (intern->message) {
-		efree(intern->message);
-	}
-
-	if (!Z_ISUNDEF(intern->info)) {
-		zval_ptr_dtor(&intern->info);
-	}
-}
-
-static zend_object* phongo_writeerror_create_object(zend_class_entry* class_type)
-{
-	PHONGO_INTERN_OBJECT_ALLOC(writeerror, class_type);
-
-	intern->std.handlers = &phongo_handler_writeerror;
-
-	return &intern->std;
-}
-
-static void phongo_writeerror_update_properties(phongo_writeerror_t* intern)
-{
-	zend_update_property_string(phongo_writeerror_ce, &intern->std, ZEND_STRL("message"), intern->message ? intern->message : "");
-	zend_update_property_long(phongo_writeerror_ce, &intern->std, ZEND_STRL("code"), intern->code);
-	zend_update_property_long(phongo_writeerror_ce, &intern->std, ZEND_STRL("index"), intern->index);
-
-	if (!Z_ISUNDEF(intern->info)) {
-		zend_update_property(phongo_writeerror_ce, &intern->std, ZEND_STRL("info"), &intern->info);
+	if (bson_iter_init_find(&iter, bson, "code") && BSON_ITER_HOLDS_INT32(&iter)) {
+		zend_update_property_long(phongo_writeerror_ce, object, ZEND_STRL("code"), bson_iter_int32(&iter));
 	} else {
-		zend_update_property_null(phongo_writeerror_ce, &intern->std, ZEND_STRL("info"));
+		zend_update_property_long(phongo_writeerror_ce, object, ZEND_STRL("code"), 0);
 	}
+
+	// Additionally check for field name used by mongoc_bulkwriteexception_t
+	if ((bson_iter_init_find(&iter, bson, "errmsg") && BSON_ITER_HOLDS_UTF8(&iter)) ||
+		(bson_iter_init_find(&iter, bson, "message") && BSON_ITER_HOLDS_UTF8(&iter))) {
+		uint32_t    errmsg_len;
+		const char* message = bson_iter_utf8(&iter, &errmsg_len);
+
+		zend_update_property_string(phongo_writeerror_ce, object, ZEND_STRL("message"), message ? message : "");
+	} else {
+		zend_update_property_string(phongo_writeerror_ce, object, ZEND_STRL("message"), "");
+	}
+
+	// Additionally check for field name used by mongoc_bulkwriteexception_t
+	if ((bson_iter_init_find(&iter, bson, "errInfo") && BSON_ITER_HOLDS_DOCUMENT(&iter)) ||
+		(bson_iter_init_find(&iter, bson, "details") && BSON_ITER_HOLDS_DOCUMENT(&iter))) {
+		uint32_t       len;
+		const uint8_t* data = NULL;
+		zval           zinfo;
+
+		bson_iter_document(&iter, &len, &data);
+
+		if (!phongo_bson_data_to_zval(data, len, &zinfo)) {
+			/* Exception already thrown */
+			zval_ptr_dtor(&zinfo);
+
+			return false;
+		}
+
+		zend_update_property(phongo_writeerror_ce, object, ZEND_STRL("info"), &zinfo);
+		zval_ptr_dtor(&zinfo);
+	} else {
+		zend_update_property_null(phongo_writeerror_ce, object, ZEND_STRL("info"));
+	}
+
+	/* If the WriteError is initialized from mongoc_bulkwriteexception_t, an
+	 * index should already have been specified. */
+	if (!index && bson_iter_init_find(&iter, bson, "index") && BSON_ITER_HOLDS_INT32(&iter)) {
+		index = bson_iter_int32(&iter);
+	}
+
+	zend_update_property_long(phongo_writeerror_ce, object, ZEND_STRL("index"), index);
+
+	return true;
 }
 
 void phongo_writeerror_init_ce(INIT_FUNC_ARGS)
 {
-	phongo_writeerror_ce                = register_class_MongoDB_Driver_WriteError();
-	phongo_writeerror_ce->create_object = phongo_writeerror_create_object;
-
-	memcpy(&phongo_handler_writeerror, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_writeerror.free_obj = phongo_writeerror_free_object;
-	phongo_handler_writeerror.offset   = XtOffsetOf(phongo_writeerror_t, std);
+	phongo_writeerror_ce = register_class_MongoDB_Driver_WriteError();
 }
 
 bool phongo_writeerror_init(zval* return_value, const bson_t* bson)
@@ -136,49 +135,7 @@ bool phongo_writeerror_init(zval* return_value, const bson_t* bson)
  * provided since the BSON document will not have an "index" field. */
 bool phongo_writeerror_init_ex(zval* return_value, const bson_t* bson, int32_t index)
 {
-	bson_iter_t iter;
+	PHONGO_OBJECT_INIT_EX(writeerror, return_value);
 
-	PHONGO_INTERN_INIT_EX(writeerror, return_value);
-	intern->code  = 0;
-	intern->index = index;
-
-	if (bson_iter_init_find(&iter, bson, "code") && BSON_ITER_HOLDS_INT32(&iter)) {
-		intern->code = bson_iter_int32(&iter);
-	}
-
-	// Additionally check for field name used by mongoc_bulkwriteexception_t
-	if ((bson_iter_init_find(&iter, bson, "errmsg") && BSON_ITER_HOLDS_UTF8(&iter)) ||
-		(bson_iter_init_find(&iter, bson, "message") && BSON_ITER_HOLDS_UTF8(&iter))) {
-		uint32_t    errmsg_len;
-		const char* err_msg = bson_iter_utf8(&iter, &errmsg_len);
-
-		intern->message = estrndup(err_msg, errmsg_len);
-	}
-
-	// Additionally check for field name used by mongoc_bulkwriteexception_t
-	if ((bson_iter_init_find(&iter, bson, "errInfo") && BSON_ITER_HOLDS_DOCUMENT(&iter)) ||
-		(bson_iter_init_find(&iter, bson, "details") && BSON_ITER_HOLDS_DOCUMENT(&iter))) {
-		uint32_t       len;
-		const uint8_t* data = NULL;
-
-		bson_iter_document(&iter, &len, &data);
-
-		if (!phongo_bson_data_to_zval(data, len, &intern->info)) {
-			/* Exception already thrown */
-			zval_ptr_dtor(&intern->info);
-			ZVAL_UNDEF(&intern->info);
-
-			return false;
-		}
-	}
-
-	/* If the WriteError is initialized from mongoc_bulkwriteexception_t, an
-	 * index should already have been specified. */
-	if (!intern->index && bson_iter_init_find(&iter, bson, "index") && BSON_ITER_HOLDS_INT32(&iter)) {
-		intern->index = bson_iter_int32(&iter);
-	}
-
-	phongo_writeerror_update_properties(intern);
-
-	return true;
+	return phongo_writeerror_update_properties(object, bson, index);
 }

--- a/src/phongo_classes.h
+++ b/src/phongo_classes.h
@@ -65,6 +65,14 @@
 		RETURN_ZVAL(zend_read_property(phongo_##name##_ce, Z_OBJ_P(getThis()), ZEND_STRL((prop)), false, &rv), 1, 0); \
 	} while (0);
 
+#define PHONGO_PROPERTY_GETTER(className, getter, name, property) \
+	static PHP_METHOD(className, getter)                          \
+	{                                                             \
+		PHONGO_PARSE_PARAMETERS_NONE();                           \
+                                                                  \
+		PHONGO_RETURN_PROPERTY(name, property);                   \
+	}
+
 #define CLASS_FETCH_OBJ_DECL(name)                                                      \
 	static inline phongo_##name##_t* php_##name##_fetch_object(const zend_object* obj)  \
 	{                                                                                   \

--- a/src/phongo_classes.h
+++ b/src/phongo_classes.h
@@ -52,6 +52,19 @@
 		intern = php_##name##_fetch_object(Z_OBJ_P(z)); \
 	} while (0)
 
+#define PHONGO_OBJECT_INIT_EX(name, z)         \
+	zend_object* object;                       \
+	do {                                       \
+		object_init_ex(z, phongo_##name##_ce); \
+		object = Z_OBJ_P(z);                   \
+	} while (0)
+
+#define PHONGO_RETURN_PROPERTY(name, prop)                                                                            \
+	do {                                                                                                              \
+		zval rv;                                                                                                      \
+		RETURN_ZVAL(zend_read_property(phongo_##name##_ce, Z_OBJ_P(getThis()), ZEND_STRL((prop)), false, &rv), 1, 0); \
+	} while (0);
+
 #define CLASS_FETCH_OBJ_DECL(name)                                                      \
 	static inline phongo_##name##_t* php_##name##_fetch_object(const zend_object* obj)  \
 	{                                                                                   \
@@ -103,8 +116,6 @@ PHONGO_DECLARE_CLASS_WITH_HELPERS(BULKWRITE, bulkwrite)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(BULKWRITECOMMAND, bulkwritecommand)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(BULKWRITECOMMANDRESULT, bulkwritecommandresult)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(WRITECONCERN, writeconcern)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(WRITECONCERNERROR, writeconcernerror)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(WRITEERROR, writeerror)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(WRITERESULT, writeresult)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(BINARY, binary)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(DOCUMENT, document)
@@ -121,18 +132,8 @@ PHONGO_DECLARE_CLASS_WITH_HELPERS(SYMBOL, symbol)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(TIMESTAMP, timestamp)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(UNDEFINED, undefined)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(UTCDATETIME, utcdatetime)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(COMMANDFAILEDEVENT, commandfailedevent)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(COMMANDSTARTEDEVENT, commandstartedevent)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(COMMANDSUCCEEDEDEVENT, commandsucceededevent)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(SERVERCHANGEDEVENT, serverchangedevent)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(SERVERCLOSEDEVENT, serverclosedevent)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(SERVERHEARTBEATFAILEDEVENT, serverheartbeatfailedevent)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(SERVERHEARTBEATSTARTEDEVENT, serverheartbeatstartedevent)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(SERVERHEARTBEATSUCCEEDEDEVENT, serverheartbeatsucceededevent)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(SERVEROPENINGEVENT, serveropeningevent)
 PHONGO_DECLARE_CLASS_WITH_HELPERS(TOPOLOGYCHANGEDEVENT, topologychangedevent)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(TOPOLOGYCLOSEDEVENT, topologyclosedevent)
-PHONGO_DECLARE_CLASS_WITH_HELPERS(TOPOLOGYOPENINGEVENT, topologyopeningevent)
 
 /*
  * On PHP < 8.4 the preprocessor version used for windows builds can cause issues when replacing ##name## macro tokens
@@ -150,6 +151,9 @@ static inline phongo_regex_t* Z_OBJ_REGEX(const zend_object* zo)
 {
 	return php_regex_fetch_object(zo);
 }
+
+PHONGO_DECLARE_CLASS(writeerror)
+PHONGO_DECLARE_CLASS(writeconcernerror)
 
 PHONGO_DECLARE_CLASS(cursor_interface)
 
@@ -188,6 +192,17 @@ PHONGO_DECLARE_CLASS(subscriber)
 PHONGO_DECLARE_CLASS(commandsubscriber)
 PHONGO_DECLARE_CLASS(logsubscriber)
 PHONGO_DECLARE_CLASS(sdamsubscriber)
+
+PHONGO_DECLARE_CLASS(commandstartedevent)
+PHONGO_DECLARE_CLASS(commandfailedevent)
+PHONGO_DECLARE_CLASS(commandsucceededevent)
+PHONGO_DECLARE_CLASS(serverclosedevent)
+PHONGO_DECLARE_CLASS(serverheartbeatfailedevent)
+PHONGO_DECLARE_CLASS(serverheartbeatstartedevent)
+PHONGO_DECLARE_CLASS(serverheartbeatsucceededevent)
+PHONGO_DECLARE_CLASS(serveropeningevent)
+PHONGO_DECLARE_CLASS(topologyclosedevent)
+PHONGO_DECLARE_CLASS(topologyopeningevent)
 
 #undef CLASS_FETCH_OBJ_DECL
 #undef CLASS_ENTRY_DECL

--- a/src/phongo_structs.h
+++ b/src/phongo_structs.h
@@ -167,21 +167,6 @@ typedef struct {
 } phongo_writeconcern_t;
 
 typedef struct {
-	int         code;
-	char*       message;
-	zval        info;
-	zend_object std;
-} phongo_writeconcernerror_t;
-
-typedef struct {
-	int         code;
-	char*       message;
-	zval        info;
-	uint32_t    index;
-	zend_object std;
-} phongo_writeerror_t;
-
-typedef struct {
 	mongoc_write_concern_t* write_concern;
 	bson_t*                 reply;
 	zval                    manager;
@@ -301,51 +286,6 @@ typedef struct {
 } phongo_utcdatetime_t;
 
 typedef struct {
-	char*              command_name;
-	char*              database_name;
-	uint32_t           server_id;
-	int64_t            operation_id;
-	int64_t            request_id;
-	int64_t            duration_micros;
-	bson_t*            reply;
-	zval               z_error;
-	bool               has_service_id;
-	bson_oid_t         service_id;
-	int64_t            server_connection_id;
-	mongoc_host_list_t host;
-	zend_object        std;
-} phongo_commandfailedevent_t;
-
-typedef struct {
-	char*              command_name;
-	char*              database_name;
-	uint32_t           server_id;
-	int64_t            operation_id;
-	int64_t            request_id;
-	bson_t*            command;
-	bool               has_service_id;
-	bson_oid_t         service_id;
-	int64_t            server_connection_id;
-	mongoc_host_list_t host;
-	zend_object        std;
-} phongo_commandstartedevent_t;
-
-typedef struct {
-	char*              command_name;
-	char*              database_name;
-	uint32_t           server_id;
-	int64_t            operation_id;
-	int64_t            request_id;
-	int64_t            duration_micros;
-	bson_t*            reply;
-	bool               has_service_id;
-	bson_oid_t         service_id;
-	int64_t            server_connection_id;
-	mongoc_host_list_t host;
-	zend_object        std;
-} phongo_commandsucceededevent_t;
-
-typedef struct {
 	bson_oid_t                   topology_id;
 	mongoc_host_list_t           host;
 	mongoc_server_description_t* new_server_description;
@@ -354,54 +294,10 @@ typedef struct {
 } phongo_serverchangedevent_t;
 
 typedef struct {
-	bson_oid_t         topology_id;
-	mongoc_host_list_t host;
-	zend_object        std;
-} phongo_serverclosedevent_t;
-
-typedef struct {
-	bool               awaited;
-	int64_t            duration_micros;
-	zval               z_error;
-	mongoc_host_list_t host;
-	zend_object        std;
-} phongo_serverheartbeatfailedevent_t;
-
-typedef struct {
-	bool               awaited;
-	mongoc_host_list_t host;
-	zend_object        std;
-} phongo_serverheartbeatstartedevent_t;
-
-typedef struct {
-	bool               awaited;
-	int64_t            duration_micros;
-	mongoc_host_list_t host;
-	bson_t*            reply;
-	zend_object        std;
-} phongo_serverheartbeatsucceededevent_t;
-
-typedef struct {
-	bson_oid_t         topology_id;
-	mongoc_host_list_t host;
-	zend_object        std;
-} phongo_serveropeningevent_t;
-
-typedef struct {
 	bson_oid_t                     topology_id;
 	mongoc_topology_description_t* new_topology_description;
 	mongoc_topology_description_t* old_topology_description;
 	zend_object                    std;
 } phongo_topologychangedevent_t;
-
-typedef struct {
-	bson_oid_t  topology_id;
-	zend_object std;
-} phongo_topologyclosedevent_t;
-
-typedef struct {
-	bson_oid_t  topology_id;
-	zend_object std;
-} phongo_topologyopeningevent_t;
 
 #endif /* PHONGO_STRUCTS */


### PR DESCRIPTION
With many classes storing internal properties in `zend_object`, we're now storing data twice in multiple classes: once in the `struct` fields, and once in the property. The `struct` fields are only used for the getters, which strictly speaking isn't necessary. To be clear, we were doing this before already once `get_properties_hash` was invoked and we populated our own `properties` table.

This PR does away with that duplicate data handling for everything that returns static information (i.e. where we don't need to keep a reference to an underlying libmongoc structure):
- The new `PHONGO_PROPERTY_GETTER` macro is used to declare the boilerplate for getters, consisting of parameter parsing and reading the property value into the `return_value` zval
- For classes affected by this, we remove the class helpers and the struct

Not only does this remove duplicate data handling, but it greatly simplifies those value object classes by doing away with class handlers, allocations, etc.