### PR TITLE
PHPC-1622: Use `get_properties_for handler` in BSON classes

### DIFF
--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -269,9 +269,8 @@ static int phongo_binary_compare_objects(zval* o1, zval* o2)
 	return zend_binary_strcmp(intern1->data, intern1->data_len, intern2->data, intern2->data_len);
 }
 
-static HashTable* phongo_binary_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_binary_get_debug_props(zend_object* object)
 {
-	*is_temp         = 1;
 	HashTable* props = phongo_binary_get_properties_hash(object, true, true);
 
 	PHONGO_INTERN_FROM_Z_OBJ(binary, object);
@@ -303,6 +302,20 @@ static HashTable* phongo_binary_get_debug_info(zend_object* object, int* is_temp
 	return props;
 }
 
+static HashTable* phongo_binary_get_properties_for(zend_object* object, zend_prop_purpose purpose)
+{
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+			return phongo_binary_get_debug_props(object);
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_binary_get_properties_hash(object, true, false);
+		default:
+			return NULL;
+	}
+}
+
 static HashTable* phongo_binary_get_properties(zend_object* object)
 {
 	return phongo_binary_get_properties_hash(object, false, false);
@@ -314,12 +327,12 @@ void phongo_binary_init_ce(INIT_FUNC_ARGS)
 	phongo_binary_ce->create_object = phongo_binary_create_object;
 
 	memcpy(&phongo_handler_binary, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_binary.compare        = phongo_binary_compare_objects;
-	phongo_handler_binary.clone_obj      = phongo_binary_clone_object;
-	phongo_handler_binary.get_debug_info = phongo_binary_get_debug_info;
-	phongo_handler_binary.get_properties = phongo_binary_get_properties;
-	phongo_handler_binary.free_obj       = phongo_binary_free_object;
-	phongo_handler_binary.offset         = XtOffsetOf(phongo_binary_t, std);
+	phongo_handler_binary.compare            = phongo_binary_compare_objects;
+	phongo_handler_binary.clone_obj          = phongo_binary_clone_object;
+	phongo_handler_binary.get_properties_for = phongo_binary_get_properties_for;
+	phongo_handler_binary.get_properties     = phongo_binary_get_properties;
+	phongo_handler_binary.free_obj           = phongo_binary_free_object;
+	phongo_handler_binary.offset             = XtOffsetOf(phongo_binary_t, std);
 }
 
 bool phongo_binary_new(zval* object, const char* data, size_t data_len, bson_subtype_t type)

--- a/src/BSON/DBPointer.c
+++ b/src/BSON/DBPointer.c
@@ -221,10 +221,17 @@ static int phongo_dbpointer_compare_objects(zval* o1, zval* o2)
 	return strcmp(intern1->id, intern2->id);
 }
 
-static HashTable* phongo_dbpointer_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_dbpointer_get_properties_for(zend_object* object, zend_prop_purpose purpose)
 {
-	*is_temp = 1;
-	return phongo_dbpointer_get_properties_hash(object, true);
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_dbpointer_get_properties_hash(object, true);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_dbpointer_get_properties(zend_object* object)
@@ -238,12 +245,12 @@ void phongo_dbpointer_init_ce(INIT_FUNC_ARGS)
 	phongo_dbpointer_ce->create_object = phongo_dbpointer_create_object;
 
 	memcpy(&phongo_handler_dbpointer, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_dbpointer.compare        = phongo_dbpointer_compare_objects;
-	phongo_handler_dbpointer.clone_obj      = phongo_dbpointer_clone_object;
-	phongo_handler_dbpointer.get_debug_info = phongo_dbpointer_get_debug_info;
-	phongo_handler_dbpointer.get_properties = phongo_dbpointer_get_properties;
-	phongo_handler_dbpointer.free_obj       = phongo_dbpointer_free_object;
-	phongo_handler_dbpointer.offset         = XtOffsetOf(phongo_dbpointer_t, std);
+	phongo_handler_dbpointer.compare            = phongo_dbpointer_compare_objects;
+	phongo_handler_dbpointer.clone_obj          = phongo_dbpointer_clone_object;
+	phongo_handler_dbpointer.get_properties_for = phongo_dbpointer_get_properties_for;
+	phongo_handler_dbpointer.get_properties     = phongo_dbpointer_get_properties;
+	phongo_handler_dbpointer.free_obj           = phongo_dbpointer_free_object;
+	phongo_handler_dbpointer.offset             = XtOffsetOf(phongo_dbpointer_t, std);
 }
 
 bool phongo_dbpointer_new(zval* object, const char* ref, size_t ref_len, const bson_oid_t* oid)

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -192,10 +192,17 @@ static zend_object* phongo_decimal128_clone_object(zend_object* object)
 	return new_object;
 }
 
-static HashTable* phongo_decimal128_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_decimal128_get_properties_for(zend_object* object, zend_prop_purpose purpose)
 {
-	*is_temp = 1;
-	return phongo_decimal128_get_properties_hash(object, true);
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_decimal128_get_properties_hash(object, true);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_decimal128_get_properties(zend_object* object)
@@ -209,11 +216,11 @@ void phongo_decimal128_init_ce(INIT_FUNC_ARGS)
 	phongo_decimal128_ce->create_object = phongo_decimal128_create_object;
 
 	memcpy(&phongo_handler_decimal128, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_decimal128.clone_obj      = phongo_decimal128_clone_object;
-	phongo_handler_decimal128.get_debug_info = phongo_decimal128_get_debug_info;
-	phongo_handler_decimal128.get_properties = phongo_decimal128_get_properties;
-	phongo_handler_decimal128.free_obj       = phongo_decimal128_free_object;
-	phongo_handler_decimal128.offset         = XtOffsetOf(phongo_decimal128_t, std);
+	phongo_handler_decimal128.clone_obj          = phongo_decimal128_clone_object;
+	phongo_handler_decimal128.get_properties_for = phongo_decimal128_get_properties_for;
+	phongo_handler_decimal128.get_properties     = phongo_decimal128_get_properties;
+	phongo_handler_decimal128.free_obj           = phongo_decimal128_free_object;
+	phongo_handler_decimal128.offset             = XtOffsetOf(phongo_decimal128_t, std);
 }
 
 bool phongo_decimal128_new(zval* object, const bson_decimal128_t* decimal)

--- a/src/BSON/Document.c
+++ b/src/BSON/Document.c
@@ -468,18 +468,14 @@ static int phongo_document_compare_objects(zval* o1, zval* o2)
 	return bson_compare(intern1->bson, intern2->bson);
 }
 
-static HashTable* phongo_document_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_document_get_debug_props(zend_object* object)
 {
 	PHONGO_INTERN_FROM_Z_OBJ(document, object);
 
-	HashTable* props;
-
-	*is_temp = 1;
-
-	/* This get_debug_info handler reports an additional property. This does not
-	 * conflict with other uses of phongo_document_get_properties_hash since
-	 * we always allocated a new HashTable with is_temp=true. */
-	props = phongo_document_get_properties_hash(object, true, 2);
+	/* This reports an additional "value" property. This does not conflict with
+	 * other uses of phongo_document_get_properties_hash since we always
+	 * allocate a new HashTable with is_temp=true. */
+	HashTable* props = phongo_document_get_properties_hash(object, true, 2);
 
 	{
 		phongo_bson_state state;
@@ -489,17 +485,27 @@ static HashTable* phongo_document_get_debug_info(zend_object* object, int* is_te
 		state.map.document.type = PHONGO_TYPEMAP_BSON;
 		if (!phongo_bson_to_zval_ex(intern->bson, &state)) {
 			zval_ptr_dtor(&state.zchild);
-			goto failure;
+			return props;
 		}
 
 		zend_hash_str_update(props, "value", sizeof("value") - 1, &state.zchild);
 	}
 
 	return props;
+}
 
-failure:
-	PHONGO_GET_PROPERTY_HASH_FREE_PROPS(is_temp, props);
-	return NULL;
+static HashTable* phongo_document_get_properties_for(zend_object* object, zend_prop_purpose purpose)
+{
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+			return phongo_document_get_debug_props(object);
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_document_get_properties_hash(object, true, 1);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_document_get_properties(zend_object* object)
@@ -572,20 +578,20 @@ void phongo_document_init_ce(INIT_FUNC_ARGS)
 	phongo_document_ce->create_object = phongo_document_create_object;
 
 	memcpy(&phongo_handler_document, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_document.compare         = phongo_document_compare_objects;
-	phongo_handler_document.clone_obj       = phongo_document_clone_object;
-	phongo_handler_document.get_debug_info  = phongo_document_get_debug_info;
-	phongo_handler_document.get_properties  = phongo_document_get_properties;
-	phongo_handler_document.free_obj        = phongo_document_free_object;
-	phongo_handler_document.read_property   = phongo_document_read_property;
-	phongo_handler_document.write_property  = phongo_document_write_property;
-	phongo_handler_document.has_property    = phongo_document_has_property;
-	phongo_handler_document.unset_property  = phongo_document_unset_property;
-	phongo_handler_document.read_dimension  = phongo_document_read_dimension;
-	phongo_handler_document.write_dimension = phongo_document_write_dimension;
-	phongo_handler_document.has_dimension   = phongo_document_has_dimension;
-	phongo_handler_document.unset_dimension = phongo_document_unset_dimension;
-	phongo_handler_document.offset          = XtOffsetOf(phongo_document_t, std);
+	phongo_handler_document.compare            = phongo_document_compare_objects;
+	phongo_handler_document.clone_obj          = phongo_document_clone_object;
+	phongo_handler_document.get_properties_for = phongo_document_get_properties_for;
+	phongo_handler_document.get_properties     = phongo_document_get_properties;
+	phongo_handler_document.free_obj           = phongo_document_free_object;
+	phongo_handler_document.read_property      = phongo_document_read_property;
+	phongo_handler_document.write_property     = phongo_document_write_property;
+	phongo_handler_document.has_property       = phongo_document_has_property;
+	phongo_handler_document.unset_property     = phongo_document_unset_property;
+	phongo_handler_document.read_dimension     = phongo_document_read_dimension;
+	phongo_handler_document.write_dimension    = phongo_document_write_dimension;
+	phongo_handler_document.has_dimension      = phongo_document_has_dimension;
+	phongo_handler_document.unset_dimension    = phongo_document_unset_dimension;
+	phongo_handler_document.offset             = XtOffsetOf(phongo_document_t, std);
 }
 
 bool phongo_document_new(zval* object, bson_t* bson, bool copy)

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -528,10 +528,17 @@ static zend_result phongo_int64_do_operation(zend_uchar opcode, zval* result, zv
 #undef PHONGO_GET_INT64
 #undef INT64_SIGN_MASK
 
-static HashTable* phongo_int64_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_int64_get_properties_for(zend_object* object, zend_prop_purpose purpose)
 {
-	*is_temp = 1;
-	return phongo_int64_get_properties_hash(object, true);
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_int64_get_properties_hash(object, true);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_int64_get_properties(zend_object* object)
@@ -545,14 +552,14 @@ void phongo_int64_init_ce(INIT_FUNC_ARGS)
 	phongo_int64_ce->create_object = phongo_int64_create_object;
 
 	memcpy(&phongo_handler_int64, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_int64.compare        = phongo_int64_compare_objects;
-	phongo_handler_int64.clone_obj      = phongo_int64_clone_object;
-	phongo_handler_int64.get_debug_info = phongo_int64_get_debug_info;
-	phongo_handler_int64.get_properties = phongo_int64_get_properties;
-	phongo_handler_int64.free_obj       = phongo_int64_free_object;
-	phongo_handler_int64.offset         = XtOffsetOf(phongo_int64_t, std);
-	phongo_handler_int64.cast_object    = phongo_int64_cast_object;
-	phongo_handler_int64.do_operation   = phongo_int64_do_operation;
+	phongo_handler_int64.compare            = phongo_int64_compare_objects;
+	phongo_handler_int64.clone_obj          = phongo_int64_clone_object;
+	phongo_handler_int64.get_properties_for = phongo_int64_get_properties_for;
+	phongo_handler_int64.get_properties     = phongo_int64_get_properties;
+	phongo_handler_int64.free_obj           = phongo_int64_free_object;
+	phongo_handler_int64.offset             = XtOffsetOf(phongo_int64_t, std);
+	phongo_handler_int64.cast_object        = phongo_int64_cast_object;
+	phongo_handler_int64.do_operation       = phongo_int64_do_operation;
 }
 
 bool phongo_int64_new(zval* object, int64_t integer)

--- a/src/BSON/Iterator.c
+++ b/src/BSON/Iterator.c
@@ -280,10 +280,17 @@ static zend_object* phongo_iterator_clone_object(zend_object* object)
 	return new_object;
 }
 
-static HashTable* phongo_iterator_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_iterator_get_properties_for(zend_object* object, zend_prop_purpose purpose)
 {
-	*is_temp = 1;
-	return phongo_iterator_get_properties_hash(object, true);
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_iterator_get_properties_hash(object, true);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_iterator_get_properties(zend_object* object)
@@ -379,9 +386,9 @@ void phongo_iterator_init_ce(INIT_FUNC_ARGS)
 	phongo_iterator_ce->get_iterator  = phongo_iterator_get_iterator;
 
 	memcpy(&phongo_handler_iterator, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_iterator.clone_obj      = phongo_iterator_clone_object;
-	phongo_handler_iterator.get_debug_info = phongo_iterator_get_debug_info;
-	phongo_handler_iterator.get_properties = phongo_iterator_get_properties;
-	phongo_handler_iterator.free_obj       = phongo_iterator_free_object;
-	phongo_handler_iterator.offset         = XtOffsetOf(phongo_iterator_t, std);
+	phongo_handler_iterator.clone_obj          = phongo_iterator_clone_object;
+	phongo_handler_iterator.get_properties_for = phongo_iterator_get_properties_for;
+	phongo_handler_iterator.get_properties     = phongo_iterator_get_properties;
+	phongo_handler_iterator.free_obj           = phongo_iterator_free_object;
+	phongo_handler_iterator.offset             = XtOffsetOf(phongo_iterator_t, std);
 }

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -295,10 +295,17 @@ static int phongo_javascript_compare_objects(zval* o1, zval* o2)
 	return strcmp(intern1->code, intern2->code);
 }
 
-static HashTable* phongo_javascript_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_javascript_get_properties_for(zend_object* object, zend_prop_purpose purpose)
 {
-	*is_temp = 1;
-	return phongo_javascript_get_properties_hash(object, true);
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_javascript_get_properties_hash(object, true);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_javascript_get_properties(zend_object* object)
@@ -312,12 +319,12 @@ void phongo_javascript_init_ce(INIT_FUNC_ARGS)
 	phongo_javascript_ce->create_object = phongo_javascript_create_object;
 
 	memcpy(&phongo_handler_javascript, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_javascript.compare        = phongo_javascript_compare_objects;
-	phongo_handler_javascript.clone_obj      = phongo_javascript_clone_object;
-	phongo_handler_javascript.get_debug_info = phongo_javascript_get_debug_info;
-	phongo_handler_javascript.get_properties = phongo_javascript_get_properties;
-	phongo_handler_javascript.free_obj       = phongo_javascript_free_object;
-	phongo_handler_javascript.offset         = XtOffsetOf(phongo_javascript_t, std);
+	phongo_handler_javascript.compare            = phongo_javascript_compare_objects;
+	phongo_handler_javascript.clone_obj          = phongo_javascript_clone_object;
+	phongo_handler_javascript.get_properties_for = phongo_javascript_get_properties_for;
+	phongo_handler_javascript.get_properties     = phongo_javascript_get_properties;
+	phongo_handler_javascript.free_obj           = phongo_javascript_free_object;
+	phongo_handler_javascript.offset             = XtOffsetOf(phongo_javascript_t, std);
 }
 
 bool phongo_javascript_new(zval* object, const char* code, size_t code_len, const bson_t* scope)

--- a/src/BSON/ObjectId.c
+++ b/src/BSON/ObjectId.c
@@ -239,10 +239,17 @@ static int phongo_objectid_compare_objects(zval* o1, zval* o2)
 	return strcmp(intern1->oid, intern2->oid);
 }
 
-static HashTable* phongo_objectid_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_objectid_get_properties_for(zend_object* object, zend_prop_purpose purpose)
 {
-	*is_temp = 1;
-	return phongo_objectid_get_properties_hash(object, true);
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_objectid_get_properties_hash(object, true);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_objectid_get_properties(zend_object* object)
@@ -256,12 +263,12 @@ void phongo_objectid_init_ce(INIT_FUNC_ARGS)
 	phongo_objectid_ce->create_object = phongo_objectid_create_object;
 
 	memcpy(&phongo_handler_objectid, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_objectid.compare        = phongo_objectid_compare_objects;
-	phongo_handler_objectid.clone_obj      = phongo_objectid_clone_object;
-	phongo_handler_objectid.get_debug_info = phongo_objectid_get_debug_info;
-	phongo_handler_objectid.get_properties = phongo_objectid_get_properties;
-	phongo_handler_objectid.free_obj       = phongo_objectid_free_object;
-	phongo_handler_objectid.offset         = XtOffsetOf(phongo_objectid_t, std);
+	phongo_handler_objectid.compare            = phongo_objectid_compare_objects;
+	phongo_handler_objectid.clone_obj          = phongo_objectid_clone_object;
+	phongo_handler_objectid.get_properties_for = phongo_objectid_get_properties_for;
+	phongo_handler_objectid.get_properties     = phongo_objectid_get_properties;
+	phongo_handler_objectid.free_obj           = phongo_objectid_free_object;
+	phongo_handler_objectid.offset             = XtOffsetOf(phongo_objectid_t, std);
 }
 
 bool phongo_objectid_new(zval* return_value, const bson_oid_t* oid)

--- a/src/BSON/PackedArray.c
+++ b/src/BSON/PackedArray.c
@@ -446,18 +446,14 @@ static int phongo_packedarray_compare_objects(zval* o1, zval* o2)
 	return bson_compare(intern1->bson, intern2->bson);
 }
 
-static HashTable* phongo_packedarray_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_packedarray_get_debug_props(zend_object* object)
 {
 	PHONGO_INTERN_FROM_Z_OBJ(packedarray, object);
 
-	HashTable* props;
-
-	*is_temp = 1;
-
-	/* This get_debug_info handler reports an additional property. This does not
-	 * conflict with other uses of phongo_document_get_properties_hash since
-	 * we always allocated a new HashTable with is_temp=true. */
-	props = phongo_packedarray_get_properties_hash(object, true, 2);
+	/* This reports an additional "value" property. This does not conflict with
+	 * other uses of phongo_packedarray_get_properties_hash since we always
+	 * allocate a new HashTable with is_temp=true. */
+	HashTable* props = phongo_packedarray_get_properties_hash(object, true, 2);
 
 	{
 		phongo_bson_state state;
@@ -468,17 +464,27 @@ static HashTable* phongo_packedarray_get_debug_info(zend_object* object, int* is
 		state.map.document.type = PHONGO_TYPEMAP_BSON;
 		if (!phongo_bson_to_zval_ex(intern->bson, &state)) {
 			zval_ptr_dtor(&state.zchild);
-			goto failure;
+			return props;
 		}
 
 		zend_hash_str_update(props, "value", sizeof("value") - 1, &state.zchild);
 	}
 
 	return props;
+}
 
-failure:
-	PHONGO_GET_PROPERTY_HASH_FREE_PROPS(is_temp, props);
-	return NULL;
+static HashTable* phongo_packedarray_get_properties_for(zend_object* object, zend_prop_purpose purpose)
+{
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+			return phongo_packedarray_get_debug_props(object);
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_packedarray_get_properties_hash(object, true, 1);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_packedarray_get_properties(zend_object* object)
@@ -535,16 +541,16 @@ void phongo_packedarray_init_ce(INIT_FUNC_ARGS)
 	phongo_packedarray_ce->create_object = phongo_packedarray_create_object;
 
 	memcpy(&phongo_handler_packedarray, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_packedarray.compare         = phongo_packedarray_compare_objects;
-	phongo_handler_packedarray.clone_obj       = phongo_packedarray_clone_object;
-	phongo_handler_packedarray.get_debug_info  = phongo_packedarray_get_debug_info;
-	phongo_handler_packedarray.get_properties  = phongo_packedarray_get_properties;
-	phongo_handler_packedarray.free_obj        = phongo_packedarray_free_object;
-	phongo_handler_packedarray.read_dimension  = phongo_packedarray_read_dimension;
-	phongo_handler_packedarray.write_dimension = phongo_packedarray_write_dimension;
-	phongo_handler_packedarray.has_dimension   = phongo_packedarray_has_dimension;
-	phongo_handler_packedarray.unset_dimension = phongo_packedarray_unset_dimension;
-	phongo_handler_packedarray.offset          = XtOffsetOf(phongo_packedarray_t, std);
+	phongo_handler_packedarray.compare            = phongo_packedarray_compare_objects;
+	phongo_handler_packedarray.clone_obj          = phongo_packedarray_clone_object;
+	phongo_handler_packedarray.get_properties_for = phongo_packedarray_get_properties_for;
+	phongo_handler_packedarray.get_properties     = phongo_packedarray_get_properties;
+	phongo_handler_packedarray.free_obj           = phongo_packedarray_free_object;
+	phongo_handler_packedarray.read_dimension     = phongo_packedarray_read_dimension;
+	phongo_handler_packedarray.write_dimension    = phongo_packedarray_write_dimension;
+	phongo_handler_packedarray.has_dimension      = phongo_packedarray_has_dimension;
+	phongo_handler_packedarray.unset_dimension    = phongo_packedarray_unset_dimension;
+	phongo_handler_packedarray.offset             = XtOffsetOf(phongo_packedarray_t, std);
 }
 
 bool phongo_packedarray_new(zval* object, bson_t* bson, bool copy)

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -268,10 +268,17 @@ static int phongo_regex_compare_objects(zval* o1, zval* o2)
 	return strcmp(intern1->flags, intern2->flags);
 }
 
-static HashTable* phongo_regex_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_regex_get_properties_for(zend_object* object, zend_prop_purpose purpose)
 {
-	*is_temp = 1;
-	return phongo_regex_get_properties_hash(object, true);
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_regex_get_properties_hash(object, true);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_regex_get_properties(zend_object* object)
@@ -285,12 +292,12 @@ void phongo_regex_init_ce(INIT_FUNC_ARGS)
 	phongo_regex_ce->create_object = phongo_regex_create_object;
 
 	memcpy(&phongo_handler_regex, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_regex.compare        = phongo_regex_compare_objects;
-	phongo_handler_regex.clone_obj      = phongo_regex_clone_object;
-	phongo_handler_regex.get_debug_info = phongo_regex_get_debug_info;
-	phongo_handler_regex.get_properties = phongo_regex_get_properties;
-	phongo_handler_regex.free_obj       = phongo_regex_free_object;
-	phongo_handler_regex.offset         = XtOffsetOf(phongo_regex_t, std);
+	phongo_handler_regex.compare            = phongo_regex_compare_objects;
+	phongo_handler_regex.clone_obj          = phongo_regex_clone_object;
+	phongo_handler_regex.get_properties_for = phongo_regex_get_properties_for;
+	phongo_handler_regex.get_properties     = phongo_regex_get_properties;
+	phongo_handler_regex.free_obj           = phongo_regex_free_object;
+	phongo_handler_regex.offset             = XtOffsetOf(phongo_regex_t, std);
 }
 
 bool phongo_regex_new(zval* object, const char* pattern, const char* flags)

--- a/src/BSON/Symbol.c
+++ b/src/BSON/Symbol.c
@@ -186,10 +186,17 @@ static int phongo_symbol_compare_objects(zval* o1, zval* o2)
 	return strcmp(intern1->symbol, intern2->symbol);
 }
 
-static HashTable* phongo_symbol_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_symbol_get_properties_for(zend_object* object, zend_prop_purpose purpose)
 {
-	*is_temp = 1;
-	return phongo_symbol_get_properties_hash(object, true);
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_symbol_get_properties_hash(object, true);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_symbol_get_properties(zend_object* object)
@@ -203,12 +210,12 @@ void phongo_symbol_init_ce(INIT_FUNC_ARGS)
 	phongo_symbol_ce->create_object = phongo_symbol_create_object;
 
 	memcpy(&phongo_handler_symbol, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_symbol.compare        = phongo_symbol_compare_objects;
-	phongo_handler_symbol.clone_obj      = phongo_symbol_clone_object;
-	phongo_handler_symbol.get_debug_info = phongo_symbol_get_debug_info;
-	phongo_handler_symbol.get_properties = phongo_symbol_get_properties;
-	phongo_handler_symbol.free_obj       = phongo_symbol_free_object;
-	phongo_handler_symbol.offset         = XtOffsetOf(phongo_symbol_t, std);
+	phongo_handler_symbol.compare            = phongo_symbol_compare_objects;
+	phongo_handler_symbol.clone_obj          = phongo_symbol_clone_object;
+	phongo_handler_symbol.get_properties_for = phongo_symbol_get_properties_for;
+	phongo_handler_symbol.get_properties     = phongo_symbol_get_properties;
+	phongo_handler_symbol.free_obj           = phongo_symbol_free_object;
+	phongo_handler_symbol.offset             = XtOffsetOf(phongo_symbol_t, std);
 }
 
 bool phongo_symbol_new(zval* object, const char* symbol, size_t symbol_len)

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -302,10 +302,17 @@ static int phongo_timestamp_compare_objects(zval* o1, zval* o2)
 	return 0;
 }
 
-static HashTable* phongo_timestamp_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_timestamp_get_properties_for(zend_object* object, zend_prop_purpose purpose)
 {
-	*is_temp = 1;
-	return phongo_timestamp_get_properties_hash(object, true);
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_timestamp_get_properties_hash(object, true);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_timestamp_get_properties(zend_object* object)
@@ -319,12 +326,12 @@ void phongo_timestamp_init_ce(INIT_FUNC_ARGS)
 	phongo_timestamp_ce->create_object = phongo_timestamp_create_object;
 
 	memcpy(&phongo_handler_timestamp, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_timestamp.compare        = phongo_timestamp_compare_objects;
-	phongo_handler_timestamp.clone_obj      = phongo_timestamp_clone_object;
-	phongo_handler_timestamp.get_debug_info = phongo_timestamp_get_debug_info;
-	phongo_handler_timestamp.get_properties = phongo_timestamp_get_properties;
-	phongo_handler_timestamp.free_obj       = phongo_timestamp_free_object;
-	phongo_handler_timestamp.offset         = XtOffsetOf(phongo_timestamp_t, std);
+	phongo_handler_timestamp.compare            = phongo_timestamp_compare_objects;
+	phongo_handler_timestamp.clone_obj          = phongo_timestamp_clone_object;
+	phongo_handler_timestamp.get_properties_for = phongo_timestamp_get_properties_for;
+	phongo_handler_timestamp.get_properties     = phongo_timestamp_get_properties;
+	phongo_handler_timestamp.free_obj           = phongo_timestamp_free_object;
+	phongo_handler_timestamp.offset             = XtOffsetOf(phongo_timestamp_t, std);
 }
 
 bool phongo_timestamp_new(zval* object, uint32_t increment, uint32_t timestamp)

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -339,10 +339,17 @@ static int phongo_utcdatetime_compare_objects(zval* o1, zval* o2)
 	return 0;
 }
 
-static HashTable* phongo_utcdatetime_get_debug_info(zend_object* object, int* is_temp)
+static HashTable* phongo_utcdatetime_get_properties_for(zend_object* object, zend_prop_purpose purpose)
 {
-	*is_temp = 1;
-	return phongo_utcdatetime_get_properties_hash(object, true);
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_DEBUG:
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_GET_OBJECT_VARS:
+			return phongo_utcdatetime_get_properties_hash(object, true);
+		default:
+			return NULL;
+	}
 }
 
 static HashTable* phongo_utcdatetime_get_properties(zend_object* object)
@@ -356,12 +363,12 @@ void phongo_utcdatetime_init_ce(INIT_FUNC_ARGS)
 	phongo_utcdatetime_ce->create_object = phongo_utcdatetime_create_object;
 
 	memcpy(&phongo_handler_utcdatetime, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
-	phongo_handler_utcdatetime.compare        = phongo_utcdatetime_compare_objects;
-	phongo_handler_utcdatetime.clone_obj      = phongo_utcdatetime_clone_object;
-	phongo_handler_utcdatetime.get_debug_info = phongo_utcdatetime_get_debug_info;
-	phongo_handler_utcdatetime.get_properties = phongo_utcdatetime_get_properties;
-	phongo_handler_utcdatetime.free_obj       = phongo_utcdatetime_free_object;
-	phongo_handler_utcdatetime.offset         = XtOffsetOf(phongo_utcdatetime_t, std);
+	phongo_handler_utcdatetime.compare            = phongo_utcdatetime_compare_objects;
+	phongo_handler_utcdatetime.clone_obj          = phongo_utcdatetime_clone_object;
+	phongo_handler_utcdatetime.get_properties_for = phongo_utcdatetime_get_properties_for;
+	phongo_handler_utcdatetime.get_properties     = phongo_utcdatetime_get_properties;
+	phongo_handler_utcdatetime.free_obj           = phongo_utcdatetime_free_object;
+	phongo_handler_utcdatetime.offset             = XtOffsetOf(phongo_utcdatetime_t, std);
 }
 
 bool phongo_utcdatetime_new(zval* object, int64_t msec_since_epoch)

--- a/src/phongo_compat.h
+++ b/src/phongo_compat.h
@@ -99,9 +99,7 @@
 #define PHONGO_RETVAL_SMART_STR(val) RETVAL_STRINGL(ZSTR_VAL((val).s), ZSTR_LEN((val).s));
 #define ZVAL_STATIC_INIT \
 	{                    \
-		{                \
-			0            \
-		}                \
+		{ 0 }            \
 	}
 
 #define ADD_NEXT_INDEX_INT64_OBJ(_zv, _value) \

--- a/tests/bson/bson-binary-get_properties_for-001.phpt
+++ b/tests/bson/bson-binary-get_properties_for-001.phpt
@@ -1,0 +1,46 @@
+--TEST--
+MongoDB\BSON\Binary get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$binary = new MongoDB\BSON\Binary('foobar', MongoDB\BSON\Binary::TYPE_GENERIC);
+
+var_dump($binary);
+
+print_r($binary);
+
+var_dump((array) $binary);
+
+var_export($binary);
+echo "\n";
+
+$restored = eval('return ' . var_export($binary, true) . ';');
+var_dump($binary == $restored);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Binary)#%d (2) {
+  ["data"]=>
+  string(8) "Zm9vYmFy"
+  ["type"]=>
+  int(0)
+}
+MongoDB\BSON\Binary Object
+(
+    [data] => Zm9vYmFy
+    [type] => 0
+)
+array(2) {
+  ["data"]=>
+  string(6) "foobar"
+  ["type"]=>
+  int(0)
+}
+%r\\?%rMongoDB\BSON\Binary::__set_state(array(
+   'data' => 'foobar',
+   'type' => 0,
+))
+bool(true)
+===DONE===

--- a/tests/bson/bson-dbpointer-get_properties_for-001.phpt
+++ b/tests/bson/bson-dbpointer-get_properties_for-001.phpt
@@ -1,0 +1,48 @@
+--TEST--
+MongoDB\BSON\DBPointer get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/tools.php';
+
+$dbpointer = createDBPointer('phongo.test', '5a2e78accd485d55b4050000');
+
+var_dump($dbpointer);
+
+print_r($dbpointer);
+
+var_dump((array) $dbpointer);
+
+var_export($dbpointer);
+echo "\n";
+
+$restored = eval('return ' . var_export($dbpointer, true) . ';');
+var_dump($dbpointer == $restored);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\DBPointer)#%d (2) {
+  ["ref"]=>
+  string(11) "phongo.test"
+  ["id"]=>
+  string(24) "5a2e78accd485d55b4050000"
+}
+MongoDB\BSON\DBPointer Object
+(
+    [ref] => phongo.test
+    [id] => 5a2e78accd485d55b4050000
+)
+array(2) {
+  ["ref"]=>
+  string(11) "phongo.test"
+  ["id"]=>
+  string(24) "5a2e78accd485d55b4050000"
+}
+%r\\?%rMongoDB\BSON\DBPointer::__set_state(array(
+   'ref' => 'phongo.test',
+   'id' => '5a2e78accd485d55b4050000',
+))
+bool(true)
+===DONE===

--- a/tests/bson/bson-decimal128-get_properties_for-001.phpt
+++ b/tests/bson/bson-decimal128-get_properties_for-001.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\BSON\Decimal128 get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$decimal = new MongoDB\BSON\Decimal128('1234.5678');
+
+var_dump($decimal);
+
+print_r($decimal);
+
+var_dump((array) $decimal);
+
+var_export($decimal);
+echo "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Decimal128)#%d (1) {
+  ["dec"]=>
+  string(9) "1234.5678"
+}
+MongoDB\BSON\Decimal128 Object
+(
+    [dec] => 1234.5678
+)
+array(1) {
+  ["dec"]=>
+  string(9) "1234.5678"
+}
+%r\\?%rMongoDB\BSON\Decimal128::__set_state(array(
+   'dec' => '1234.5678',
+))
+===DONE===

--- a/tests/bson/bson-document-get_properties_for-001.phpt
+++ b/tests/bson/bson-document-get_properties_for-001.phpt
@@ -1,0 +1,53 @@
+--TEST--
+MongoDB\BSON\Document get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$document = MongoDB\BSON\Document::fromJSON('{"x": 1, "y": "foo"}');
+
+var_dump($document);
+
+print_r($document);
+
+var_dump((array) $document);
+
+var_export($document);
+echo "\n";
+
+$restored = eval('return ' . var_export($document, true) . ';');
+var_dump($document == $restored);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Document)#%d (2) {
+  ["data"]=>
+  string(32) "FwAAABB4AAEAAAACeQAEAAAAZm9vAAA="
+  ["value"]=>
+  object(stdClass)#%d (2) {
+    ["x"]=>
+    int(1)
+    ["y"]=>
+    string(3) "foo"
+  }
+}
+MongoDB\BSON\Document Object
+(
+    [data] => FwAAABB4AAEAAAACeQAEAAAAZm9vAAA=
+    [value] => stdClass Object
+        (
+            [x] => 1
+            [y] => foo
+        )
+
+)
+array(1) {
+  ["data"]=>
+  string(32) "FwAAABB4AAEAAAACeQAEAAAAZm9vAAA="
+}
+%r\\?%rMongoDB\BSON\Document::__set_state(array(
+   'data' => 'FwAAABB4AAEAAAACeQAEAAAAZm9vAAA=',
+))
+bool(true)
+===DONE===

--- a/tests/bson/bson-int64-get_properties_for-001.phpt
+++ b/tests/bson/bson-int64-get_properties_for-001.phpt
@@ -1,0 +1,40 @@
+--TEST--
+MongoDB\BSON\Int64 get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$int64 = new MongoDB\BSON\Int64(42);
+
+var_dump($int64);
+
+print_r($int64);
+
+var_dump((array) $int64);
+
+var_export($int64);
+echo "\n";
+
+$restored = eval('return ' . var_export($int64, true) . ';');
+var_dump($int64 == $restored);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Int64)#%d (1) {
+  ["integer"]=>
+  string(2) "42"
+}
+MongoDB\BSON\Int64 Object
+(
+    [integer] => 42
+)
+array(1) {
+  ["integer"]=>
+  string(2) "42"
+}
+%r\\?%rMongoDB\BSON\Int64::__set_state(array(
+   'integer' => '42',
+))
+bool(true)
+===DONE===

--- a/tests/bson/bson-iterator-get_properties_for-001.phpt
+++ b/tests/bson/bson-iterator-get_properties_for-001.phpt
@@ -1,0 +1,55 @@
+--TEST--
+MongoDB\BSON\Iterator get_properties_for handler (var_dump, print_r, array cast)
+--FILE--
+<?php
+
+$iterator = MongoDB\BSON\Document::fromJSON('{"x": 1}')->getIterator();
+
+var_dump($iterator);
+
+print_r($iterator);
+
+var_dump((array) $iterator);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Iterator)#%d (1) {
+  ["bson"]=>
+  object(MongoDB\BSON\Document)#%d (%d) {
+    ["data"]=>
+    string(%d) "%a"
+    ["value"]=>
+    object(stdClass)#%d (%d) {
+      ["x"]=>
+      int(1)
+    }
+  }
+}
+MongoDB\BSON\Iterator Object
+(
+    [bson] => MongoDB\BSON\Document Object
+        (
+            [data] => %a
+            [value] => stdClass Object
+                (
+                    [x] => 1
+                )
+
+        )
+
+)
+array(1) {
+  ["bson"]=>
+  object(MongoDB\BSON\Document)#%d (%d) {
+    ["data"]=>
+    string(%d) "%a"
+    ["value"]=>
+    object(stdClass)#%d (%d) {
+      ["x"]=>
+      int(1)
+    }
+  }
+}
+===DONE===

--- a/tests/bson/bson-javascript-get_properties_for-001.phpt
+++ b/tests/bson/bson-javascript-get_properties_for-001.phpt
@@ -1,0 +1,59 @@
+--TEST--
+MongoDB\BSON\Javascript get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$javascript = new MongoDB\BSON\Javascript('function(x) { return x; }', ['x' => 1]);
+
+var_dump($javascript);
+
+print_r($javascript);
+
+var_dump((array) $javascript);
+
+var_export($javascript);
+echo "\n";
+
+$restored = eval('return ' . var_export($javascript, true) . ';');
+var_dump($javascript == $restored);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Javascript)#%d (2) {
+  ["code"]=>
+  string(25) "function(x) { return x; }"
+  ["scope"]=>
+  object(stdClass)#%d (1) {
+    ["x"]=>
+    int(1)
+  }
+}
+MongoDB\BSON\Javascript Object
+(
+    [code] => function(x) { return x; }
+    [scope] => stdClass Object
+        (
+            [x] => 1
+        )
+
+)
+array(2) {
+  ["code"]=>
+  string(25) "function(x) { return x; }"
+  ["scope"]=>
+  object(stdClass)#%d (1) {
+    ["x"]=>
+    int(1)
+  }
+}
+%r\\?%rMongoDB\BSON\Javascript::__set_state(array(
+   'code' => 'function(x) { return x; }',
+   'scope' =>%S
+  (object) array(
+     'x' => 1,
+  ),
+))
+bool(true)
+===DONE===

--- a/tests/bson/bson-objectid-get_properties_for-001.phpt
+++ b/tests/bson/bson-objectid-get_properties_for-001.phpt
@@ -1,0 +1,40 @@
+--TEST--
+MongoDB\BSON\ObjectId get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$oid = new MongoDB\BSON\ObjectId('53e2a1c40640fd72175d4603');
+
+var_dump($oid);
+
+print_r($oid);
+
+var_dump((array) $oid);
+
+var_export($oid);
+echo "\n";
+
+$restored = eval('return ' . var_export($oid, true) . ';');
+var_dump($oid == $restored);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\ObjectId)#%d (1) {
+  ["oid"]=>
+  string(24) "53e2a1c40640fd72175d4603"
+}
+MongoDB\BSON\ObjectId Object
+(
+    [oid] => 53e2a1c40640fd72175d4603
+)
+array(1) {
+  ["oid"]=>
+  string(24) "53e2a1c40640fd72175d4603"
+}
+%r\\?%rMongoDB\BSON\ObjectId::__set_state(array(
+   'oid' => '53e2a1c40640fd72175d4603',
+))
+bool(true)
+===DONE===

--- a/tests/bson/bson-packedarray-get_properties_for-001.phpt
+++ b/tests/bson/bson-packedarray-get_properties_for-001.phpt
@@ -1,0 +1,53 @@
+--TEST--
+MongoDB\BSON\PackedArray get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$packedarray = MongoDB\BSON\PackedArray::fromPHP([1, 'foo']);
+
+var_dump($packedarray);
+
+print_r($packedarray);
+
+var_dump((array) $packedarray);
+
+var_export($packedarray);
+echo "\n";
+
+$restored = eval('return ' . var_export($packedarray, true) . ';');
+var_dump($packedarray == $restored);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\PackedArray)#%d (2) {
+  ["data"]=>
+  string(32) "FwAAABAwAAEAAAACMQAEAAAAZm9vAAA="
+  ["value"]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(3) "foo"
+  }
+}
+MongoDB\BSON\PackedArray Object
+(
+    [data] => FwAAABAwAAEAAAACMQAEAAAAZm9vAAA=
+    [value] => Array
+        (
+            [0] => 1
+            [1] => foo
+        )
+
+)
+array(1) {
+  ["data"]=>
+  string(32) "FwAAABAwAAEAAAACMQAEAAAAZm9vAAA="
+}
+%r\\?%rMongoDB\BSON\PackedArray::__set_state(array(
+   'data' => 'FwAAABAwAAEAAAACMQAEAAAAZm9vAAA=',
+))
+bool(true)
+===DONE===

--- a/tests/bson/bson-regex-get_properties_for-001.phpt
+++ b/tests/bson/bson-regex-get_properties_for-001.phpt
@@ -1,0 +1,42 @@
+--TEST--
+MongoDB\BSON\Regex get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$regex = new MongoDB\BSON\Regex('regexp', 'i');
+
+var_dump($regex);
+
+print_r($regex);
+
+var_dump((array) $regex);
+
+var_export($regex);
+echo "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Regex)#%d (2) {
+  ["pattern"]=>
+  string(6) "regexp"
+  ["flags"]=>
+  string(1) "i"
+}
+MongoDB\BSON\Regex Object
+(
+    [pattern] => regexp
+    [flags] => i
+)
+array(2) {
+  ["pattern"]=>
+  string(6) "regexp"
+  ["flags"]=>
+  string(1) "i"
+}
+%r\\?%rMongoDB\BSON\Regex::__set_state(array(
+   'pattern' => 'regexp',
+   'flags' => 'i',
+))
+===DONE===

--- a/tests/bson/bson-symbol-get_properties_for-001.phpt
+++ b/tests/bson/bson-symbol-get_properties_for-001.phpt
@@ -1,0 +1,40 @@
+--TEST--
+MongoDB\BSON\Symbol get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$symbol = MongoDB\BSON\Document::fromJSON('{ "symbol": {"$symbol": "test"} }')->toPHP()->symbol;
+
+var_dump($symbol);
+
+print_r($symbol);
+
+var_dump((array) $symbol);
+
+var_export($symbol);
+echo "\n";
+
+$restored = eval('return ' . var_export($symbol, true) . ';');
+var_dump($symbol == $restored);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Symbol)#%d (1) {
+  ["symbol"]=>
+  string(4) "test"
+}
+MongoDB\BSON\Symbol Object
+(
+    [symbol] => test
+)
+array(1) {
+  ["symbol"]=>
+  string(4) "test"
+}
+%r\\?%rMongoDB\BSON\Symbol::__set_state(array(
+   'symbol' => 'test',
+))
+bool(true)
+===DONE===

--- a/tests/bson/bson-timestamp-get_properties_for-001.phpt
+++ b/tests/bson/bson-timestamp-get_properties_for-001.phpt
@@ -1,0 +1,46 @@
+--TEST--
+MongoDB\BSON\Timestamp get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$timestamp = new MongoDB\BSON\Timestamp(1, 2);
+
+var_dump($timestamp);
+
+print_r($timestamp);
+
+var_dump((array) $timestamp);
+
+var_export($timestamp);
+echo "\n";
+
+$restored = eval('return ' . var_export($timestamp, true) . ';');
+var_dump($timestamp == $restored);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Timestamp)#%d (2) {
+  ["increment"]=>
+  string(1) "1"
+  ["timestamp"]=>
+  string(1) "2"
+}
+MongoDB\BSON\Timestamp Object
+(
+    [increment] => 1
+    [timestamp] => 2
+)
+array(2) {
+  ["increment"]=>
+  string(1) "1"
+  ["timestamp"]=>
+  string(1) "2"
+}
+%r\\?%rMongoDB\BSON\Timestamp::__set_state(array(
+   'increment' => '1',
+   'timestamp' => '2',
+))
+bool(true)
+===DONE===

--- a/tests/bson/bson-utcdatetime-get_properties_for-001.phpt
+++ b/tests/bson/bson-utcdatetime-get_properties_for-001.phpt
@@ -1,0 +1,40 @@
+--TEST--
+MongoDB\BSON\UTCDateTime get_properties_for handler (var_dump, print_r, array cast, var_export)
+--FILE--
+<?php
+
+$utcdatetime = new MongoDB\BSON\UTCDateTime(1000);
+
+var_dump($utcdatetime);
+
+print_r($utcdatetime);
+
+var_dump((array) $utcdatetime);
+
+var_export($utcdatetime);
+echo "\n";
+
+$restored = eval('return ' . var_export($utcdatetime, true) . ';');
+var_dump($utcdatetime == $restored);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\UTCDateTime)#%d (1) {
+  ["milliseconds"]=>
+  string(4) "1000"
+}
+MongoDB\BSON\UTCDateTime Object
+(
+    [milliseconds] => 1000
+)
+array(1) {
+  ["milliseconds"]=>
+  string(4) "1000"
+}
+%r\\?%rMongoDB\BSON\UTCDateTime::__set_state(array(
+   'milliseconds' => '1000',
+))
+bool(true)
+===DONE===


### PR DESCRIPTION
Fix PHPC-1622

Replace the deprecated `get_debug_info` handler with the PHP 7.4+ `get_properties_for` handler in all BSON classes.

The new handler uses a switch on `zend_prop_purpose` to tailor output per context:
- `ZEND_PROP_PURPOSE_DEBUG` — debug format (e.g. base64 data for Binary, decoded `value` for Document/PackedArray)
- `ZEND_PROP_PURPOSE_ARRAY_CAST`, `VAR_EXPORT`, `GET_OBJECT_VARS` — serialization-friendly format (raw data)
- default — returns `NULL` (e.g. for `serialize()` and `json_encode()` which use dedicated methods)

The `get_properties` handler is kept for `foreach` support on non-Traversable classes.