### PR TITLE
Relax check on internal object id, not relevant for the test

### DIFF
--- a/tests/bulkwritecommand/bulkwritecommand-debug-003.phpt
+++ b/tests/bulkwritecommand/bulkwritecommand-debug-003.phpt
@@ -75,7 +75,7 @@ object(MongoDB\Driver\BulkWriteCommand)#%d (%d) {
   ["bypassDocumentValidation"]=>
   NULL
   ["comment"]=>
-  object(stdClass)#2 (1) {
+  object(stdClass)#%d (1) {
     ["foo"]=>
     int(1)
   }
@@ -90,7 +90,7 @@ object(MongoDB\Driver\BulkWriteCommand)#%d (%d) {
   ["bypassDocumentValidation"]=>
   NULL
   ["let"]=>
-  object(stdClass)#2 (2) {
+  object(stdClass)#%d (2) {
     ["id"]=>
     int(1)
     ["x"]=>


### PR DESCRIPTION
An other implementation of the driver don't have to hold the same object id.