### PR TITLE
Replace XtOffsetOf() with offsetof() for PHP 8.6

### DIFF
--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -319,7 +319,7 @@ void phongo_binary_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_binary.get_debug_info = phongo_binary_get_debug_info;
 	phongo_handler_binary.get_properties = phongo_binary_get_properties;
 	phongo_handler_binary.free_obj       = phongo_binary_free_object;
-	phongo_handler_binary.offset         = XtOffsetOf(phongo_binary_t, std);
+	phongo_handler_binary.offset         = offsetof(phongo_binary_t, std);
 }
 
 bool phongo_binary_new(zval* object, const char* data, size_t data_len, bson_subtype_t type)

--- a/src/BSON/DBPointer.c
+++ b/src/BSON/DBPointer.c
@@ -243,7 +243,7 @@ void phongo_dbpointer_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_dbpointer.get_debug_info = phongo_dbpointer_get_debug_info;
 	phongo_handler_dbpointer.get_properties = phongo_dbpointer_get_properties;
 	phongo_handler_dbpointer.free_obj       = phongo_dbpointer_free_object;
-	phongo_handler_dbpointer.offset         = XtOffsetOf(phongo_dbpointer_t, std);
+	phongo_handler_dbpointer.offset         = offsetof(phongo_dbpointer_t, std);
 }
 
 bool phongo_dbpointer_new(zval* object, const char* ref, size_t ref_len, const bson_oid_t* oid)

--- a/src/BSON/Decimal128.c
+++ b/src/BSON/Decimal128.c
@@ -213,7 +213,7 @@ void phongo_decimal128_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_decimal128.get_debug_info = phongo_decimal128_get_debug_info;
 	phongo_handler_decimal128.get_properties = phongo_decimal128_get_properties;
 	phongo_handler_decimal128.free_obj       = phongo_decimal128_free_object;
-	phongo_handler_decimal128.offset         = XtOffsetOf(phongo_decimal128_t, std);
+	phongo_handler_decimal128.offset         = offsetof(phongo_decimal128_t, std);
 }
 
 bool phongo_decimal128_new(zval* object, const bson_decimal128_t* decimal)

--- a/src/BSON/Document.c
+++ b/src/BSON/Document.c
@@ -585,7 +585,7 @@ void phongo_document_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_document.write_dimension = phongo_document_write_dimension;
 	phongo_handler_document.has_dimension   = phongo_document_has_dimension;
 	phongo_handler_document.unset_dimension = phongo_document_unset_dimension;
-	phongo_handler_document.offset          = XtOffsetOf(phongo_document_t, std);
+	phongo_handler_document.offset          = offsetof(phongo_document_t, std);
 }
 
 bool phongo_document_new(zval* object, bson_t* bson, bool copy)

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -550,7 +550,7 @@ void phongo_int64_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_int64.get_debug_info = phongo_int64_get_debug_info;
 	phongo_handler_int64.get_properties = phongo_int64_get_properties;
 	phongo_handler_int64.free_obj       = phongo_int64_free_object;
-	phongo_handler_int64.offset         = XtOffsetOf(phongo_int64_t, std);
+	phongo_handler_int64.offset         = offsetof(phongo_int64_t, std);
 	phongo_handler_int64.cast_object    = phongo_int64_cast_object;
 	phongo_handler_int64.do_operation   = phongo_int64_do_operation;
 }

--- a/src/BSON/Iterator.c
+++ b/src/BSON/Iterator.c
@@ -383,5 +383,5 @@ void phongo_iterator_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_iterator.get_debug_info = phongo_iterator_get_debug_info;
 	phongo_handler_iterator.get_properties = phongo_iterator_get_properties;
 	phongo_handler_iterator.free_obj       = phongo_iterator_free_object;
-	phongo_handler_iterator.offset         = XtOffsetOf(phongo_iterator_t, std);
+	phongo_handler_iterator.offset         = offsetof(phongo_iterator_t, std);
 }

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -317,7 +317,7 @@ void phongo_javascript_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_javascript.get_debug_info = phongo_javascript_get_debug_info;
 	phongo_handler_javascript.get_properties = phongo_javascript_get_properties;
 	phongo_handler_javascript.free_obj       = phongo_javascript_free_object;
-	phongo_handler_javascript.offset         = XtOffsetOf(phongo_javascript_t, std);
+	phongo_handler_javascript.offset         = offsetof(phongo_javascript_t, std);
 }
 
 bool phongo_javascript_new(zval* object, const char* code, size_t code_len, const bson_t* scope)

--- a/src/BSON/ObjectId.c
+++ b/src/BSON/ObjectId.c
@@ -261,7 +261,7 @@ void phongo_objectid_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_objectid.get_debug_info = phongo_objectid_get_debug_info;
 	phongo_handler_objectid.get_properties = phongo_objectid_get_properties;
 	phongo_handler_objectid.free_obj       = phongo_objectid_free_object;
-	phongo_handler_objectid.offset         = XtOffsetOf(phongo_objectid_t, std);
+	phongo_handler_objectid.offset         = offsetof(phongo_objectid_t, std);
 }
 
 bool phongo_objectid_new(zval* return_value, const bson_oid_t* oid)

--- a/src/BSON/PackedArray.c
+++ b/src/BSON/PackedArray.c
@@ -544,7 +544,7 @@ void phongo_packedarray_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_packedarray.write_dimension = phongo_packedarray_write_dimension;
 	phongo_handler_packedarray.has_dimension   = phongo_packedarray_has_dimension;
 	phongo_handler_packedarray.unset_dimension = phongo_packedarray_unset_dimension;
-	phongo_handler_packedarray.offset          = XtOffsetOf(phongo_packedarray_t, std);
+	phongo_handler_packedarray.offset          = offsetof(phongo_packedarray_t, std);
 }
 
 bool phongo_packedarray_new(zval* object, bson_t* bson, bool copy)

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -290,7 +290,7 @@ void phongo_regex_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_regex.get_debug_info = phongo_regex_get_debug_info;
 	phongo_handler_regex.get_properties = phongo_regex_get_properties;
 	phongo_handler_regex.free_obj       = phongo_regex_free_object;
-	phongo_handler_regex.offset         = XtOffsetOf(phongo_regex_t, std);
+	phongo_handler_regex.offset         = offsetof(phongo_regex_t, std);
 }
 
 bool phongo_regex_new(zval* object, const char* pattern, const char* flags)

--- a/src/BSON/Symbol.c
+++ b/src/BSON/Symbol.c
@@ -208,7 +208,7 @@ void phongo_symbol_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_symbol.get_debug_info = phongo_symbol_get_debug_info;
 	phongo_handler_symbol.get_properties = phongo_symbol_get_properties;
 	phongo_handler_symbol.free_obj       = phongo_symbol_free_object;
-	phongo_handler_symbol.offset         = XtOffsetOf(phongo_symbol_t, std);
+	phongo_handler_symbol.offset         = offsetof(phongo_symbol_t, std);
 }
 
 bool phongo_symbol_new(zval* object, const char* symbol, size_t symbol_len)

--- a/src/BSON/Timestamp.c
+++ b/src/BSON/Timestamp.c
@@ -324,7 +324,7 @@ void phongo_timestamp_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_timestamp.get_debug_info = phongo_timestamp_get_debug_info;
 	phongo_handler_timestamp.get_properties = phongo_timestamp_get_properties;
 	phongo_handler_timestamp.free_obj       = phongo_timestamp_free_object;
-	phongo_handler_timestamp.offset         = XtOffsetOf(phongo_timestamp_t, std);
+	phongo_handler_timestamp.offset         = offsetof(phongo_timestamp_t, std);
 }
 
 bool phongo_timestamp_new(zval* object, uint32_t increment, uint32_t timestamp)

--- a/src/BSON/UTCDateTime.c
+++ b/src/BSON/UTCDateTime.c
@@ -361,7 +361,7 @@ void phongo_utcdatetime_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_utcdatetime.get_debug_info = phongo_utcdatetime_get_debug_info;
 	phongo_handler_utcdatetime.get_properties = phongo_utcdatetime_get_properties;
 	phongo_handler_utcdatetime.free_obj       = phongo_utcdatetime_free_object;
-	phongo_handler_utcdatetime.offset         = XtOffsetOf(phongo_utcdatetime_t, std);
+	phongo_handler_utcdatetime.offset         = offsetof(phongo_utcdatetime_t, std);
 }
 
 bool phongo_utcdatetime_new(zval* object, int64_t msec_since_epoch)

--- a/src/BSON/Undefined.c
+++ b/src/BSON/Undefined.c
@@ -96,5 +96,5 @@ void phongo_undefined_init_ce(INIT_FUNC_ARGS)
 	/* Re-assign default handler previously removed in phongo.c */
 	phongo_handler_undefined.clone_obj = zend_objects_clone_obj;
 	phongo_handler_undefined.free_obj  = phongo_undefined_free_object;
-	phongo_handler_undefined.offset    = XtOffsetOf(phongo_undefined_t, std);
+	phongo_handler_undefined.offset    = offsetof(phongo_undefined_t, std);
 }

--- a/src/MongoDB/BulkWrite.c
+++ b/src/MongoDB/BulkWrite.c
@@ -660,5 +660,5 @@ void phongo_bulkwrite_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_bulkwrite, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_bulkwrite.get_debug_info = phongo_bulkwrite_get_debug_info;
 	phongo_handler_bulkwrite.free_obj       = phongo_bulkwrite_free_object;
-	phongo_handler_bulkwrite.offset         = XtOffsetOf(phongo_bulkwrite_t, std);
+	phongo_handler_bulkwrite.offset         = offsetof(phongo_bulkwrite_t, std);
 }

--- a/src/MongoDB/BulkWriteCommand.c
+++ b/src/MongoDB/BulkWriteCommand.c
@@ -830,5 +830,5 @@ void phongo_bulkwritecommand_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_bulkwritecommand, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_bulkwritecommand.get_debug_info = phongo_bulkwritecommand_get_debug_info;
 	phongo_handler_bulkwritecommand.free_obj       = phongo_bulkwritecommand_free_object;
-	phongo_handler_bulkwritecommand.offset         = XtOffsetOf(phongo_bulkwritecommand_t, std);
+	phongo_handler_bulkwritecommand.offset         = offsetof(phongo_bulkwritecommand_t, std);
 }

--- a/src/MongoDB/BulkWriteCommandResult.c
+++ b/src/MongoDB/BulkWriteCommandResult.c
@@ -228,7 +228,7 @@ void phongo_bulkwritecommandresult_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_bulkwritecommandresult, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_bulkwritecommandresult.get_debug_info = phongo_bulkwritecommandresult_get_debug_info;
 	phongo_handler_bulkwritecommandresult.free_obj       = phongo_bulkwritecommandresult_free_object;
-	phongo_handler_bulkwritecommandresult.offset         = XtOffsetOf(phongo_bulkwritecommandresult_t, std);
+	phongo_handler_bulkwritecommandresult.offset         = offsetof(phongo_bulkwritecommandresult_t, std);
 }
 
 static inline bson_t* _bson_copy_or_null(const bson_t* bson)

--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -520,7 +520,7 @@ void phongo_clientencryption_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_clientencryption, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_clientencryption.get_debug_info = phongo_clientencryption_get_debug_info;
 	phongo_handler_clientencryption.free_obj       = phongo_clientencryption_free_object;
-	phongo_handler_clientencryption.offset         = XtOffsetOf(phongo_clientencryption_t, std);
+	phongo_handler_clientencryption.offset         = offsetof(phongo_clientencryption_t, std);
 }
 
 #ifdef MONGOC_ENABLE_CLIENT_SIDE_ENCRYPTION

--- a/src/MongoDB/Command.c
+++ b/src/MongoDB/Command.c
@@ -172,5 +172,5 @@ void phongo_command_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_command, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_command.get_debug_info = phongo_command_get_debug_info;
 	phongo_handler_command.free_obj       = phongo_command_free_object;
-	phongo_handler_command.offset         = XtOffsetOf(phongo_command_t, std);
+	phongo_handler_command.offset         = offsetof(phongo_command_t, std);
 }

--- a/src/MongoDB/Cursor.c
+++ b/src/MongoDB/Cursor.c
@@ -416,7 +416,7 @@ void phongo_cursor_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_cursor, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_cursor.get_debug_info = phongo_cursor_get_debug_info;
 	phongo_handler_cursor.free_obj       = phongo_cursor_free_object;
-	phongo_handler_cursor.offset         = XtOffsetOf(phongo_cursor_t, std);
+	phongo_handler_cursor.offset         = offsetof(phongo_cursor_t, std);
 }
 
 static void phongo_cursor_init(zval* return_value, zval* manager, mongoc_cursor_t* cursor, zval* readPreference, zval* session)

--- a/src/MongoDB/Manager.c
+++ b/src/MongoDB/Manager.c
@@ -853,5 +853,5 @@ void phongo_manager_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_manager, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_manager.get_debug_info = phongo_manager_get_debug_info;
 	phongo_handler_manager.free_obj       = phongo_manager_free_object;
-	phongo_handler_manager.offset         = XtOffsetOf(phongo_manager_t, std);
+	phongo_handler_manager.offset         = offsetof(phongo_manager_t, std);
 }

--- a/src/MongoDB/Monitoring/ServerChangedEvent.c
+++ b/src/MongoDB/Monitoring/ServerChangedEvent.c
@@ -136,7 +136,7 @@ void phongo_serverchangedevent_init_ce(INIT_FUNC_ARGS)
 
 	memcpy(&phongo_handler_serverchangedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_serverchangedevent.free_obj = phongo_serverchangedevent_free_object;
-	phongo_handler_serverchangedevent.offset   = XtOffsetOf(phongo_serverchangedevent_t, std);
+	phongo_handler_serverchangedevent.offset   = offsetof(phongo_serverchangedevent_t, std);
 }
 
 void phongo_serverchangedevent_init(zval* return_value, const mongoc_apm_server_changed_t* event)

--- a/src/MongoDB/Monitoring/TopologyChangedEvent.c
+++ b/src/MongoDB/Monitoring/TopologyChangedEvent.c
@@ -112,7 +112,7 @@ void phongo_topologychangedevent_init_ce(INIT_FUNC_ARGS)
 
 	memcpy(&phongo_handler_topologychangedevent, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_topologychangedevent.free_obj = phongo_topologychangedevent_free_object;
-	phongo_handler_topologychangedevent.offset   = XtOffsetOf(phongo_topologychangedevent_t, std);
+	phongo_handler_topologychangedevent.offset   = offsetof(phongo_topologychangedevent_t, std);
 }
 
 void phongo_topologychangedevent_init(zval* return_value, const mongoc_apm_topology_changed_t* event)

--- a/src/MongoDB/Query.c
+++ b/src/MongoDB/Query.c
@@ -414,5 +414,5 @@ void phongo_query_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_query, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_query.get_debug_info = phongo_query_get_debug_info;
 	phongo_handler_query.free_obj       = phongo_query_free_object;
-	phongo_handler_query.offset         = XtOffsetOf(phongo_query_t, std);
+	phongo_handler_query.offset         = offsetof(phongo_query_t, std);
 }

--- a/src/MongoDB/ReadConcern.c
+++ b/src/MongoDB/ReadConcern.c
@@ -213,7 +213,7 @@ void phongo_readconcern_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_readconcern, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_readconcern.clone_obj = phongo_readconcern_clone_object;
 	phongo_handler_readconcern.free_obj  = phongo_readconcern_free_object;
-	phongo_handler_readconcern.offset    = XtOffsetOf(phongo_readconcern_t, std);
+	phongo_handler_readconcern.offset    = offsetof(phongo_readconcern_t, std);
 }
 
 void phongo_readconcern_init(zval* return_value, const mongoc_read_concern_t* read_concern)

--- a/src/MongoDB/ReadPreference.c
+++ b/src/MongoDB/ReadPreference.c
@@ -522,7 +522,7 @@ void phongo_readpreference_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_readpreference.clone_obj     = phongo_readpreference_clone_object;
 	phongo_handler_readpreference.read_property = phongo_readpreference_read_property;
 	phongo_handler_readpreference.free_obj      = phongo_readpreference_free_object;
-	phongo_handler_readpreference.offset        = XtOffsetOf(phongo_readpreference_t, std);
+	phongo_handler_readpreference.offset        = offsetof(phongo_readpreference_t, std);
 }
 
 void phongo_readpreference_init(zval* return_value, const mongoc_read_prefs_t* read_prefs)

--- a/src/MongoDB/Server.c
+++ b/src/MongoDB/Server.c
@@ -671,7 +671,7 @@ void phongo_server_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_server.compare        = phongo_server_compare_objects;
 	phongo_handler_server.get_debug_info = phongo_server_get_debug_info;
 	phongo_handler_server.free_obj       = phongo_server_free_object;
-	phongo_handler_server.offset         = XtOffsetOf(phongo_server_t, std);
+	phongo_handler_server.offset         = offsetof(phongo_server_t, std);
 }
 
 void phongo_server_init(zval* return_value, zval* manager, uint32_t server_id)

--- a/src/MongoDB/ServerApi.c
+++ b/src/MongoDB/ServerApi.c
@@ -245,5 +245,5 @@ void phongo_serverapi_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_serverapi.get_debug_info = phongo_serverapi_get_debug_info;
 	phongo_handler_serverapi.get_properties = phongo_serverapi_get_properties;
 	phongo_handler_serverapi.free_obj       = phongo_serverapi_free_object;
-	phongo_handler_serverapi.offset         = XtOffsetOf(phongo_serverapi_t, std);
+	phongo_handler_serverapi.offset         = offsetof(phongo_serverapi_t, std);
 }

--- a/src/MongoDB/ServerDescription.c
+++ b/src/MongoDB/ServerDescription.c
@@ -262,7 +262,7 @@ void phongo_serverdescription_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_serverdescription.get_debug_info = phongo_serverdescription_get_debug_info;
 	phongo_handler_serverdescription.get_properties = phongo_serverdescription_get_properties;
 	phongo_handler_serverdescription.free_obj       = phongo_serverdescription_free_object;
-	phongo_handler_serverdescription.offset         = XtOffsetOf(phongo_serverdescription_t, std);
+	phongo_handler_serverdescription.offset         = offsetof(phongo_serverdescription_t, std);
 }
 
 void phongo_serverdescription_init_ex(zval* return_value, mongoc_server_description_t* server_description, bool copy)

--- a/src/MongoDB/Session.c
+++ b/src/MongoDB/Session.c
@@ -693,7 +693,7 @@ void phongo_session_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_session, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_session.get_debug_info = phongo_session_get_debug_info;
 	phongo_handler_session.free_obj       = phongo_session_free_object;
-	phongo_handler_session.offset         = XtOffsetOf(phongo_session_t, std);
+	phongo_handler_session.offset         = offsetof(phongo_session_t, std);
 }
 
 void phongo_session_init(zval* return_value, zval* manager, mongoc_client_session_t* client_session)

--- a/src/MongoDB/TopologyDescription.c
+++ b/src/MongoDB/TopologyDescription.c
@@ -183,7 +183,7 @@ void phongo_topologydescription_init_ce(INIT_FUNC_ARGS)
 	phongo_handler_topologydescription.get_debug_info = phongo_topologydescription_get_debug_info;
 	phongo_handler_topologydescription.get_properties = phongo_topologydescription_get_properties;
 	phongo_handler_topologydescription.free_obj       = phongo_topologydescription_free_object;
-	phongo_handler_topologydescription.offset         = XtOffsetOf(phongo_topologydescription_t, std);
+	phongo_handler_topologydescription.offset         = offsetof(phongo_topologydescription_t, std);
 }
 
 void phongo_topologydescription_init(zval* return_value, mongoc_topology_description_t* topology_description)

--- a/src/MongoDB/WriteConcern.c
+++ b/src/MongoDB/WriteConcern.c
@@ -383,7 +383,7 @@ void phongo_writeconcern_init_ce(INIT_FUNC_ARGS)
 	memcpy(&phongo_handler_writeconcern, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_writeconcern.clone_obj = phongo_writeconcern_clone_object;
 	phongo_handler_writeconcern.free_obj  = phongo_writeconcern_free_object;
-	phongo_handler_writeconcern.offset    = XtOffsetOf(phongo_writeconcern_t, std);
+	phongo_handler_writeconcern.offset    = offsetof(phongo_writeconcern_t, std);
 }
 
 void phongo_writeconcern_init(zval* return_value, const mongoc_write_concern_t* write_concern)

--- a/src/MongoDB/WriteResult.c
+++ b/src/MongoDB/WriteResult.c
@@ -418,7 +418,7 @@ void phongo_writeresult_init_ce(INIT_FUNC_ARGS)
 
 	memcpy(&phongo_handler_writeresult, phongo_get_std_object_handlers(), sizeof(zend_object_handlers));
 	phongo_handler_writeresult.free_obj = phongo_writeresult_free_object;
-	phongo_handler_writeresult.offset   = XtOffsetOf(phongo_writeresult_t, std);
+	phongo_handler_writeresult.offset   = offsetof(phongo_writeresult_t, std);
 }
 
 void phongo_writeresult_init(zval* return_value, bson_t* reply, zval* manager, uint32_t server_id, const mongoc_write_concern_t* write_concern)

--- a/src/phongo_classes.h
+++ b/src/phongo_classes.h
@@ -73,10 +73,10 @@
 		PHONGO_RETURN_PROPERTY(name, property);                   \
 	}
 
-#define CLASS_FETCH_OBJ_DECL(name)                                                      \
-	static inline phongo_##name##_t* php_##name##_fetch_object(const zend_object* obj)  \
-	{                                                                                   \
-		return (phongo_##name##_t*) ((char*) obj - XtOffsetOf(phongo_##name##_t, std)); \
+#define CLASS_FETCH_OBJ_DECL(name)                                                     \
+	static inline phongo_##name##_t* php_##name##_fetch_object(const zend_object* obj) \
+	{                                                                                  \
+		return (phongo_##name##_t*) ((char*) obj - offsetof(phongo_##name##_t, std));  \
 	}
 
 #define CLASS_ENTRY_DECL(name) extern zend_class_entry* phongo_##name##_ce


### PR DESCRIPTION
PHP 8.6 removed `XtOffsetOf()`, which was an alias for the standard C `offsetof()` macro. Replace all usages  with `offsetof()` directly.

replace 's/XtOffsetOf/offsetof/g' 

ref https://github.com/php/php-src/commit/7114314c5a96c362b95663f7e7c9184586721f58