### PR TITLE
Fix ZVAL_STATIC_INIT macro formatting for clang-format compatibility

### DIFF
--- a/src/phongo_compat.h
+++ b/src/phongo_compat.h
@@ -97,12 +97,9 @@
 	} while (0)
 #define ADD_NEXT_INDEX_STRINGL(_zv, _value, _len) add_next_index_stringl(_zv, _value, _len);
 #define PHONGO_RETVAL_SMART_STR(val) RETVAL_STRINGL(ZSTR_VAL((val).s), ZSTR_LEN((val).s));
-#define ZVAL_STATIC_INIT \
-	{                    \
-		{                \
-			0            \
-		}                \
-	}
+/* clang-format off */
+#define ZVAL_STATIC_INIT { { 0 } }
+/* clang-format on */
 
 #define ADD_NEXT_INDEX_INT64_OBJ(_zv, _value) \
 	do {                                      \


### PR DESCRIPTION
Use a compact single-line form wrapped in `clang-format off/on` to avoid formatting differences between clang-format versions (v18 on CI vs v22 locally).