### PR TITLE
PHPC-2715: Fix out-of-source-tree builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -295,3 +295,31 @@ jobs:
         run: |
           "$GITHUB_WORKSPACE/php-src/sapi/cli/php" -m | grep -ix mongodb
           "$GITHUB_WORKSPACE/php-src/sapi/cli/php" --ri mongodb
+
+  test-out-of-source-build:
+    name: "Out-of-source Build"
+    runs-on: "ubuntu-latest"
+    env:
+      PHP_VERSION: "8.5"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v6"
+        with:
+          submodules: true
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ env.PHP_VERSION }}-debug"
+          extensions: "none,date,json,spl,standard,xml"
+
+      - name: "phpize"
+        run: phpize
+
+      - name: "Build driver (out-of-source)"
+        run: |
+          mkdir -p /tmp/mongodb-build
+          cd /tmp/mongodb-build
+          ${GITHUB_WORKSPACE}/configure --enable-mongodb-developer-flags
+          make all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,7 +179,7 @@ jobs:
     runs-on: "ubuntu-latest"
     env:
       PHP_VERSION: "8.3"
-      LIBMONGOCRYPT_VERSION: "1.17.3"
+      LIBMONGOCRYPT_VERSION: "1.18.0"
       # Note: include the patch version when referring to a libmongoc release tarball
       LIBMONGOC_VERSION: "2.3.0"
       SERVER_VERSION: "8.0"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -244,8 +244,7 @@ jobs:
     name: "Static PHP Build"
     runs-on: "ubuntu-latest"
     env:
-      # Update this when cutting a new PHP 8.3 patch release
-      PHP_VERSION: "8.3.21"
+      PHP_VERSION: "8.5.5"
 
     steps:
       - name: "Checkout"

--- a/config.m4
+++ b/config.m4
@@ -387,6 +387,7 @@ if test "$PHP_MONGODB" != "no"; then
     dnl of build layout.  Using $PWD here breaks PHP in-tree builds because $PWD is
     dnl the PHP source/build root, not the extension's subdirectory within it.
     php_mongodb_ext_builddir=PHP_EXT_BUILDDIR(mongodb)
+    php_mongodb_ext_srcdir=PHP_EXT_SRCDIR(mongodb)
 
     dnl Add the build directories as include paths so the compiler finds generated
     dnl config headers (common-config.h, bson/config.h, mongoc-config.h, etc.).
@@ -419,12 +420,12 @@ if test "$PHP_MONGODB" != "no"; then
     dnl For standalone out-of-source builds this stays in the build tree; for
     dnl PHP in-tree builds it lands under ext/mongodb/ rather than the PHP root.
     AC_CONFIG_FILES([
-      ${php_mongodb_ext_builddir}/src/libmongoc/src/common/src/common-config.h
-      ${php_mongodb_ext_builddir}/src/libmongoc/src/libbson/src/bson/config.h
-      ${php_mongodb_ext_builddir}/src/libmongoc/src/libbson/src/bson/version.h
-      ${php_mongodb_ext_builddir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config.h
-      ${php_mongodb_ext_builddir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config-private.h
-      ${php_mongodb_ext_builddir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-version.h
+      ${php_mongodb_ext_srcdir}/src/libmongoc/src/common/src/common-config.h
+      ${php_mongodb_ext_srcdir}/src/libmongoc/src/libbson/src/bson/config.h
+      ${php_mongodb_ext_srcdir}/src/libmongoc/src/libbson/src/bson/version.h
+      ${php_mongodb_ext_srcdir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config.h
+      ${php_mongodb_ext_srcdir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config-private.h
+      ${php_mongodb_ext_srcdir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-version.h
     ])
 
     if test "x$bundled_utf8proc" = "xyes"; then
@@ -439,7 +440,7 @@ if test "$PHP_MONGODB" != "no"; then
       PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/zlib-1.3.1/], $PHP_MONGODB_ZLIB_SOURCES, $PHP_MONGODB_ZLIB_CFLAGS)
       PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/zlib-1.3.1/])
       PHP_MONGODB_ADD_BUILD_DIR([src/libmongoc/src/zlib-1.3.1/])
-      AC_CONFIG_FILES([${php_mongodb_ext_builddir}/src/libmongoc/src/zlib-1.3.1/zconf.h])
+      AC_CONFIG_FILES([${php_mongodb_ext_srcdir}/src/libmongoc/src/zlib-1.3.1/zconf.h])
     fi
 
     if test "$PHP_MONGODB_CLIENT_SIDE_ENCRYPTION" = "yes"; then
@@ -478,7 +479,7 @@ if test "$PHP_MONGODB" != "no"; then
       PHP_MONGODB_ADD_BUILD_DIR([src/libmongocrypt/kms-message/src/])
 
       AC_CONFIG_FILES([
-        ${php_mongodb_ext_builddir}/src/libmongocrypt/src/mongocrypt-config.h
+        ${php_mongodb_ext_srcdir}/src/libmongocrypt/src/mongocrypt-config.h
       ])
     fi
   fi


### PR DESCRIPTION
PHPC-2715

Runs phpize in the extension source directory, then invokes configure and make from a separate build directory. This catches regressions where generated headers are placed relative to $PWD rather than the extension source (PHP_EXT_SRCDIR), which breaks any build where configure is not run from within the extension directory.

This PR also cherry-picks the fix from #2007 to ensure the out-of-source build is actually fixed.