### PR TITLE
PHPC-2647, PHPC-2715: Fix all possible build configurations (standalone vs. in-tree, in-source vs. out-of-source)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -253,7 +253,7 @@ jobs:
 
     strategy:
       matrix:
-        mode: ['from-source', 'out-of-source']
+        mode: ['in-source', 'out-of-source']
 
     steps:
       - name: "Checkout"
@@ -290,8 +290,11 @@ jobs:
           if [ "${{ matrix.mode }}" = "out-of-source" ]; then
             mkdir -p /tmp/php-build
             echo "PHP_BUILD_DIR=/tmp/php-build" >> "$GITHUB_ENV"
-          else
+          elif [ "${{ matrix.mode }}" = "in-source" ]; then
             echo "PHP_BUILD_DIR=$GITHUB_WORKSPACE/php-src" >> "$GITHUB_ENV"
+          else
+            echo "Invalid mode"
+            exit 1
           fi
 
         # Note: --with-openssl is needed for the bundled libmongoc's TLS support.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -300,6 +300,7 @@ jobs:
         # Note: --with-openssl is needed for the bundled libmongoc's TLS support.
       - name: "Configure PHP with MongoDB extension (static)"
         run: |
+          [ -n "$PHP_BUILD_DIR" ] || { echo "PHP_BUILD_DIR is not set"; exit 1; }
           "$GITHUB_WORKSPACE/php-src/configure" \
             --enable-debug \
             --enable-cli \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,11 +240,20 @@ jobs:
   # --enable-mongodb instead of --enable-mongodb=shared), as done by projects
   # like StaticPHP.  This exercises the PHP in-tree build path where configure
   # is invoked from the PHP source root rather than the extension directory.
-  test-static-php-build:
-    name: "Static PHP Build"
+  # Two modes are tested:
+  #   from-source   — configure and build run from the PHP source directory
+  #                   (PHP source dir = PHP build dir, layout 3)
+  #   out-of-source — configure and build run from a separate build directory
+  #                   (PHP source dir ≠ PHP build dir, layout 4)
+  test-in-tree-build:
+    name: "Static PHP Build (${{ matrix.mode }})"
     runs-on: "ubuntu-latest"
     env:
       PHP_VERSION: "8.5.5"
+
+    strategy:
+      matrix:
+        mode: ['from-source', 'out-of-source']
 
     steps:
       - name: "Checkout"
@@ -276,24 +285,34 @@ jobs:
       - name: "Generate PHP build scripts"
         run: cd "$GITHUB_WORKSPACE/php-src" && ./buildconf --force
 
+      - name: "Set build directory"
+        run: |
+          if [ "${{ matrix.mode }}" = "out-of-source" ]; then
+            mkdir -p /tmp/php-build
+            echo "PHP_BUILD_DIR=/tmp/php-build" >> "$GITHUB_ENV"
+          else
+            echo "PHP_BUILD_DIR=$GITHUB_WORKSPACE/php-src" >> "$GITHUB_ENV"
+          fi
+
         # Note: --with-openssl is needed for the bundled libmongoc's TLS support.
       - name: "Configure PHP with MongoDB extension (static)"
         run: |
-          cd "$GITHUB_WORKSPACE/php-src"
-          ./configure \
+          "$GITHUB_WORKSPACE/php-src/configure" \
             --enable-debug \
             --enable-cli \
             --enable-mongodb \
             --enable-mongodb-developer-flags \
             --with-openssl
+        working-directory: ${{ env.PHP_BUILD_DIR }}
 
       - name: "Build PHP"
-        run: cd "$GITHUB_WORKSPACE/php-src" && make -j$(nproc)
+        run: make -j$(nproc)
+        working-directory: ${{ env.PHP_BUILD_DIR }}
 
       - name: "Verify MongoDB extension is compiled in"
         run: |
-          "$GITHUB_WORKSPACE/php-src/sapi/cli/php" -m | grep -ix mongodb
-          "$GITHUB_WORKSPACE/php-src/sapi/cli/php" --ri mongodb
+          "$PHP_BUILD_DIR/sapi/cli/php" -m | grep -ix mongodb
+          "$PHP_BUILD_DIR/sapi/cli/php" --ri mongodb
 
   test-out-of-source-build:
     name: "Out-of-source Build"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -241,7 +241,7 @@ jobs:
   # like StaticPHP.  This exercises the PHP in-tree build path where configure
   # is invoked from the PHP source root rather than the extension directory.
   # Two modes are tested:
-  #   from-source   — configure and build run from the PHP source directory
+  #   in-source     — configure and build run from the PHP source directory
   #                   (PHP source dir = PHP build dir, layout 3)
   #   out-of-source — configure and build run from a separate build directory
   #                   (PHP source dir ≠ PHP build dir, layout 4)

--- a/config.m4
+++ b/config.m4
@@ -374,27 +374,6 @@ if test "$PHP_MONGODB" != "no"; then
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libbson/src/jsonsl/], $PHP_MONGODB_JSONSL_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libmongoc/src/mongoc/], $PHP_MONGODB_MONGOC_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
 
-    dnl TODO: Use $ext_builddir/$ext_srcdir once this block can move after PHP_NEW_EXTENSION.
-    dnl $ext_builddir and $ext_srcdir are set by PHP_NEW_EXTENSION, but PHP_ADD_INCLUDE
-    dnl and PHP_MONGODB_ADD_SOURCES calls must precede PHP_NEW_EXTENSION, so the whole
-    dnl block cannot be deferred.  PHP_EXT_BUILDDIR/PHP_EXT_SRCDIR are M4 macros that
-    dnl are always available and provide equivalent values without that constraint.
-    dnl
-    dnl PHP_EXT_BUILDDIR expands to the extension's directory relative to the build
-    dnl root: "ext/mongodb" for PHP in-tree builds, "." for phpize builds.  Pairing
-    dnl it with $abs_builddir (the absolute path to wherever configure was invoked)
-    dnl produces the correct absolute path to the generated config headers regardless
-    dnl of build layout.  Using $PWD here breaks PHP in-tree builds because $PWD is
-    dnl the PHP source/build root, not the extension's subdirectory within it.
-    php_mongodb_ext_builddir=PHP_EXT_BUILDDIR(mongodb)
-    php_mongodb_ext_srcdir=PHP_EXT_SRCDIR(mongodb)
-
-    dnl Add the build directories as include paths so the compiler finds generated
-    dnl config headers (common-config.h, bson/config.h, mongoc-config.h, etc.).
-    PHP_ADD_INCLUDE([$abs_builddir/$php_mongodb_ext_builddir/src/libmongoc/src/common/src])
-    PHP_ADD_INCLUDE([$abs_builddir/$php_mongodb_ext_builddir/src/libmongoc/src/libbson/src])
-    PHP_ADD_INCLUDE([$abs_builddir/$php_mongodb_ext_builddir/src/libmongoc/src/libmongoc/src])
-
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/common/src/])
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/uthash/])
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/libbson/src/])
@@ -415,17 +394,26 @@ if test "$PHP_MONGODB" != "no"; then
       PHP_MONGODB_ADD_BUILD_DIR([src/libmongoc/src/kms-message/src/])
     fi
 
-    dnl Write generated config headers into the extension's build directory
-    dnl (${php_mongodb_ext_builddir}/... relative to the configure invocation directory).
-    dnl For standalone out-of-source builds this stays in the build tree; for
-    dnl PHP in-tree builds it lands under ext/mongodb/ rather than the PHP root.
+    dnl PHP_EXT_BUILDDIR expands to "ext/mongodb" for PHP in-tree builds and
+    dnl "." for phpize builds.  Captured as a shell variable here because
+    dnl AC_CONFIG_FILES paths are expanded at configure run time, not at M4
+    dnl processing time.
+    mongodb_builddir=PHP_EXT_BUILDDIR(mongodb)
+
+    dnl Generated config headers are written into the extension build directory.
+    dnl For standalone out-of-source builds they stay in the build tree; for PHP
+    dnl in-tree builds they land under ext/mongodb/ rather than the PHP root.
+    PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongoc/src/common/src/])
+    PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongoc/src/libbson/src/])
+    PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongoc/src/libmongoc/src/])
+
     AC_CONFIG_FILES([
-      ${php_mongodb_ext_srcdir}/src/libmongoc/src/common/src/common-config.h
-      ${php_mongodb_ext_srcdir}/src/libmongoc/src/libbson/src/bson/config.h
-      ${php_mongodb_ext_srcdir}/src/libmongoc/src/libbson/src/bson/version.h
-      ${php_mongodb_ext_srcdir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config.h
-      ${php_mongodb_ext_srcdir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config-private.h
-      ${php_mongodb_ext_srcdir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-version.h
+      ${mongodb_builddir}/src/libmongoc/src/common/src/common-config.h
+      ${mongodb_builddir}/src/libmongoc/src/libbson/src/bson/config.h
+      ${mongodb_builddir}/src/libmongoc/src/libbson/src/bson/version.h
+      ${mongodb_builddir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config.h
+      ${mongodb_builddir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-config-private.h
+      ${mongodb_builddir}/src/libmongoc/src/libmongoc/src/mongoc/mongoc-version.h
     ])
 
     if test "x$bundled_utf8proc" = "xyes"; then
@@ -440,7 +428,8 @@ if test "$PHP_MONGODB" != "no"; then
       PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/zlib-1.3.1/], $PHP_MONGODB_ZLIB_SOURCES, $PHP_MONGODB_ZLIB_CFLAGS)
       PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/zlib-1.3.1/])
       PHP_MONGODB_ADD_BUILD_DIR([src/libmongoc/src/zlib-1.3.1/])
-      AC_CONFIG_FILES([${php_mongodb_ext_srcdir}/src/libmongoc/src/zlib-1.3.1/zconf.h])
+      PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongoc/src/zlib-1.3.1/])
+      AC_CONFIG_FILES([${mongodb_builddir}/src/libmongoc/src/zlib-1.3.1/zconf.h])
     fi
 
     if test "$PHP_MONGODB_CLIENT_SIDE_ENCRYPTION" = "yes"; then
@@ -478,8 +467,10 @@ if test "$PHP_MONGODB" != "no"; then
       PHP_MONGODB_ADD_BUILD_DIR([src/libmongocrypt/src/unicode/])
       PHP_MONGODB_ADD_BUILD_DIR([src/libmongocrypt/kms-message/src/])
 
+      PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongocrypt/src/])
+
       AC_CONFIG_FILES([
-        ${php_mongodb_ext_srcdir}/src/libmongocrypt/src/mongocrypt-config.h
+        ${mongodb_builddir}/src/libmongocrypt/src/mongocrypt-config.h
       ])
     fi
   fi

--- a/scripts/autotools/m4/php_mongodb.m4
+++ b/scripts/autotools/m4/php_mongodb.m4
@@ -41,6 +41,17 @@ AC_DEFUN([PHP_MONGODB_ADD_INCLUDE],[
 ])
 
 dnl
+dnl PHP_MONGODB_ADD_BUILD_INCLUDE(path)
+dnl
+dnl Adds an include path relative to the extension build directory (i.e.
+dnl PHP_EXT_BUILDDIR). Use this for directories containing generated files
+dnl (e.g. config headers written by AC_CONFIG_FILES).
+dnl
+AC_DEFUN([PHP_MONGODB_ADD_BUILD_INCLUDE],[
+  PHP_ADD_INCLUDE(PHP_EXT_BUILDDIR(mongodb)[/][$1])
+])
+
+dnl
 dnl PHP_MONGODB_ADD_BUILD_DIR(path)
 dnl
 dnl Adds a build directory relative to the extension build directory (i.e.

--- a/scripts/autotools/m4/php_mongodb.m4
+++ b/scripts/autotools/m4/php_mongodb.m4
@@ -47,8 +47,19 @@ dnl Adds an include path relative to the extension build directory (i.e.
 dnl PHP_EXT_BUILDDIR). Use this for directories containing generated files
 dnl (e.g. config headers written by AC_CONFIG_FILES).
 dnl
+dnl PHP_EXT_BUILDDIR returns a path relative to the configure invocation
+dnl directory (e.g. "." for phpize builds, "ext/mongodb" for in-tree builds).
+dnl The subdirectory passed as $1 does not exist at configure time (build dirs
+dnl are created in AC_CONFIG_COMMANDS_PRE), so passing the full relative path
+dnl to PHP_ADD_INCLUDE would cause PHP_EXPAND_PATH to silently discard it when
+dnl the "cd $path && pwd" probe fails.  To avoid this, we resolve only the base
+dnl (PHP_EXT_BUILDDIR, which always exists at configure time) to an absolute
+dnl path first, then append $1.  PHP_ADD_INCLUDE skips the cd-probe for paths
+dnl that already start with "/".
+dnl
 AC_DEFUN([PHP_MONGODB_ADD_BUILD_INCLUDE],[
-  PHP_ADD_INCLUDE(PHP_EXT_BUILDDIR(mongodb)[/][$1])
+  PHP_EXPAND_PATH(PHP_EXT_BUILDDIR(mongodb), php_mongodb_abs_builddir)
+  PHP_ADD_INCLUDE([$php_mongodb_abs_builddir/$1])
 ])
 
 dnl


### PR DESCRIPTION
PHPC-2647, PHPC-2715

This PR revives the original goal of PHPC-2647 — keeping generated config headers (`common-config.h`, `bson/config.h`, `mongoc-config.h`, etc.) out of the source tree during out-of-source builds — while correctly handling all four build layouts the extension supports. It supersedes the partial fixes in PHPC-2714 and PHPC-2715.

## The four build layouts

**1. phpize — in-source**

`phpize` is run in the source directory, and `./configure` is invoked from that same directory. This is the standard workflow for building the extension standalone.

```
cd /path/to/mongo-php-driver
phpize
./configure
make
```

`PHP_EXT_BUILDDIR(mongodb)` = `.` (resolves to `/path/to/mongo-php-driver`); `PHP_EXT_SRCDIR(mongodb)` = `/path/to/mongo-php-driver`

**2. phpize — out-of-source**

`phpize` is run in the source directory to generate `configure`, then `configure` is invoked from a *separate* build directory. This is the layout used by RHEL/RPM packaging and any packager that wants a clean source tree.

```
cd /path/to/mongo-php-driver
phpize
mkdir /tmp/build && cd /tmp/build
/path/to/mongo-php-driver/configure
make
```

`PHP_EXT_BUILDDIR(mongodb)` = `.` (resolves to `/tmp/build`); `PHP_EXT_SRCDIR(mongodb)` = `/path/to/mongo-php-driver`

**3. PHP in-tree — source = build**

The extension is compiled statically into PHP (used by projects like
[StaticPHP](https://github.com/crazywhalecc/static-php-cli)). PHP's `buildconf`
discovers the extension's `config.m4` via a glob over `ext/*/config.m4`, and
`./configure` is run from the PHP source directory, which doubles as the build
directory.

```
ln -s /path/to/mongo-php-driver /path/to/php-src/ext/mongodb
cd /path/to/php-src
./buildconf --force
./configure --enable-mongodb
make
```

`PHP_EXT_BUILDDIR(mongodb)` = `ext/mongodb` (resolves to `/path/to/php-src/ext/mongodb`); `PHP_EXT_SRCDIR(mongodb)` = `/path/to/php-src/ext/mongodb`

**4. PHP in-tree — source ≠ build**

Same as (3) but PHP itself is configured with a dedicated build directory.

```
ln -s /path/to/mongo-php-driver /path/to/php-src/ext/mongodb
cd /path/to/php-src && ./buildconf --force
mkdir /tmp/php-build && cd /tmp/php-build
/path/to/php-src/configure --enable-mongodb
make
```

`PHP_EXT_BUILDDIR(mongodb)` = `ext/mongodb` (resolves to `/tmp/php-build/ext/mongodb`); `PHP_EXT_SRCDIR(mongodb)` = `/path/to/php-src/ext/mongodb`

## History of the problem

**PHPC-2647** (`a2bb085`) changed `AC_CONFIG_FILES` from absolute source-tree
paths to bare relative paths (e.g. `src/libmongoc/src/common/src/common-config.h`).
Relative paths in `AC_CONFIG_FILES` are resolved relative to the directory
where `./configure` was invoked:

| Build layout | configure invocation dir | Headers written to |
|---|---|---|
| phpize in-source | `/source` | `/source/src/...` — in source tree |
| phpize out-of-source | `/build` | `/build/src/...` — in build tree ✓ |
| PHP in-tree (src=build) | `/php-src` | `/php-src/src/libmongoc/...` — wrong location ✗ |
| PHP in-tree (src≠build) | `/php-build` | `/php-build/src/libmongoc/...` — wrong location ✗ |

For in-tree PHP builds (layouts 3 and 4), the configure invocation directory is
the PHP root, so bare relative paths like `src/libmongoc/...` land at
`/php-root/src/libmongoc/...` instead of under `ext/mongodb/`.

**PHPC-2714** (`79b6416`) fixed layouts 3 and 4 by using
`${php_mongodb_ext_builddir}/src/...` where
`php_mongodb_ext_builddir = PHP_EXT_BUILDDIR(mongodb)`. That macro expands to
`ext/mongodb` for in-tree builds and `.` for phpize builds, so the headers land
in the right place relative to the build root in all cases. However, the fix
added build-tree include paths via `$abs_builddir/$php_mongodb_ext_builddir/...`,
which failed for phpize out-of-source builds (layout 2) due to how `abs_builddir`
interacts with relative `PHP_EXT_BUILDDIR` expansion. The failure was not caught
because no CI job tested layout 2 at the time.

**PHPC-2715** (`8f28ee4`) added a CI job for out-of-source builds and fixed the
failure by reverting `AC_CONFIG_FILES` to use `PHP_EXT_SRCDIR(mongodb)` (the
absolute source-tree path). This restores the pre-PHPC-2647 behaviour: headers
are always written to the source tree. The include paths, however, continued
to point into the build tree:

| Build layout | `AC_CONFIG_FILES` writes to | Include path reads from | Match? |
|---|---|---|---|
| phpize in-source | `/source/src/...` (srcdir) | `/source/src/...` (builddir = srcdir) | ✓ |
| phpize out-of-source | `/source/src/...` (srcdir) | `/build/src/...` (builddir ≠ srcdir) | ✗ |
| PHP in-tree (src=build) | `/php-src/ext/mongodb/src/...` | `/php-src/ext/mongodb/src/...` | ✓ |
| PHP in-tree (src≠build) | `/php-src/ext/mongodb/src/...` | `/php-build/ext/mongodb/src/...` | ✗ |

PHPC-2715 works only when source dir = build dir (layouts 1 and 3), which
happened to cover all tested scenarios. Layouts 2 and 4 remained broken.
Additionally, using `PHP_EXT_SRCDIR` always writes generated files into the
source tree, abandoning the PHPC-2647 goal.

## What this PR does

Three changes:

**1. Add `PHP_MONGODB_ADD_BUILD_INCLUDE` to `scripts/autotools/m4/php_mongodb.m4`**

A new macro, parallel to the existing `PHP_MONGODB_ADD_INCLUDE` (which uses
`PHP_EXT_SRCDIR`) and `PHP_MONGODB_ADD_BUILD_DIR` (which uses
`PHP_EXT_BUILDDIR`):

```m4
AC_DEFUN([PHP_MONGODB_ADD_BUILD_INCLUDE],[
  PHP_EXPAND_PATH(PHP_EXT_BUILDDIR(mongodb), php_mongodb_abs_builddir)
  PHP_ADD_INCLUDE([$php_mongodb_abs_builddir/$1])
])
```

`PHP_ADD_INCLUDE` calls `PHP_EXPAND_PATH` internally, which resolves a path to
absolute using `cd $path && pwd`. This probe requires the target directory to
exist, but the build subdirectories (e.g. `src/libmongoc/src/libbson/src/`) are
only created by `PHP_ADD_BUILD_DIR` later in `AC_CONFIG_COMMANDS_PRE`. Passing
the full relative path (e.g. `./src/libmongoc/src/libbson/src/`) would cause
`PHP_EXPAND_PATH` to silently discard it when the `cd` fails.

To avoid this, we first expand only `PHP_EXT_BUILDDIR(mongodb)` — which is `.`
or `ext/mongodb`, both of which exist at configure time — to get the absolute
build root. We then append the subdirectory and pass the resulting absolute path
to `PHP_ADD_INCLUDE`. `PHP_EXPAND_PATH` short-circuits for paths starting with
`/` and uses them as-is, so the subdirectory is not required to exist yet.

**2. Use `PHP_EXT_BUILDDIR` for `AC_CONFIG_FILES` and `PHP_MONGODB_ADD_BUILD_INCLUDE` for the compiler include paths in `config.m4`**

`AC_CONFIG_FILES` paths now use `${mongodb_builddir}` where
`mongodb_builddir = PHP_EXT_BUILDDIR(mongodb)`. A `PHP_MONGODB_ADD_BUILD_INCLUDE`
call is added alongside each group of `AC_CONFIG_FILES` entries so the compiler
include paths mirror the write locations:

| Build layout | `AC_CONFIG_FILES` writes to | `ADD_BUILD_INCLUDE` adds | Source tree written? |
|---|---|---|---|
| phpize in-source | `./src/...` → `/source/src/...` | `-I/source/src/...` | Yes (unavoidable: src=build) |
| phpize out-of-source | `./src/...` → `/build/src/...` | `-I/build/src/...` | No ✓ |
| PHP in-tree (src=build) | `ext/mongodb/src/...` → `/php-src/ext/mongodb/src/...` | `-I/php-src/ext/mongodb/src/...` | Yes (unavoidable: src=build) |
| PHP in-tree (src≠build) | `ext/mongodb/src/...` → `/php-build/ext/mongodb/src/...` | `-I/php-build/ext/mongodb/src/...` | No ✓ |

Write location and include path always agree. The source tree is only written to
when the build directory is the same as the source directory, which is
unavoidable by definition.

**3. Extend `test-in-tree-build` in `.github/workflows/tests.yml` with an `out-of-source` mode**

The existing job (formerly `test-static-php-build`, added in PHPC-2714) only
ran PHP's configure from the PHP source directory (layout 3). A `mode` matrix
(`from-source`, `out-of-source`) is added. The `out-of-source` mode creates a
separate `/tmp/php-build` directory and runs configure and make from there,
exercising layout 4.

## CI coverage

The `test-in-tree-build` job (renamed from `test-static-php-build`, added in PHPC-2714) covers layouts 3 and 4 via a `mode` matrix (`from-source` and `out-of-source`).
The `test-out-of-source-build` job (added in PHPC-2715) covers layout 2.
Layout 1 is covered by the standard `linux-test` jobs.
