### PR TITLE
Implement memory handling correctness fixes

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -480,6 +480,7 @@ if test "$PHP_MONGODB" != "no"; then
   PHP_SUBST(MONGODB_SHARED_LIBADD)
 
   PHP_ADD_EXTENSION_DEP(mongodb, date)
+  PHP_ADD_EXTENSION_DEP(mongodb, hash)
   PHP_ADD_EXTENSION_DEP(mongodb, json)
   PHP_ADD_EXTENSION_DEP(mongodb, spl)
   PHP_ADD_EXTENSION_DEP(mongodb, standard)

--- a/config.w32
+++ b/config.w32
@@ -75,6 +75,7 @@ ARG_WITH("mongodb-client-side-encryption", "MongoDB: Enable client-side encrypti
 
 if (PHP_MONGODB != "no") {
   ADD_EXTENSION_DEP("mongodb", "date", false);
+  ADD_EXTENSION_DEP("mongodb", "hash", false);
   ADD_EXTENSION_DEP("mongodb", "standard", false);
   ADD_EXTENSION_DEP("mongodb", "json", false);
   ADD_EXTENSION_DEP("mongodb", "spl", false);

--- a/src/BSON/Binary.c
+++ b/src/BSON/Binary.c
@@ -51,6 +51,10 @@ static bool phongo_binary_init(phongo_binary_t* intern, const char* data, size_t
 		return false;
 	}
 
+	if (intern->data) {
+		efree(intern->data);
+	}
+
 	intern->data     = estrndup(data, data_len);
 	intern->data_len = data_len;
 	intern->type     = (uint8_t) type;

--- a/src/BSON/Int64.c
+++ b/src/BSON/Int64.c
@@ -443,12 +443,20 @@ static zend_result phongo_int64_do_operation_ex(zend_uchar opcode, zval* result,
 
 		case ZEND_SL:
 			PHONGO_GET_INT64(value2, op2);
-			OPERATION_RESULT_INT64(value1 << value2);
+			if (value2 < 0) {
+				zend_throw_exception(zend_ce_arithmetic_error, "Bit shift by negative number", 0);
+				return FAILURE;
+			}
+			OPERATION_RESULT_INT64(value2 >= 64 ? 0 : (int64_t) ((uint64_t) value1 << value2));
 			return SUCCESS;
 
 		case ZEND_SR:
 			PHONGO_GET_INT64(value2, op2);
-			OPERATION_RESULT_INT64(value1 >> value2);
+			if (value2 < 0) {
+				zend_throw_exception(zend_ce_arithmetic_error, "Bit shift by negative number", 0);
+				return FAILURE;
+			}
+			OPERATION_RESULT_INT64(value2 >= 64 ? (value1 < 0 ? -1 : 0) : value1 >> value2);
 			return SUCCESS;
 
 		case ZEND_POW:

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -46,6 +46,14 @@ static bool phongo_javascript_init(phongo_javascript_t* intern, const char* code
 	if (scope && (Z_TYPE_P(scope) == IS_OBJECT || Z_TYPE_P(scope) == IS_ARRAY)) {
 		intern->scope = bson_new();
 		phongo_zval_to_bson(scope, PHONGO_BSON_NONE, intern->scope, NULL);
+
+		if (EG(exception)) {
+			efree(intern->code);
+			intern->code = NULL;
+			bson_destroy(intern->scope);
+			intern->scope = NULL;
+			return false;
+		}
 	} else {
 		intern->scope = NULL;
 	}

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -40,6 +40,14 @@ static bool phongo_javascript_init(phongo_javascript_t* intern, const char* code
 		return false;
 	}
 
+	if (intern->code) {
+		efree(intern->code);
+	}
+	if (intern->scope) {
+		bson_destroy(intern->scope);
+		intern->scope = NULL;
+	}
+
 	intern->code     = estrndup(code, code_len);
 	intern->code_len = code_len;
 

--- a/src/BSON/Javascript.c
+++ b/src/BSON/Javascript.c
@@ -30,6 +30,9 @@ zend_class_entry* phongo_javascript_ce;
  * be thrown on error. */
 static bool phongo_javascript_init(phongo_javascript_t* intern, const char* code, size_t code_len, zval* scope)
 {
+	char*   new_code  = NULL;
+	bson_t* new_scope = NULL;
+
 	if (scope && Z_TYPE_P(scope) != IS_OBJECT && Z_TYPE_P(scope) != IS_ARRAY && Z_TYPE_P(scope) != IS_NULL) {
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected scope to be array or object, %s given", zend_get_type_by_const(Z_TYPE_P(scope)));
 		return false;
@@ -40,31 +43,31 @@ static bool phongo_javascript_init(phongo_javascript_t* intern, const char* code
 		return false;
 	}
 
+	new_code = estrndup(code, code_len);
+
+	if (scope && (Z_TYPE_P(scope) == IS_OBJECT || Z_TYPE_P(scope) == IS_ARRAY)) {
+		new_scope = bson_new();
+		phongo_zval_to_bson(scope, PHONGO_BSON_NONE, new_scope, NULL);
+
+		if (EG(exception)) {
+			efree(new_code);
+			bson_destroy(new_scope);
+			return false;
+		}
+	}
+
+	/* Commit the new state only after all fallible steps have succeeded so a
+	 * failure leaves the object's previous contents untouched. */
 	if (intern->code) {
 		efree(intern->code);
 	}
 	if (intern->scope) {
 		bson_destroy(intern->scope);
-		intern->scope = NULL;
 	}
 
-	intern->code     = estrndup(code, code_len);
+	intern->code     = new_code;
 	intern->code_len = code_len;
-
-	if (scope && (Z_TYPE_P(scope) == IS_OBJECT || Z_TYPE_P(scope) == IS_ARRAY)) {
-		intern->scope = bson_new();
-		phongo_zval_to_bson(scope, PHONGO_BSON_NONE, intern->scope, NULL);
-
-		if (EG(exception)) {
-			efree(intern->code);
-			intern->code = NULL;
-			bson_destroy(intern->scope);
-			intern->scope = NULL;
-			return false;
-		}
-	} else {
-		intern->scope = NULL;
-	}
+	intern->scope    = new_scope;
 
 	return true;
 }

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -42,14 +42,23 @@ static bool phongo_regex_init(phongo_regex_t* intern, const char* pattern, size_
 		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Pattern cannot contain null bytes");
 		return false;
 	}
+
+	if (flags && strlen(flags) != (size_t) flags_len) {
+		phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Flags cannot contain null bytes");
+		return false;
+	}
+
+	if (intern->pattern) {
+		efree(intern->pattern);
+	}
+	if (intern->flags) {
+		efree(intern->flags);
+	}
+
 	intern->pattern     = estrndup(pattern, pattern_len);
 	intern->pattern_len = pattern_len;
 
 	if (flags) {
-		if (strlen(flags) != (size_t) flags_len) {
-			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Flags cannot contain null bytes");
-			return false;
-		}
 		intern->flags     = estrndup(flags, flags_len);
 		intern->flags_len = flags_len;
 		/* Ensure flags are alphabetized upon initialization */

--- a/src/BSON/Regex.c
+++ b/src/BSON/Regex.c
@@ -296,10 +296,6 @@ void phongo_regex_init_ce(INIT_FUNC_ARGS)
 bool phongo_regex_new(zval* object, const char* pattern, const char* flags)
 {
 	PHONGO_INTERN_INIT_EX(regex, object);
-	intern->pattern_len = strlen(pattern);
-	intern->pattern     = estrndup(pattern, intern->pattern_len);
-	intern->flags_len   = strlen(flags);
-	intern->flags       = estrndup(flags, intern->flags_len);
 
-	return true;
+	return phongo_regex_init(intern, pattern, strlen(pattern), flags, strlen(flags));
 }

--- a/src/MongoDB/ClientEncryption.c
+++ b/src/MongoDB/ClientEncryption.c
@@ -856,7 +856,7 @@ static mongoc_client_encryption_encrypt_range_opts_t* phongo_clientencryption_en
 	if (php_array_existsc(options, "sparsity")) {
 		int64_t sparsity = php_array_fetchc_long(options, "sparsity");
 
-		if (sparsity < 0 || sparsity > INT64_MAX) {
+		if (sparsity < 0) {
 			phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Expected \"sparsity\" range option to be a positive 64-bit integer, %" PRId64 " given", sparsity);
 			goto cleanup;
 		}

--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -787,6 +787,15 @@ static bool phongo_bson_visit_document(const bson_iter_t* iter ARG_UNUSED, const
 			object_init_ex(&obj, obj_ce);
 
 			zend_call_method_with_1_params(Z_OBJ_P(&obj), NULL, NULL, BSON_UNSERIALIZE_FUNC_NAME, NULL, &state.zchild);
+
+			if (EG(exception)) {
+				zval_ptr_dtor(&obj);
+				zval_ptr_dtor(&state.zchild);
+				phongo_bson_state_dtor(&state);
+				phongo_field_path_pop(parent_state->field_path);
+				return true;
+			}
+
 			zval_ptr_dtor(&state.zchild);
 			ZVAL_COPY_VALUE(&state.zchild, &obj);
 
@@ -863,6 +872,15 @@ static bool phongo_bson_visit_array(const bson_iter_t* iter ARG_UNUSED, const ch
 
 			object_init_ex(&obj, state.field_type.ce);
 			zend_call_method_with_1_params(Z_OBJ_P(&obj), NULL, NULL, BSON_UNSERIALIZE_FUNC_NAME, NULL, &state.zchild);
+
+			if (EG(exception)) {
+				zval_ptr_dtor(&obj);
+				zval_ptr_dtor(&state.zchild);
+				phongo_bson_state_dtor(&state);
+				phongo_field_path_pop(parent_state->field_path);
+				return true;
+			}
+
 			zval_ptr_dtor(&state.zchild);
 			ZVAL_COPY_VALUE(&state.zchild, &obj);
 			break;

--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -205,6 +205,10 @@ bool phongo_field_path_push(phongo_field_path* field_path, const char* element, 
 
 bool phongo_field_path_pop(phongo_field_path* field_path)
 {
+	if (field_path->size == 0) {
+		return false;
+	}
+
 	phongo_field_path_ensure_allocation(field_path, field_path->size);
 
 	field_path->elements[field_path->size]      = NULL;

--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -115,7 +115,11 @@ char* phongo_field_path_as_string(phongo_field_path* field_path)
 		ptr++;
 	}
 
-	ptr[-1] = '\0';
+	if (ptr == path) {
+		path[0] = '\0';
+	} else {
+		ptr[-1] = '\0';
+	}
 
 	return path;
 }

--- a/src/phongo_bson.c
+++ b/src/phongo_bson.c
@@ -927,7 +927,7 @@ bool phongo_bson_to_zval(const bson_t* b, zval* zv)
 }
 
 /* Converts BSON data to a PHP value using the default typemap. */
-bool phongo_bson_data_to_zval(const unsigned char* data, int data_len, zval* zv)
+bool phongo_bson_data_to_zval(const unsigned char* data, size_t data_len, zval* zv)
 {
 	bool              retval;
 	phongo_bson_state state;
@@ -1209,7 +1209,7 @@ cleanup:
  * as-is on PHP 7; however, it should have the type undefined if the state
  * was initialized to zero.
  */
-bool phongo_bson_data_to_zval_ex(const unsigned char* data, int data_len, phongo_bson_state* state)
+bool phongo_bson_data_to_zval_ex(const unsigned char* data, size_t data_len, phongo_bson_state* state)
 {
 	bson_reader_t* reader = NULL;
 	const bson_t*  b;

--- a/src/phongo_bson.h
+++ b/src/phongo_bson.h
@@ -109,8 +109,8 @@ bool               phongo_field_path_pop(phongo_field_path* field_path);
 bool phongo_bson_to_json(zval* return_value, const bson_t* bson, phongo_json_mode_t mode);
 bool phongo_bson_to_zval(const bson_t* b, zval* zv);
 bool phongo_bson_to_zval_ex(const bson_t* b, phongo_bson_state* state);
-bool phongo_bson_data_to_zval(const unsigned char* data, int data_len, zval* zv);
-bool phongo_bson_data_to_zval_ex(const unsigned char* data, int data_len, phongo_bson_state* state);
+bool phongo_bson_data_to_zval(const unsigned char* data, size_t data_len, zval* zv);
+bool phongo_bson_data_to_zval_ex(const unsigned char* data, size_t data_len, phongo_bson_state* state);
 
 bool phongo_bson_value_to_zval(const bson_value_t* value, zval* zv);
 bool phongo_bson_value_to_zval_legacy(const bson_value_t* value, zval* zv);

--- a/src/phongo_bson_encode.c
+++ b/src/phongo_bson_encode.c
@@ -571,11 +571,12 @@ void phongo_zval_to_bson(zval* data, phongo_bson_flags_t flags, bson_t* bson, bs
 	phongo_field_path_free(field_path);
 }
 
-static void phongo_zval_to_bson_value_ex(zval* data, phongo_bson_flags_t flags, bson_value_t* value)
+static bool phongo_zval_to_bson_value_ex(zval* data, phongo_bson_flags_t flags, bson_value_t* value)
 {
 	bson_iter_t iter;
 	bson_t      bson = BSON_INITIALIZER;
 	zval        data_object;
+	bool        success = false;
 
 	array_init_size(&data_object, 1);
 	add_assoc_zval(&data_object, "data", data);
@@ -584,12 +585,15 @@ static void phongo_zval_to_bson_value_ex(zval* data, phongo_bson_flags_t flags, 
 
 	phongo_zval_to_bson(&data_object, flags, &bson, NULL);
 
-	if (bson_iter_init_find(&iter, &bson, "data")) {
+	if (!EG(exception) && bson_iter_init_find(&iter, &bson, "data")) {
 		bson_value_copy(bson_iter_value(&iter), value);
+		success = true;
 	}
 
 	bson_destroy(&bson);
 	zval_ptr_dtor(&data_object);
+
+	return success;
 }
 
 /* Converts the argument to a bson_value_t. If the object is an instance of
@@ -651,8 +655,7 @@ bool phongo_zval_to_bson_value(zval* data, bson_value_t* value)
 		case IS_ARRAY:
 		case IS_OBJECT:
 			/* Use phongo_zval_to_bson internally to convert arrays and documents */
-			phongo_zval_to_bson_value_ex(data, PHONGO_BSON_NONE, value);
-			return true;
+			return phongo_zval_to_bson_value_ex(data, PHONGO_BSON_NONE, value);
 	}
 
 	phongo_throw_exception(PHONGO_ERROR_INVALID_ARGUMENT, "Unsupported type %s", zend_zval_type_name(data));

--- a/src/phongo_bson_encode.c
+++ b/src/phongo_bson_encode.c
@@ -643,6 +643,11 @@ bool phongo_zval_to_bson_value(zval* data, bson_value_t* value)
 			return true;
 
 		case IS_STRING:
+			if (!bson_utf8_validate(Z_STRVAL_P(data), Z_STRLEN_P(data), true)) {
+				phongo_throw_exception(PHONGO_ERROR_UNEXPECTED_VALUE, "Detected invalid UTF-8 in string value");
+				return false;
+			}
+
 			value->value_type       = BSON_TYPE_UTF8;
 			value->value.v_utf8.len = Z_STRLEN_P(data);
 

--- a/src/phongo_client.c
+++ b/src/phongo_client.c
@@ -18,6 +18,8 @@
 #include "mongoc/mongoc.h"
 
 #include <php.h>
+#include <ext/hash/php_hash.h>
+#include <ext/hash/php_hash_sha.h>
 #include <ext/standard/php_var.h>
 #include <Zend/zend_smart_str.h>
 
@@ -820,7 +822,7 @@ static zval* phongo_manager_prepare_manager_for_hash(zval* driverOptions, bool* 
 	return driverOptionsClone;
 }
 
-/* Creates a hash for a client by concatenating the URI string with serialized
+/* Creates a hash for a client from a digest of the URI string and serialized
  * options arrays. On success, a persistent string is returned (i.e. pefree()
  * should be used to free it) and hash_len will be set to the string's length.
  * On error, an exception will have been thrown and NULL will be returned. */
@@ -831,12 +833,21 @@ static char* phongo_manager_make_client_hash(const char* uri_string, zval* optio
 	php_serialize_data_t var_hash;
 	zval*                serializable_driver_options = NULL;
 	bool                 free_driver_options         = false;
+	PHP_SHA256_CTX       sha_ctx;
+	unsigned char        sha_digest[32];
+	char                 sha_hex[65];
 
 	zval args;
 
+	PHP_SHA256Init(&sha_ctx);
+	PHP_SHA256Update(&sha_ctx, (const unsigned char*) uri_string, strlen(uri_string));
+	PHP_SHA256Final(sha_digest, &sha_ctx);
+	php_hash_bin2hex(sha_hex, sha_digest, sizeof(sha_digest));
+	sha_hex[64] = '\0';
+
 	array_init_size(&args, 4);
 	ADD_ASSOC_LONG_EX(&args, "pid", getpid());
-	ADD_ASSOC_STRING(&args, "uri", uri_string);
+	ADD_ASSOC_STRINGL(&args, "uri", sha_hex, 64);
 
 	if (options) {
 		ADD_ASSOC_ZVAL_EX(&args, "options", options);

--- a/src/phongo_client.c
+++ b/src/phongo_client.c
@@ -835,19 +835,16 @@ static char* phongo_manager_make_client_hash(const char* uri_string, zval* optio
 	bool                 free_driver_options         = false;
 	PHP_SHA256_CTX       sha_ctx;
 	unsigned char        sha_digest[32];
-	char                 sha_hex[65];
 
 	zval args;
 
 	PHP_SHA256Init(&sha_ctx);
 	PHP_SHA256Update(&sha_ctx, (const unsigned char*) uri_string, strlen(uri_string));
 	PHP_SHA256Final(sha_digest, &sha_ctx);
-	php_hash_bin2hex(sha_hex, sha_digest, sizeof(sha_digest));
-	sha_hex[64] = '\0';
 
 	array_init_size(&args, 4);
 	ADD_ASSOC_LONG_EX(&args, "pid", getpid());
-	ADD_ASSOC_STRINGL(&args, "uri", sha_hex, 64);
+	ADD_ASSOC_STRINGL(&args, "uri", (char*) sha_digest, sizeof(sha_digest));
 
 	if (options) {
 		ADD_ASSOC_ZVAL_EX(&args, "options", options);

--- a/src/phongo_structs.h
+++ b/src/phongo_structs.h
@@ -244,9 +244,9 @@ typedef struct {
 
 typedef struct {
 	char*       pattern;
-	int         pattern_len;
+	size_t      pattern_len;
 	char*       flags;
-	int         flags_len;
+	size_t      flags_len;
 	HashTable*  properties;
 	zend_object std;
 } phongo_regex_t;

--- a/tests/bson/bson-int64-operation-006.phpt
+++ b/tests/bson/bson-int64-operation-006.phpt
@@ -1,0 +1,52 @@
+--TEST--
+MongoDB\BSON\Int64 operations: shift count at or above operand width
+--FILE--
+<?php
+
+$pos = new MongoDB\BSON\Int64(10);
+$neg = new MongoDB\BSON\Int64(-10);
+
+// Left shift at or above 64 always returns 0
+var_dump($pos << 64);
+var_dump($neg << 64);
+var_dump($pos << 100);
+
+// Right shift at or above 64 returns 0 for positive, -1 for negative
+var_dump($pos >> 64);
+var_dump($neg >> 64);
+var_dump($pos >> 100);
+var_dump($neg >> 100);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(1) "0"
+}
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(1) "0"
+}
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(1) "0"
+}
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(1) "0"
+}
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(2) "-1"
+}
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(1) "0"
+}
+object(MongoDB\BSON\Int64)#%d (%d) {
+  ["integer"]=>
+  string(2) "-1"
+}
+===DONE===

--- a/tests/bson/bson-int64-operation_error-002.phpt
+++ b/tests/bson/bson-int64-operation_error-002.phpt
@@ -1,0 +1,26 @@
+--TEST--
+MongoDB\BSON\Int64 operation errors: shift by negative number
+--FILE--
+<?php
+
+require_once __DIR__ . '/../utils/basic.inc';
+
+$value = new MongoDB\BSON\Int64(10);
+
+echo throws(function() use ($value) {
+    var_dump($value << -1);
+}, ArithmeticError::class), "\n";
+
+echo throws(function() use ($value) {
+    var_dump($value >> -1);
+}, ArithmeticError::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got ArithmeticError
+Bit shift by negative number
+OK: Got ArithmeticError
+Bit shift by negative number
+===DONE===

--- a/tests/bulk/bulkwrite-ctor-comment_error-003.phpt
+++ b/tests/bulk/bulkwrite-ctor-comment_error-003.phpt
@@ -1,0 +1,18 @@
+--TEST--
+MongoDB\Driver\BulkWrite::__construct(): comment option encoding error (invalid UTF-8 scalar string)
+--FILE--
+<?php
+
+require_once __DIR__ . "/../utils/basic.inc";
+
+echo throws(function() {
+    new MongoDB\Driver\BulkWrite(['comment' => "\xc3\x28"]);
+}, MongoDB\Driver\Exception\UnexpectedValueException::class), "\n";
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+OK: Got MongoDB\Driver\Exception\UnexpectedValueException
+Detected invalid UTF-8 in string value
+===DONE===

--- a/tests/manager/manager-ctor-007.phpt
+++ b/tests/manager/manager-ctor-007.phpt
@@ -13,8 +13,8 @@ ini_set('mongodb.debug', '');
 <?php exit(0); ?>
 --EXPECTF--
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 %A
-[%s]     PHONGO: DEBUG   > Found client for hash: %s
+[%s]     PHONGO: DEBUG   > Found client for hash: %a
 %A
 ===DONE===

--- a/tests/manager/manager-ctor-008.phpt
+++ b/tests/manager/manager-ctor-008.phpt
@@ -13,8 +13,8 @@ ini_set('mongodb.debug', '');
 <?php exit(0); ?>
 --EXPECTF--
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 %A
 ===DONE===

--- a/tests/manager/manager-ctor-disableClientPersistence-001.phpt
+++ b/tests/manager/manager-ctor-disableClientPersistence-001.phpt
@@ -24,18 +24,18 @@ ini_set('mongodb.debug', '');
 <?php exit(0); ?>
 --EXPECTF--
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
-[%s]     PHONGO: DEBUG   > Stored persistent client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
+[%s]     PHONGO: DEBUG   > Stored persistent client with hash: %a
 [%s]     PHONGO: DEBUG   > Not destroying persistent client for Manager%A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
-[%s]     PHONGO: DEBUG   > Stored persistent client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
+[%s]     PHONGO: DEBUG   > Stored persistent client with hash: %a
 [%s]     PHONGO: DEBUG   > Not destroying persistent client for Manager%A
-[%s]     PHONGO: DEBUG   > Found client for hash: %s
+[%s]     PHONGO: DEBUG   > Found client for hash: %a
 [%s]     PHONGO: DEBUG   > Not destroying persistent client for Manager%A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 [%s]     PHONGO: DEBUG   > Stored non-persistent client
 [%s]     PHONGO: DEBUG   > Destroying non-persistent client for Manager%A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 [%s]     PHONGO: DEBUG   > Stored non-persistent client
 [%s]     PHONGO: DEBUG   > Destroying non-persistent client for Manager%A
 ===DONE===

--- a/tests/manager/manager-ctor-disableClientPersistence-002.phpt
+++ b/tests/manager/manager-ctor-disableClientPersistence-002.phpt
@@ -41,7 +41,7 @@ ini_set('mongodb.debug', '');
 <?php exit(0); ?>
 --EXPECTF--
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 [%s]     PHONGO: DEBUG   > Stored non-persistent client
 Inserting data
 Creating cursor

--- a/tests/manager/manager-ctor-disableClientPersistence-003.phpt
+++ b/tests/manager/manager-ctor-disableClientPersistence-003.phpt
@@ -30,7 +30,7 @@ ini_set('mongodb.debug', '');
 <?php exit(0); ?>
 --EXPECTF--
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 [%s]     PHONGO: DEBUG   > Stored non-persistent client
 Creating session
 Unsetting manager

--- a/tests/manager/manager-ctor-disableClientPersistence-004.phpt
+++ b/tests/manager/manager-ctor-disableClientPersistence-004.phpt
@@ -29,7 +29,7 @@ ini_set('mongodb.debug', '');
 <?php exit(0); ?>
 --EXPECTF--
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 [%s]     PHONGO: DEBUG   > Stored non-persistent client
 Creating server
 Unsetting manager

--- a/tests/manager/manager-ctor-disableClientPersistence-005.phpt
+++ b/tests/manager/manager-ctor-disableClientPersistence-005.phpt
@@ -34,7 +34,7 @@ ini_set('mongodb.debug', '');
 <?php exit(0); ?>
 --EXPECTF--
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 [%s]     PHONGO: DEBUG   > Stored non-persistent client
 Inserting data
 Unsetting manager

--- a/tests/manager/manager-ctor-disableClientPersistence-006.phpt
+++ b/tests/manager/manager-ctor-disableClientPersistence-006.phpt
@@ -32,7 +32,7 @@ ini_set('mongodb.debug', '');
 <?php exit(0); ?>
 --EXPECTF--
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 [%s]     PHONGO: DEBUG   > Stored non-persistent client
 Creating clientEncryption
 Unsetting manager

--- a/tests/manager/manager-ctor-disableClientPersistence-007.phpt
+++ b/tests/manager/manager-ctor-disableClientPersistence-007.phpt
@@ -39,10 +39,10 @@ ini_set('mongodb.debug', '');
 <?php exit(0); ?>
 --EXPECTF--
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 [%s]     PHONGO: DEBUG   > Stored non-persistent client
 %A
-[%s]     PHONGO: DEBUG   > Created client with hash: %s
+[%s]     PHONGO: DEBUG   > Created client with hash: %a
 [%s]     PHONGO: DEBUG   > Stored non-persistent client
 Creating clientEncryption
 Unsetting manager


### PR DESCRIPTION
This PR introduces a bunch of defensive hardening and consistency fixes across the extension. Each commit is scoped to a single change to keep review and bisecting straightforward.

- Manager cache key — store a SHA-256 digest of the URI rather than the raw connection string in phongo_manager_make_client_hash.
- Int64 shift operators — match PHP's native integer-shift handlers: throw `ArithmeticError` on negative shift counts and return `0`/`-1` at or above the operand width.
- BSON traversal — halt the document and array visitors cleanly when `bsonUnserialize` throws, instead of inserting a partially-constructed object into the parent.
- BSON value encoder — propagate failure from `phongo_zval_to_bson_value_ex` and validate UTF-8 in the scalar path so it matches `phongo_bson_append`.
- Field path helpers — guard `phongo_field_path_pop` against an empty path and fix the trailing-separator overwrite in `phongo_field_path_as_string` when all entries are NULL.
- Binary / Regex / Javascript — free pre-existing buffers before re-init, surface scope-encoding errors from `phongo_javascript_init`, route `phongo_regex_new` through `phongo_regex_init` so BSON-decoded Regex instances pick up the same flag canonicalisation as PHP-constructed ones.
- Type cleanups — use `size_t` for BSON data lengths and for `phongo_regex_t` length fields; drop a tautological `sparsity > INT64_MAX` check in ClientEncryption.