### PR TITLE
Use debug env var for debug builds

### DIFF
--- a/.github/actions/linux/build/action.yml
+++ b/.github/actions/linux/build/action.yml
@@ -14,9 +14,11 @@ runs:
     - name: "Install PHP"
       uses: "shivammathur/setup-php@v2"
       with:
-        php-version: "${{ inputs.version }}-debug"
+        php-version: "${{ inputs.version }}"
         # Only install required extensions
         extensions: "none,date,json,spl,standard,xml"
+      env:
+        debug: true
 
     - name: "Configure driver"
       run: .github/workflows/configure.sh

--- a/.github/workflows/arginfo-files.yml
+++ b/.github/workflows/arginfo-files.yml
@@ -27,7 +27,9 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "${{ env.PHP_VERSION }}-debug"
+          php-version: "${{ env.PHP_VERSION }}"
+        env:
+          debug: true
 
       - name: "Run phpize"
         run: phpize

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -27,7 +27,9 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "${{ env.PHP_VERSION }}-debug"
+          php-version: "${{ env.PHP_VERSION }}"
+        env:
+          debug: true
 
       - name: "Configure driver"
         run: .github/workflows/configure.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -333,8 +333,10 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "${{ env.PHP_VERSION }}-debug"
+          php-version: "${{ env.PHP_VERSION }}"
           extensions: "none,date,json,spl,standard,xml"
+        env:
+          debug: true
 
       - name: "phpize"
         run: phpize

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,7 +179,7 @@ jobs:
     runs-on: "ubuntu-latest"
     env:
       PHP_VERSION: "8.3"
-      LIBMONGOCRYPT_VERSION: "1.18.0"
+      LIBMONGOCRYPT_VERSION: "1.18"
       # Note: include the patch version when referring to a libmongoc release tarball
       LIBMONGOC_VERSION: "2.3.0"
       SERVER_VERSION: "8.0"


### PR DESCRIPTION
A recent change to setup-php broke installs when the version contains the `-debug` suffix. This way of installing debug versions of PHP was never supported, it should've been requested using the `debug` env var.