### PR TITLE
PHPC-2715: fix PHP_MONGODB_ADD_BUILD_INCLUDE and include ordering for phpize/PECL builds on Alpine/musl

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -374,6 +374,13 @@ if test "$PHP_MONGODB" != "no"; then
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libbson/src/jsonsl/], $PHP_MONGODB_JSONSL_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
     PHP_MONGODB_ADD_SOURCES([src/libmongoc/src/libmongoc/src/mongoc/], $PHP_MONGODB_MONGOC_SOURCES, $PHP_MONGODB_BUNDLED_CFLAGS)
 
+    dnl Build-dir includes must come before source-dir includes so that the
+    dnl compiler finds configure-generated headers (e.g. mongoc-config.h with
+    dnl correct MONGOC_HAVE_RES_* values) rather than the pre-bundled copies.
+    PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongoc/src/common/src/])
+    PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongoc/src/libbson/src/])
+    PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongoc/src/libmongoc/src/])
+
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/common/src/])
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/uthash/])
     PHP_MONGODB_ADD_INCLUDE([src/libmongoc/src/libbson/src/])
@@ -403,10 +410,6 @@ if test "$PHP_MONGODB" != "no"; then
     dnl Generated config headers are written into the extension build directory.
     dnl For standalone out-of-source builds they stay in the build tree; for PHP
     dnl in-tree builds they land under ext/mongodb/ rather than the PHP root.
-    PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongoc/src/common/src/])
-    PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongoc/src/libbson/src/])
-    PHP_MONGODB_ADD_BUILD_INCLUDE([src/libmongoc/src/libmongoc/src/])
-
     AC_CONFIG_FILES([
       ${mongodb_builddir}/src/libmongoc/src/common/src/common-config.h
       ${mongodb_builddir}/src/libmongoc/src/libbson/src/bson/config.h

--- a/scripts/autotools/m4/php_mongodb.m4
+++ b/scripts/autotools/m4/php_mongodb.m4
@@ -47,19 +47,16 @@ dnl Adds an include path relative to the extension build directory (i.e.
 dnl PHP_EXT_BUILDDIR). Use this for directories containing generated files
 dnl (e.g. config headers written by AC_CONFIG_FILES).
 dnl
-dnl PHP_EXT_BUILDDIR returns a path relative to the configure invocation
-dnl directory (e.g. "." for phpize builds, "ext/mongodb" for in-tree builds).
-dnl The subdirectory passed as $1 does not exist at configure time (build dirs
-dnl are created in AC_CONFIG_COMMANDS_PRE), so passing the full relative path
-dnl to PHP_ADD_INCLUDE would cause PHP_EXPAND_PATH to silently discard it when
-dnl the "cd $path && pwd" probe fails.  To avoid this, we resolve only the base
-dnl (PHP_EXT_BUILDDIR, which always exists at configure time) to an absolute
-dnl path first, then append $1.  PHP_ADD_INCLUDE skips the cd-probe for paths
-dnl that already start with "/".
+dnl AC_CONFIG_FILES paths (and therefore generated header locations) are
+dnl resolved relative to $abs_builddir — the absolute path of the directory
+dnl where config.status is run.  In phpize builds this is the pear build
+dnl directory (e.g. /tmp/pear/temp/pear-build-.../mongodb-x.y.z/), which
+dnl differs from the extension source directory resolved by PHP_EXT_BUILDDIR.
+dnl Using $abs_builddir directly ensures the compiler finds the configure-
+dnl generated headers rather than the pre-bundled source-tree copies.
 dnl
 AC_DEFUN([PHP_MONGODB_ADD_BUILD_INCLUDE],[
-  PHP_EXPAND_PATH(PHP_EXT_BUILDDIR(mongodb), php_mongodb_abs_builddir)
-  PHP_ADD_INCLUDE([$php_mongodb_abs_builddir/$1])
+  PHP_ADD_INCLUDE([$abs_builddir/$1])
 ])
 
 dnl


### PR DESCRIPTION
## Summary

Fixes a regression introduced in 2.3.2 (commit 5d19cfa) where \`pecl install mongodb\` fails on Alpine/musl with implicit-declaration errors for \`res_ninit\`, \`res_nsearch\`, and \`res_nclose\` (see #2020).

## Root cause (two bugs)

**Bug 1 — wrong \`$abs_builddir\` in \`PHP_MONGODB_ADD_BUILD_INCLUDE\`:**
\`AC_CONFIG_FILES\` writes generated headers (e.g. \`mongoc-config.h\`) relative to \`$abs_builddir\` — the directory where \`config.status\` runs. In a phpize/PECL build this is the pear build directory (e.g. \`/tmp/pear/temp/pear-build-.../mongodb-x.y.z/\`), **not** the extension source directory.

\`PHP_MONGODB_ADD_BUILD_INCLUDE\` was using \`PHP_EXPAND_PATH(PHP_EXT_BUILDDIR(mongodb), ...)\`, which in phpize builds resolves to the extension source directory (e.g. \`/tmp/pear/temp/mongodb/\`). These two directories differ, so the compiler never found the configure-generated headers.

**Bug 2 — include ordering:**
In 2.3.2, the three \`PHP_MONGODB_ADD_BUILD_INCLUDE\` calls were placed *after* the \`PHP_MONGODB_ADD_INCLUDE\` (source-dir) calls in \`config.m4\`. Even with Bug 1 fixed, if build-dir includes appear after source-dir includes in the \`-I\` list, the compiler finds the pre-bundled source-tree \`mongoc-config.h\` first.

The pre-bundled copy was generated on a glibc system with \`MONGOC_HAVE_RES_NSEARCH=1\` hardcoded. On musl/Alpine, \`configure\` correctly sets \`MONGOC_HAVE_RES_NSEARCH=0\` in the generated header — but with wrong ordering, the wrong header wins, causing compilation to include \`res_ninit\`/\`res_nsearch\` call sites that musl does not implement, which fail with GCC 15's new error-on-implicit-declaration.

## Fix

**Commit 1** ([23233d8](https://github.com/a8ns/mongo-php-driver/commit/23233d84)): Replace \`PHP_EXPAND_PATH(PHP_EXT_BUILDDIR(...), ...)\` with \`\$abs_builddir\` directly in \`PHP_MONGODB_ADD_BUILD_INCLUDE\`. This is the same path \`AC_CONFIG_FILES\` uses.

**Commit 2** ([08d8528](https://github.com/a8ns/mongo-php-driver/commit/08d8528b)): Move \`PHP_MONGODB_ADD_BUILD_INCLUDE\` calls before \`PHP_MONGODB_ADD_INCLUDE\` calls in \`config.m4\`. Remove the duplicate block that was placed after \`AC_CONFIG_FILES\`.

## Testing

Verified that \`pecl install mongodb-2.3.2\` builds successfully on \`php:8.4.16-fpm-alpine3.23\` (Alpine 3.23, musl libc, GCC 15.2.0) with both patches applied:

```
Build complete.
install ok: channel://pecl.php.net/mongodb-2.3.2
```
```
mongodb version: 2.3.2
```

Without the fix, the build fails with:
```
error: implicit declaration of function 'res_ninit'; did you mean 'res_init'?
error: implicit declaration of function 'res_nsearch'
error: implicit declaration of function 'res_nclose'
```