### PR TITLE
PHPC-2731: Pin libmongocrypt runtime and dev packages in lockstep

### DIFF
--- a/.github/actions/linux/build-libmongocrypt/action.yml
+++ b/.github/actions/linux/build-libmongocrypt/action.yml
@@ -23,6 +23,6 @@ runs:
 
     - name: Install libmongocrypt
       shell: bash
-      run: sudo apt-get install -y "libmongocrypt-dev=${LIBMONGOCRYPT_VERSION}*"
+      run: sudo apt-get install -y "libmongocrypt-dev=${LIBMONGOCRYPT_VERSION}*" "libmongocrypt0=${LIBMONGOCRYPT_VERSION}*"
       env:
         LIBMONGOCRYPT_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
[PHPC-2731](https://jira.mongodb.org/browse/PHPC-2731)

## Problem

The System Library Tests CI job installs libmongocrypt from MongoDB's apt repo but pins only the `libmongocrypt-dev` package. Since `libmongocrypt-dev` has an exact `Depends: libmongocrypt0 (= <version>)` and the runtime package is left unpinned, apt resolves `libmongocrypt0` to the newest available version. When upstream publishes a new libmongocrypt release, the install fails with a dependency conflict:

```
libmongocrypt-dev : Depends: libmongocrypt0 (= 1.19.2-0) but 1.20.0-0 is to be installed
```

This breaks CI on active branches on every unrelated upstream release, and permanently on maintenance branches.

## Fix

Pin both `libmongocrypt-dev` and `libmongocrypt0` to the same version prefix so apt keeps them in lockstep and no longer pulls a newer runtime.