### PR TITLE
DEVPROD-34208: use Silkbomb image from ECR instead of Artifactory

### DIFF
--- a/scripts/update-sbom.sh
+++ b/scripts/update-sbom.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 ROOT_DIR=$(realpath "${SCRIPT_DIR}/../")
 PURLS_FILE="${ROOT_DIR}/purls.txt"
+trap 'rm -f "$PURLS_FILE"' EXIT
 
 LIBMONGOC_VERSION=$(cat "${ROOT_DIR}/src/libmongoc/VERSION_CURRENT" | tr -d '[:space:]')
 LIBMONGOCRYPT_VERSION=$(cat "${ROOT_DIR}/src/LIBMONGOCRYPT_VERSION_CURRENT" | tr -d '[:space:]')
@@ -21,5 +24,3 @@ aws ecr get-login-password --region us-east-1 --profile "$profile" | docker logi
 docker run --platform="linux/amd64" -i --rm -v "${ROOT_DIR}:/pwd" \
   901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0 \
   update --sbom-in /pwd/sbom.json --purls /pwd/purls.txt --sbom-out /pwd/sbom.json
-
-rm "$PURLS_FILE"

--- a/scripts/update-sbom.sh
+++ b/scripts/update-sbom.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 ROOT_DIR=$(realpath "${SCRIPT_DIR}/../")
 PURLS_FILE="${ROOT_DIR}/purls.txt"
 
-LIBMONGOC_VERSION=$(cat ${ROOT_DIR}/src/libmongoc/VERSION_CURRENT | tr -d '[:space:]')
-LIBMONGOCRYPT_VERSION=$(cat ${ROOT_DIR}/src/LIBMONGOCRYPT_VERSION_CURRENT | tr -d '[:space:]')
+LIBMONGOC_VERSION=$(cat "${ROOT_DIR}/src/libmongoc/VERSION_CURRENT" | tr -d '[:space:]')
+LIBMONGOCRYPT_VERSION=$(cat "${ROOT_DIR}/src/LIBMONGOCRYPT_VERSION_CURRENT" | tr -d '[:space:]')
 
 # Generate purls file from stored versions
-echo "pkg:github/mongodb/mongo-c-driver@${LIBMONGOC_VERSION}" > $PURLS_FILE
-echo "pkg:github/mongodb/libmongocrypt@${LIBMONGOCRYPT_VERSION}" >> $PURLS_FILE
+echo "pkg:github/mongodb/mongo-c-driver@${LIBMONGOC_VERSION}" > "$PURLS_FILE"
+echo "pkg:github/mongodb/libmongocrypt@${LIBMONGOCRYPT_VERSION}" >> "$PURLS_FILE"
+
+# Log in to the DevProd Platforms ECR registry that hosts silkbomb. Requires membership in the
+# devprod-platforms-ecr-users Okta group and an AWS SSO profile for the account; see
+# https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr#from-your-laptop
+profile="${DEVPROD_PLATFORMS_ECR_AWS_PROFILE:-ECRScopedAccess-901841024863}"
+aws ecr get-login-password --region us-east-1 --profile "$profile" | docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
 
 # Use silkbomb to update the sbom.json file
-docker run --platform="linux/amd64" -i --rm -v ${ROOT_DIR}:/pwd \
-  artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 \
+docker run --platform="linux/amd64" -i --rm -v "${ROOT_DIR}:/pwd" \
+  901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0 \
   update --sbom-in /pwd/sbom.json --purls /pwd/purls.txt --sbom-out /pwd/sbom.json
 
-rm $PURLS_FILE
+rm "$PURLS_FILE"

--- a/scripts/update-sbom.sh
+++ b/scripts/update-sbom.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 ROOT_DIR=$(realpath "${SCRIPT_DIR}/../")
 PURLS_FILE="${ROOT_DIR}/purls.txt"
-trap 'rm -f "$PURLS_FILE"' EXIT
+registry="901841024863.dkr.ecr.us-east-1.amazonaws.com"
 
 LIBMONGOC_VERSION=$(cat "${ROOT_DIR}/src/libmongoc/VERSION_CURRENT" | tr -d '[:space:]')
 LIBMONGOCRYPT_VERSION=$(cat "${ROOT_DIR}/src/LIBMONGOCRYPT_VERSION_CURRENT" | tr -d '[:space:]')
@@ -14,13 +14,15 @@ LIBMONGOCRYPT_VERSION=$(cat "${ROOT_DIR}/src/LIBMONGOCRYPT_VERSION_CURRENT" | tr
 echo "pkg:github/mongodb/mongo-c-driver@${LIBMONGOC_VERSION}" > "$PURLS_FILE"
 echo "pkg:github/mongodb/libmongocrypt@${LIBMONGOCRYPT_VERSION}" >> "$PURLS_FILE"
 
+trap 'rm -f "$PURLS_FILE"' EXIT
+
 # Log in to the DevProd Platforms ECR registry that hosts silkbomb. Requires membership in the
 # devprod-platforms-ecr-users Okta group and an AWS SSO profile for the account; see
 # https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr#from-your-laptop
 profile="${DEVPROD_PLATFORMS_ECR_AWS_PROFILE:-ECRScopedAccess-901841024863}"
-aws ecr get-login-password --region us-east-1 --profile "$profile" | docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
+aws ecr get-login-password --region us-east-1 --profile "$profile" | docker login --username AWS --password-stdin "$registry"
 
 # Use silkbomb to update the sbom.json file
 docker run --platform="linux/amd64" -i --rm -v "${ROOT_DIR}:/pwd" \
-  901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0 \
+  "${registry}/release-infrastructure/silkbomb:2.0" \
   update --sbom-in /pwd/sbom.json --purls /pwd/purls.txt --sbom-out /pwd/sbom.json


### PR DESCRIPTION
MongoDB Artifactory will be deprecated soon, so the Silkbomb image must be pulled from ECR instead.