### PR TITLE
PHPC-2738: Escape release notes when generating package.xml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,7 @@ jobs:
           version: ${{ env.PHP_VERSION }}
 
       - name: "Write changelog file for packaging"
-        run: echo "Testing" > changelog
+        run: echo 'Testing <special> & "chars" to exercise XML escaping' > changelog
 
       - name: "Build package.xml"
         run: "make package.xml RELEASE_NOTES_FILE=$(pwd)/changelog"

--- a/bin/prep-release.php
+++ b/bin/prep-release.php
@@ -211,7 +211,7 @@ $REPLACE = array(
     "%RELEASE_VERSION%" => $VERSION,
     "%RELEASE_STABILITY%" => $STABILITY,
     "%RELEASE_FILES%" => join("\n", $TREE),
-    "%RELEASE_NOTES%" => is_string($RELEASE_NOTES_FILE) && file_exists($RELEASE_NOTES_FILE) ? file_get_contents($RELEASE_NOTES_FILE) : '',
+    "%RELEASE_NOTES%" => is_string($RELEASE_NOTES_FILE) && file_exists($RELEASE_NOTES_FILE) ? htmlspecialchars(file_get_contents($RELEASE_NOTES_FILE), ENT_XML1 | ENT_QUOTES, 'UTF-8') : '',
 );
 
 $contents = str_replace(array_keys($REPLACE), array_values($REPLACE), $contents);


### PR DESCRIPTION
The release notes file is spliced verbatim into the `<notes>` element of `package.xml`. Escape XML metacharacters with `htmlspecialchars(..., ENT_XML1 | ENT_QUOTES, 'UTF-8')` before the `str_replace`.

Fix PHPC-2738