### PR TITLE
PHPC-2708: Update release docs and add version-transition reminders

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -33,3 +33,9 @@ jobs:
           devBranchNamePattern: 'v<major>.x'
           ignoredBranches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
           enableAutoMerge: true
+
+      - name: "Label the merge-up pull request"
+        if: ${{ steps.create-pull-request.outputs.pullRequestUrl != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr edit ${{ steps.create-pull-request.outputs.pullRequestUrl }} --add-label merge-up

--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -13,7 +13,6 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
-      issues: write
 
     steps:
       - name: Checkout
@@ -27,16 +26,12 @@ jobs:
 
       - name: Create pull request
         id: create-pull-request
-        uses: alcaeus/automatic-merge-up-action@1.0.1
+        # Pinned to a commit on main for the `labels` input, pending a release after 1.0.1
+        uses: alcaeus/automatic-merge-up-action@48b5ff50ed307f17a7db57154047fa49ab7c6cff
         with:
           ref: ${{ github.ref_name }}
           branchNamePattern: 'v<major>.<minor>'
           devBranchNamePattern: 'v<major>.x'
           ignoredBranches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
           enableAutoMerge: true
-
-      - name: "Label the merge-up pull request"
-        if: ${{ steps.create-pull-request.outputs.pullRequestUrl != '' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh pr edit ${{ steps.create-pull-request.outputs.pullRequestUrl }} --add-label merge-up
+          labels: merge-up

--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -13,6 +13,7 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
           git add phongo_version.h
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "Bump to next minor dev version"
+          git commit -m "Bump version to $(./bin/update-release-version.php get-version)"
           git push origin ${DEV_BRANCH}
           git checkout ${RELEASE_BRANCH}
 
@@ -199,3 +199,4 @@ jobs:
         run: |
           echo '🚀 Created tag and drafted release for version [${{ inputs.version }}](${{ env.RELEASE_URL }})' >> $GITHUB_STEP_SUMMARY
           echo '✍️ You may now update the release notes and publish the release when ready' >> $GITHUB_STEP_SUMMARY
+          echo '🏷️ Once published, mark the [JIRA version](https://jira.mongodb.org/projects/PHPC/versions/${{ inputs.jira-version-number }}) as released' >> $GITHUB_STEP_SUMMARY

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,28 +1,17 @@
 # Releasing
 
-## Branch management
+## Merge-up branches
 
-When releasing a new minor version of the driver (i.e. `X.Y.0`), create a new
-maintenance branch named `vX.Y` from the default branch. Then, update the
-version information in the default branch to the next minor release:
-
-```shell
-$ ./bin/update-release-version.php to-next-minor-dev
-```
-
-Commit and push the resulting changes:
-
-```shell
-$ git commit -m "Master is now X.Y-dev" phongo_version.h
-$ git push mongodb
-```
-
-Before starting the release process, make sure that all open merge-up pull
-requests containing changes from the release branch have been merged. Handling
-the merge conflicts resulting from the version updates will be much more
-difficult if other changes need merging.
+Make sure all open [merge-up pull requests](https://github.com/mongodb/mongo-php-driver/pulls?q=is%3Apr+is%3Aopen+label%3Amerge-up)
+containing changes from the release branch have been merged. The release bumps
+version numbers across branches, so leaving other changes unmerged makes the
+resulting merge conflicts much harder to resolve.
 
 ## Transition JIRA issues and version
+
+Find the release version on the
+[Manage Versions](https://jira.mongodb.org/plugins/servlet/project-config/PHPC/versions)
+page.
 
 All issues associated with the release version should be in the "Closed" state
 and have a resolution of "Fixed". Issues with other resolutions (e.g.
@@ -32,16 +21,16 @@ that they do not appear in the release notes.
 Check the corresponding ".x" fix version to see if it contains any issues that
 are resolved as "Fixed" and should be included in this release version.
 
-Update the version's release date and status from the
-[Manage Versions](https://jira.mongodb.org/plugins/servlet/project-config/PHPC/versions)
-page.
+Set the version's release date to the current date.
 
 ## Trigger the release workflow
 
 Releases are done automatically through a GitHub Action. Visit the corresponding
 [Release New Version](https://github.com/mongodb/mongo-php-driver/actions/workflows/release.yml)
-workflow page to trigger a new build. Select the correct branch (e.g. `v1.18`)
-and trigger a new run using the "Run workflow" button. In the following prompt,
+workflow page to trigger a new build. Select the correct branch: the default
+development branch (`vX.x`) for a new minor release, or the corresponding
+maintenance branch (e.g. `v1.18`) for a patch release. Trigger a new run using
+the "Run workflow" button. In the following prompt,
 enter the version number and the corresponding JIRA version ID for the release.
 This version ID can be obtained from a link in the "Version" column on the
 [PHPC releases page](https://jira.mongodb.org/projects/PHPC?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased).
@@ -68,6 +57,10 @@ highlights. Fill in release highlights and wait for the entire packaging
 workflow to complete. Once all release assets have been uploaded, you can
 publish the release. Note that since releases are immutable, publishing release
 notes before all packages have been added will result in a broken release.
+
+Once the release is published, mark the version as released on the
+[Manage Versions](https://jira.mongodb.org/plugins/servlet/project-config/PHPC/versions)
+page.
 
 ## Upload package to PECL
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-## Merge-up branches
+## Merge-up pull requests
 
 Make sure all open [merge-up pull requests](https://github.com/mongodb/mongo-php-driver/pulls?q=is%3Apr+is%3Aopen+label%3Amerge-up)
 containing changes from the release branch have been merged. The release bumps


### PR DESCRIPTION
Follow-up to #2027: aligns RELEASING.md with the now-automated branch management, adds a [`merge-up`](https://github.com/mongodb/mongo-php-driver/issues?q=label%3Amerge-up&page=1) label with a search link, and reminds to mark the JIRA version as released only after publishing.