### PR TITLE
PHPC-2753 Add link to ECR log-in

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -101,7 +101,7 @@ When bumping the bundled `src/libmongocrypt` submodule, update all of the follow
 - `src/LIBMONGOCRYPT_VERSION_CURRENT` — plain-text version string read by `scripts/autotools/libmongocrypt/Version.m4` and `config.w32`
 - `config.m4` — `PHP_MONGODB_MIN_LIBMONGOCRYPT_VERSION` for the system-libs build
 - `.github/workflows/tests.yml` — `LIBMONGOCRYPT_VERSION` env for the System Library Tests job (installs `libmongocrypt-dev` from apt; must match the released minor)
-- `sbom.json` — regenerate via `scripts/update-sbom.sh`. This requires [logging in to AWS ECR](https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr#from-your-laptop).
+- `sbom.json` — regenerate via `scripts/update-sbom.sh` (requires [logging in to AWS ECR (MongoDB internal access required)](https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr#from-your-laptop))
 
 ### Test Format (PHPT)
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -101,7 +101,7 @@ When bumping the bundled `src/libmongocrypt` submodule, update all of the follow
 - `src/LIBMONGOCRYPT_VERSION_CURRENT` — plain-text version string read by `scripts/autotools/libmongocrypt/Version.m4` and `config.w32`
 - `config.m4` — `PHP_MONGODB_MIN_LIBMONGOCRYPT_VERSION` for the system-libs build
 - `.github/workflows/tests.yml` — `LIBMONGOCRYPT_VERSION` env for the System Library Tests job (installs `libmongocrypt-dev` from apt; must match the released minor)
-- `sbom.json` — regenerate via `scripts/update-sbom.sh`
+- `sbom.json` — regenerate via `scripts/update-sbom.sh`. This requires [logging in to AWS ECR](https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr#from-your-laptop).
 
 ### Test Format (PHPT)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,7 +317,7 @@ script to automate this process:
 
 This script will generate a temporary purl file with our dependencies, then run
 the internal silkbomb tool to update the SBOM. Note that you need to have docker
-installed in order to run this. And this requires [logging in to AWS ECR](https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr#from-your-laptop).
+installed in order to run this. You must also [log in to AWS ECR (MongoDB internal access required)](https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr#from-your-laptop).
 
 #### Test and commit your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,7 +317,7 @@ script to automate this process:
 
 This script will generate a temporary purl file with our dependencies, then run
 the internal silkbomb tool to update the SBOM. Note that you need to have docker
-installed in order to run this.
+installed in order to run this. And this requires [logging in to AWS ECR](https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr#from-your-laptop).
 
 #### Test and commit your changes
 


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-php-driver/pull/2039 to document the need to log-in to AWS ECR to run `update-sbom.sh`. This is noted [in `update-sbom.sh`](https://github.com/mongodb/mongo-php-driver/blob/v2.x/scripts/update-sbom.sh#L21) but may be easily missed.